### PR TITLE
One implementation for grouped bar chart support in CombinedChartView

### DIFF
--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -160,6 +160,21 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     
     // MARK: - BarChartDataProbider
     
+    public func getBarChartTransformer(which: ChartYAxis.AxisDependency) -> ChartTransformer
+    {
+        return super.getTransformer(which)
+    }
+    
+    public var barChartXMax: Double
+        {
+            return _chartXMax
+    }
+    
+    public var barChartXMin: Double
+        {
+            return _chartXMin
+    }
+    
     public var barData: BarChartData? { return _data as? BarChartData }
     
     /// - returns: true if drawing the highlighting arrow is enabled, false if not

--- a/Charts/Classes/Charts/CombinedChartView.swift
+++ b/Charts/Classes/Charts/CombinedChartView.swift
@@ -20,6 +20,16 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
     /// the fill-formatter used for determining the position of the fill-line
     internal var _fillFormatter: ChartFillFormatter!
     
+    internal var _barChartXMax = Double(0.0)
+    internal var _barChartXMin = Double(0.0)
+    internal var _barChartDeltaX = CGFloat(0.0)
+    
+    internal var _barChartLeftYAxisRenderer: ChartYAxisRenderer!
+    internal var _barChartRightYAxisRenderer: ChartYAxisRenderer!
+    
+    internal var _barChartLeftAxisTransformer: ChartTransformer!
+    internal var _barChartRightAxisTransformer: ChartTransformer!
+    
     /// enum that allows to specify the order in which the different data objects for the combined-chart are drawn
     @objc
     public enum CombinedChartDrawOrder: Int
@@ -40,6 +50,12 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
         /// WORKAROUND: Swift 2.0 compiler malfunctions when optimizations are enabled, and assigning directly to _fillFormatter causes a crash with a EXC_BAD_ACCESS. See https://github.com/danielgindi/ios-charts/issues/406
         let workaroundFormatter = ChartDefaultFillFormatter()
         _fillFormatter = workaroundFormatter
+        
+        _barChartLeftAxisTransformer = ChartTransformer(viewPortHandler: _viewPortHandler)
+        _barChartRightAxisTransformer = ChartTransformer(viewPortHandler: _viewPortHandler)
+        
+        _barChartLeftYAxisRenderer = ChartYAxisRenderer(viewPortHandler: _viewPortHandler, yAxis: _leftAxis, transformer: _leftAxisTransformer)
+        _barChartRightYAxisRenderer = ChartYAxisRenderer(viewPortHandler: _viewPortHandler, yAxis: _rightAxis, transformer: _rightAxisTransformer)
         
         renderer = CombinedChartRenderer(chart: self, animator: _animator, viewPortHandler: _viewPortHandler)
     }
@@ -71,6 +87,26 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
                     }
                 }
             }
+            
+            if (self.barData !== nil)
+            {
+                let barData = self.barData
+                
+                _barChartXMin = _chartXMin
+                _barChartXMax = _chartXMax
+                _barChartDeltaX = _deltaX
+                // increase deltax by 1 because the bars have a width of 1
+                _barChartDeltaX += 0.5
+                
+                // extend xDelta to make space for multiple datasets (if ther are one)
+                _barChartDeltaX *= CGFloat(barData!.dataSetCount)
+                
+                let maxEntry = _data.xValCount
+                
+                let groupSpace = barData!.groupSpace
+                _barChartDeltaX += CGFloat(maxEntry) * groupSpace
+                _barChartXMax = Double(_barChartDeltaX) - _barChartXMin
+            }
         }
         
         _deltaX = CGFloat(abs(_chartXMax - _chartXMin))
@@ -79,6 +115,78 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
         {
             _deltaX = 1.0
         }
+    }
+    
+    internal override func prepareValuePxMatrix()
+    {
+        super.prepareValuePxMatrix()
+        
+        _barChartRightAxisTransformer.prepareMatrixValuePx(chartXMin: _barChartXMin, deltaX: _barChartDeltaX, deltaY: CGFloat(_rightAxis.axisRange), chartYMin: _rightAxis.axisMinimum)
+        _barChartLeftAxisTransformer.prepareMatrixValuePx(chartXMin: _barChartXMin, deltaX: _barChartDeltaX, deltaY: CGFloat(_leftAxis.axisRange), chartYMin: _leftAxis.axisMinimum)
+    }
+    
+    internal override func prepareOffsetMatrix()
+    {
+        super.prepareOffsetMatrix()
+        
+        _barChartRightAxisTransformer.prepareMatrixOffset(_rightAxis.isInverted)
+        _barChartLeftAxisTransformer.prepareMatrixOffset(_leftAxis.isInverted)
+    }
+    
+    /// Returns the Transformer class that contains all matrices and is
+    /// responsible for transforming values into pixels on the screen and
+    /// backwards.
+    public func getBarChartTransformer(which: ChartYAxis.AxisDependency) -> ChartTransformer
+    {
+        if (which == .Left)
+        {
+            return _barChartLeftAxisTransformer
+        }
+        else
+        {
+            return _barChartRightAxisTransformer
+        }
+    }
+    
+    public override func getMarkerPosition(entry e: ChartDataEntry, highlight: ChartHighlight) -> CGPoint
+    {
+        let dataSetIndex = highlight.dataSetIndex
+        let dataSet = _data.getDataSetByIndex(dataSetIndex)
+        var xPos = CGFloat(e.xIndex)
+        var yPos = e.value
+        
+        if (dataSet!.dynamicType === BarChartDataSet.self)
+        {
+            let bd = (_data as! CombinedChartData).barData
+            let space = bd.groupSpace
+            
+            let barDataSetIndex = bd.indexOfDataSet(dataSet)
+            
+            let x = CGFloat(e.xIndex * (bd.dataSetCount - 1) + barDataSetIndex) + space * CGFloat(e.xIndex) + space / 2.0
+            
+            xPos += x
+            
+            if let barEntry = e as? BarChartDataEntry
+            {
+                if barEntry.values != nil && highlight.range !== nil
+                {
+                    yPos = highlight.range!.to
+                }
+            }
+        }
+        
+        var pt = CGPoint(x: xPos, y: CGFloat(yPos) * _animator.phaseY)
+        
+        if (dataSet!.dynamicType === BarChartDataSet.self)
+        {
+            getBarChartTransformer(_data.getDataSetByIndex(dataSetIndex)!.axisDependency).pointValueToPixel(&pt)
+        }
+        else
+        {
+            getTransformer(_data.getDataSetByIndex(dataSetIndex)!.axisDependency).pointValueToPixel(&pt)
+        }
+        
+        return pt
     }
     
     public override var data: ChartData?
@@ -136,6 +244,16 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
             }
             return (_data as! CombinedChartData!).barData
         }
+    }
+    
+    public var barChartXMax: Double
+        {
+            return _barChartXMax
+    }
+    
+    public var barChartXMin: Double
+        {
+            return _barChartXMin
     }
     
     // MARK: - ScatterChartDataProvider

--- a/Charts/Classes/Highlight/CombinedHighlighter.swift
+++ b/Charts/Classes/Highlight/CombinedHighlighter.swift
@@ -17,51 +17,310 @@ import CoreGraphics
 
 public class CombinedHighlighter: ChartHighlighter
 {
-    /// Returns a list of SelectionDetail object corresponding to the given xIndex.
-    /// - parameter xIndex:
-    /// - returns:
+    /// Attension: Use super's getSelectionDetailsAtIndex to return the dataSetIndex in whole data.dataSets range, not subData's
     public override func getSelectionDetailsAtIndex(xIndex: Int) -> [ChartSelectionDetail]
     {
-        var vals = [ChartSelectionDetail]()
+        return super.getSelectionDetailsAtIndex(xIndex)
+    }
+
+    public override func getHighlight(x x: Double, y: Double) -> ChartHighlight?
+    {
+        var h: ChartHighlight?
         
-        if let data = self.chart?.data as? CombinedChartData
+        h = super.getHighlight(x: x, y: y)
+        
+        if h === nil
         {
-            // get all chartdata objects
-            var dataObjects = data.allData
-            
-            var pt = CGPoint()
-            
-            for var i = 0; i < dataObjects.count; i++
+            return h
+        }
+        else
+        {
+            if let set = chart?.data?.getDataSetByIndex(h!.dataSetIndex) as? BarChartDataSet
             {
-                for var j = 0; j < dataObjects[i].dataSetCount; j++
+                if set.isStacked
                 {
-                    let dataSet = dataObjects[i].getDataSetByIndex(j)
+                    // caeate an array of the touch-point
+                    var pt = CGPoint()
+                    pt.y = CGFloat(y)
                     
-                    // dont include datasets that cannot be highlighted
-                    if !dataSet.isHighlightEnabled
+                    // take the barChartTransformer from CombinedChartView to determine the x-axis value
+                    (chart as? CombinedChartView)?.getBarChartTransformer(set.axisDependency).pixelToValue(&pt)
+                    
+                    return getStackedHighlight(old: h, set: set, xIndex: h!.xIndex, dataSetIndex: h!.dataSetIndex, yValue: Double(pt.y))
+                }
+                else
+                {
+                    
+                }
+            }
+            
+            return h
+        }
+    }
+    
+    /**
+     Returns the corresponding x-index for a given touch-position in pixels.
+     
+     - parameter x: Double, point.x
+     
+     - returns: Int, xIndex
+     */
+    public override func getXIndex(x: Double) -> Int
+    {
+        if let barData = (chart as? CombinedChartView)?.barData
+        {
+            if !barData.isGrouped
+            {
+                return super.getXIndex(x)
+            }
+            else
+            {
+                let baseNoSpace = getBase(x)
+                
+                let setCount = barData.dataSetCount
+                var xIndex = Int(baseNoSpace) / setCount
+                
+                if let valCount = chart?.data?.xValCount
+                {
+                    if xIndex < 0
                     {
-                        continue
+                        xIndex = 0
+                    }
+                    else if xIndex >= valCount
+                    {
+                        xIndex = valCount - 1
                     }
                     
-                    // extract all y-values from all DataSets at the given x-index
-                    let yVal = dataSet.yValForXIndex(xIndex)
-                    if yVal.isNaN
-                    {
-                        continue
-                    }
-                    
-                    pt.y = CGFloat(yVal)
-                    
-                    self.chart!.getTransformer(dataSet.axisDependency).pointValueToPixel(&pt)
-                    
-                    if !pt.y.isNaN
-                    {
-                        vals.append(ChartSelectionDetail(value: Double(pt.y), dataSetIndex: j, dataSet: dataSet))
-                    }
+                    return xIndex
+                }
+                else
+                {
+                    return -Int.max
                 }
             }
         }
         
-        return vals
+        return super.getXIndex(x)
+    }
+    
+    /**
+     get dataSetIndex for combined chart data.
+     
+     if the barData is not grouped, call super's;
+     
+     if the super's dataSetIndex's corresponding dataSet is LineChartDataSet, return this index
+     
+     Otherwise, calculate dataSetIndex for combined chart data based on the index of bar data's dataSetIndex
+     
+     - parameter xIndex: Int
+     - parameter x:      Double
+     - parameter y:      Double
+     
+     - returns: Int
+     */
+    public override func getDataSetIndex(xIndex xIndex: Int, x: Double, y: Double) -> Int
+    {
+        if let barData = (chart as? CombinedChartView)?.barData
+        {
+            if !barData.isGrouped
+            {
+                return super.getDataSetIndex(xIndex: xIndex, x: x, y: y)
+            }
+            else
+            {
+                // test which bar dataSet is selected
+                let baseNoSpace = getBase(x)
+                
+                let setCount = barData.dataSetCount
+                var dataSetIndex = Int(baseNoSpace) % setCount
+                
+                if dataSetIndex < 0
+                {
+                    dataSetIndex = 0
+                }
+                else if dataSetIndex >= setCount
+                {
+                    dataSetIndex = setCount - 1
+                }
+                
+                let superDataSetIndex = super.getDataSetIndex(xIndex: xIndex, x: x, y: y)
+                let dataSet = (chart as? CombinedChartView)?.data?.getDataSetByIndex(superDataSetIndex)
+                
+                if (dataSet != nil)
+                {
+                    if (dataSet!.dynamicType !== BarChartDataSet.self)
+                    {
+                        return superDataSetIndex
+                    }
+                }
+                
+                let barDataSet = barData.getDataSetByIndex(dataSetIndex)
+                
+                let combinedData = (chart as! CombinedChartView).data
+                
+                let barDataSetIndexInCombinedChartData = combinedData!.indexOfDataSet(barDataSet!)
+                
+                return barDataSetIndexInCombinedChartData
+            }
+        }
+        else
+        {
+            return super.getDataSetIndex(xIndex: xIndex, x: x, y: y)
+        }
+    }
+    
+    /**
+     Same as BarChartHighlighter.getStackedHighlight()
+     
+     Whatever changed in BarChartHighlighter.getStackedHighlight() should also be applied here
+     
+     This method creates the Highlight object that also indicates which value of a stacked BarEntry has been selected.
+     
+     - parameter old:          ChartHighlight
+     - parameter set:          BarChartDataSet
+     - parameter xIndex:       Int
+     - parameter dataSetIndex: Int
+     - parameter yValue:       Double
+     
+     - returns: ChartHighlight?
+     */
+    internal func getStackedHighlight(old old: ChartHighlight?, set: BarChartDataSet, xIndex: Int, dataSetIndex: Int, yValue: Double) -> ChartHighlight?
+    {
+        let entry = set.entryForXIndex(xIndex) as? BarChartDataEntry
+        
+        if entry?.values === nil
+        {
+            return old
+        }
+        
+        if let ranges = getRanges(entry: entry!)
+        {
+            let stackIndex = getClosestStackIndex(ranges: ranges, value: yValue)
+            let h = ChartHighlight(xIndex: xIndex, dataSetIndex: dataSetIndex, stackIndex: stackIndex, range: ranges[stackIndex])
+            return h
+        }
+        return nil
+    }
+    
+    /**
+     Same as BarChartHighlighter.getClosestStackIndex()
+     
+     Whatever changed in BarChartHighlighter.getClosestStackIndex() should also be applied here
+     
+     Returns the index of the closest value inside the values array / ranges (stacked barchart) to the value given as a parameter.
+     
+     - parameter ranges: [ChartRange]?
+     - parameter value:  Double
+     
+     - returns: Int
+     */
+    internal func getClosestStackIndex(ranges ranges: [ChartRange]?, value: Double) -> Int
+    {
+        if ranges == nil
+        {
+            return 0
+        }
+        
+        var stackIndex = 0
+        
+        for range in ranges!
+        {
+            if range.contains(value)
+            {
+                return stackIndex
+            }
+            else
+            {
+                stackIndex++
+            }
+        }
+        
+        let length = ranges!.count - 1
+        
+        return (value > ranges![length].to) ? length : 0
+    }
+    
+    /**
+     Same as BarChartHighlighter.getBase()
+     
+     Whatever changed in BarChartHighlighter.getBase() should also be applied here
+     
+     Returns the base x-value to the corresponding x-touch value in pixels.
+     
+     - parameter x: Double
+     
+     - returns: Double
+     */
+    internal func getBase(x: Double) -> Double
+    {
+        if let barData = (chart as? CombinedChartView)?.barData
+        {
+            // create an array of the touch-point
+            var pt = CGPoint()
+            pt.x = CGFloat(x)
+            
+            // take any transformer to determine the x-axis value
+            (chart as? CombinedChartView)?.getBarChartTransformer(ChartYAxis.AxisDependency.Left).pixelToValue(&pt)
+            let xVal = Double(pt.x)
+            
+            let setCount = barData.dataSetCount ?? 0
+            
+            // calculate how often the group-space appears
+            let steps = Int(xVal / (Double(setCount) + Double(barData.groupSpace)))
+            
+            let groupSpaceSum = Double(barData.groupSpace) * Double(steps)
+            
+            let baseNoSpace = xVal - groupSpaceSum
+            
+            return baseNoSpace
+        }
+        else
+        {
+            return 0.0
+        }
+    }
+    
+    /**
+     Same as BarChartHighlighter.getRanges()
+     
+     Whatever changed in BarChartHighlighter.getRanges() should also be applied here
+     
+     Splits up the stack-values of the given bar-entry into Range objects.
+     
+     - parameter entry: BarChartDataEntry
+     
+     - returns: [ChartRange]?
+     */
+    internal func getRanges(entry entry: BarChartDataEntry) -> [ChartRange]?
+    {
+        let values = entry.values
+        if (values == nil)
+        {
+            return nil
+        }
+        
+        var negRemain = -entry.negativeSum
+        var posRemain: Double = 0.0
+        
+        var ranges = [ChartRange]()
+        ranges.reserveCapacity(values!.count)
+        
+        for (var i = 0, count = values!.count; i < count; i++)
+        {
+            let value = values![i]
+            
+            if value < 0
+            {
+                ranges.append(ChartRange(from: negRemain, to: negRemain + abs(value)))
+                negRemain += abs(value)
+            }
+            else
+            {
+                ranges.append(ChartRange(from: posRemain, to: posRemain+value))
+                posRemain += value
+            }
+        }
+        
+        return ranges
     }
 }

--- a/Charts/Classes/Interfaces/BarChartDataProvider.swift
+++ b/Charts/Classes/Interfaces/BarChartDataProvider.swift
@@ -19,6 +19,9 @@ public protocol BarChartDataProvider: BarLineScatterCandleBubbleChartDataProvide
 {
     var barData: BarChartData? { get }
     
+    func getBarChartTransformer(which: ChartYAxis.AxisDependency) -> ChartTransformer
+    var barChartXMin: Double { get }
+    var barChartXMax: Double { get }
     var isDrawBarShadowEnabled: Bool { get }
     var isDrawValueAboveBarEnabled: Bool { get }
     var isDrawHighlightArrowEnabled: Bool { get }

--- a/Charts/Classes/Renderers/BarChartRenderer.swift
+++ b/Charts/Classes/Renderers/BarChartRenderer.swift
@@ -56,7 +56,7 @@ public class BarChartRenderer: ChartDataRendererBase
         
         CGContextSaveGState(context)
         
-        let trans = dataProvider.getTransformer(dataSet.axisDependency)
+        let trans = dataProvider.getBarChartTransformer(dataSet.axisDependency)
         
         let drawBarShadowEnabled: Bool = dataProvider.isDrawBarShadowEnabled
         let dataSetOffset = (barData.dataSetCount - 1)
@@ -303,7 +303,7 @@ public class BarChartRenderer: ChartDataRendererBase
                 
                 guard let formatter = dataSet.valueFormatter else { continue }
                 
-                let trans = dataProvider.getTransformer(dataSet.axisDependency)
+                let trans = dataProvider.getBarChartTransformer(dataSet.axisDependency)
                 
                 let phaseY = animator.phaseY
                 let dataSetCount = barData.dataSetCount
@@ -485,13 +485,13 @@ public class BarChartRenderer: ChartDataRendererBase
             
             let barspaceHalf = set.barSpace / 2.0
             
-            let trans = dataProvider.getTransformer(set.axisDependency)
+            let trans = dataProvider.getBarChartTransformer(set.axisDependency)
             
             CGContextSetFillColorWithColor(context, set.highlightColor.CGColor)
             CGContextSetAlpha(context, set.highlightAlpha)
             
             // check outofbounds
-            if (CGFloat(index) < (CGFloat(dataProvider.chartXMax) * animator.phaseX) / CGFloat(setCount))
+            if (CGFloat(index) < (CGFloat(dataProvider.barChartXMax) * animator.phaseX) / CGFloat(setCount))
             {
                 let e = set.entryForXIndex(index) as! BarChartDataEntry!
                 

--- a/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
+++ b/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13D38A461B708CE1009D4C4D /* GroupedCombinedChartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 13D38A451B708CE1009D4C4D /* GroupedCombinedChartViewController.m */; };
 		55E356501ADC638F00A57971 /* BubbleChartViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55E3564D1ADC638F00A57971 /* BubbleChartViewController.xib */; };
 		55E356511ADC638F00A57971 /* BubbleChartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 55E3564F1ADC638F00A57971 /* BubbleChartViewController.m */; };
 		5B0CC7851ABB875400665592 /* PieChartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B0CC7831ABB875400665592 /* PieChartViewController.m */; };
@@ -166,6 +167,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		13D38A441B708CE1009D4C4D /* GroupedCombinedChartViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GroupedCombinedChartViewController.h; sourceTree = "<group>"; };
+		13D38A451B708CE1009D4C4D /* GroupedCombinedChartViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GroupedCombinedChartViewController.m; sourceTree = "<group>"; };
 		55E3564D1ADC638F00A57971 /* BubbleChartViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BubbleChartViewController.xib; sourceTree = "<group>"; };
 		55E3564E1ADC638F00A57971 /* BubbleChartViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BubbleChartViewController.h; sourceTree = "<group>"; };
 		55E3564F1ADC638F00A57971 /* BubbleChartViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BubbleChartViewController.m; sourceTree = "<group>"; };
@@ -445,6 +448,8 @@
 				5BDEDC441ABB871E007D3A60 /* CombinedChartViewController.h */,
 				5BDEDC451ABB871E007D3A60 /* CombinedChartViewController.m */,
 				5BDEDC461ABB871E007D3A60 /* CombinedChartViewController.xib */,
+				13D38A441B708CE1009D4C4D /* GroupedCombinedChartViewController.h */,
+				13D38A451B708CE1009D4C4D /* GroupedCombinedChartViewController.m */,
 				5BEAED2E1ABC18F00013F194 /* CubicLineChartViewController.h */,
 				5BEAED2F1ABC18F00013F194 /* CubicLineChartViewController.m */,
 				5BEAED301ABC18F00013F194 /* CubicLineChartViewController.xib */,
@@ -747,6 +752,7 @@
 				5BEAED361ABC192F0013F194 /* RadarChartViewController.m in Sources */,
 				5B6654D11BB0A36F00890030 /* MyCustomXValueFormatter.m in Sources */,
 				5B9624411B38608C007763E2 /* NegativeStackedBarChartViewController.m in Sources */,
+				13D38A461B708CE1009D4C4D /* GroupedCombinedChartViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ChartsDemo/Classes/DemoListViewController.m
+++ b/ChartsDemo/Classes/DemoListViewController.m
@@ -17,6 +17,7 @@
 #import "BarChartViewController.h"
 #import "HorizontalBarChartViewController.h"
 #import "CombinedChartViewController.h"
+#import "GroupedCombinedChartViewController.h"
 #import "PieChartViewController.h"
 #import "ScatterChartViewController.h"
 #import "StackedBarChartViewController.h"
@@ -72,6 +73,11 @@
                           @"title": @"Combined Chart",
                           @"subtitle": @"Demonstrates how to create a combined chart (bar and line in this case).",
                           @"class": CombinedChartViewController.class
+                          },
+                      @{
+                          @"title": @"Grouped Combined Chart",
+                          @"subtitle": @"Demonstrates how to create a grouped combined chart (bar and line in this case).",
+                          @"class": GroupedCombinedChartViewController.class
                           },
                       @{
                           @"title": @"Pie Chart",

--- a/ChartsDemo/Classes/Demos/GroupedCombinedChartViewController.h
+++ b/ChartsDemo/Classes/Demos/GroupedCombinedChartViewController.h
@@ -1,0 +1,18 @@
+//
+//  GroupedCombinedChartViewController.h
+//  ChartsDemo
+//
+//  Created by Xuan on 8/3/15.
+//
+//  Copyright 2015 Daniel Cohen Gindi & Philipp Jahoda
+//  A port of MPAndroidChart for iOS
+//  Licensed under Apache License 2.0
+//
+//  https://github.com/danielgindi/ios-charts
+//
+
+#import "CombinedChartViewController.h"
+
+@interface GroupedCombinedChartViewController : CombinedChartViewController
+
+@end

--- a/ChartsDemo/Classes/Demos/GroupedCombinedChartViewController.m
+++ b/ChartsDemo/Classes/Demos/GroupedCombinedChartViewController.m
@@ -1,0 +1,124 @@
+//
+//  GroupedCombinedChartViewController.m
+//  ChartsDemo
+//
+//  Created by Xuan on 8/3/15.
+//
+//  Copyright 2015 Daniel Cohen Gindi & Philipp Jahoda
+//  A port of MPAndroidChart for iOS
+//  Licensed under Apache License 2.0
+//
+//  https://github.com/danielgindi/ios-charts
+//
+
+#import "GroupedCombinedChartViewController.h"
+#import "ChartsDemo-Swift.h"
+
+#define ITEM_COUNT 12
+
+@interface GroupedCombinedChartViewController ()
+
+@end
+
+@implementation GroupedCombinedChartViewController
+
+// used by lazy nib initializer for subclasses
+-(NSString *)nibName {
+    return @"CombinedChartViewController";
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+- (LineChartData *)generateLineData
+{
+    LineChartData *d = [[LineChartData alloc] init];
+    
+    NSArray *colors = @[ChartColorTemplates.vordiplom[0], ChartColorTemplates.vordiplom[1], ChartColorTemplates.vordiplom[2]];
+    
+    NSMutableArray *dataSets = [[NSMutableArray alloc] init];
+    
+    for (int z = 0; z < 3; z++)
+    {
+        NSMutableArray *values = [[NSMutableArray alloc] init];
+        
+        for (int i = 0; i < ITEM_COUNT; i++)
+        {
+            double val = (double) (arc4random_uniform(25) + i);
+            [values addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:i]];
+        }
+        
+        LineChartDataSet *d = [[LineChartDataSet alloc] initWithYVals:values label:[NSString stringWithFormat:@"DataSet %d", z + 1]];
+        d.lineWidth = 2.5;
+        d.circleRadius = 4.0;
+        
+        UIColor *color = colors[z % colors.count];
+        [d setColor:color];
+        [d setCircleColor:color];
+        [dataSets addObject:d];
+    }
+    
+    ((LineChartDataSet *)dataSets[0]).lineDashLengths = @[@5.f, @5.f];
+    ((LineChartDataSet *)dataSets[0]).colors = ChartColorTemplates.vordiplom;
+    ((LineChartDataSet *)dataSets[0]).circleColors = ChartColorTemplates.vordiplom;
+    [d addDataSet:dataSets[0]];
+    [d addDataSet:dataSets[1]];
+    [d addDataSet:dataSets[2]];
+    
+    return d;
+}
+
+- (BarChartData *)generateBarData
+{
+    NSMutableArray *yVals1 = [[NSMutableArray alloc] init];
+    NSMutableArray *yVals2 = [[NSMutableArray alloc] init];
+    NSMutableArray *yVals3 = [[NSMutableArray alloc] init];
+    NSMutableArray *yVals4 = [[NSMutableArray alloc] init];
+    
+    for (int i = 0; i < ITEM_COUNT; i++)
+    {
+        double val = (double) (arc4random_uniform(15) + 3.0);
+        [yVals1 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        
+        val = (double) (arc4random_uniform(15) + 3.0);
+        [yVals2 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        
+        val = (double) (arc4random_uniform(15) + 3.0);
+        [yVals3 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        
+        val = (double) (arc4random_uniform(15) + 4.0);
+        [yVals4 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+    }
+    
+    BarChartDataSet *set1 = [[BarChartDataSet alloc] initWithYVals:yVals1 label:@"Company A"];
+    [set1 setColor:[UIColor colorWithRed:60/255.f green:220/255.f blue:78/255.f alpha:1.f]];
+    set1.valueFont = [UIFont systemFontOfSize:10.f];
+    set1.valueTextColor = [UIColor colorWithRed:60/255.f green:220/255.f blue:78/255.f alpha:1.f];
+    
+    BarChartDataSet *set2 = [[BarChartDataSet alloc] initWithYVals:yVals2 label:@"Company B"];
+    [set2 setColor:[UIColor colorWithRed:164/255.f green:228/255.f blue:251/255.f alpha:1.f]];
+    set2.valueFont = [UIFont systemFontOfSize:10.f];
+    set2.valueTextColor = [UIColor colorWithRed:60/255.f green:220/255.f blue:78/255.f alpha:1.f];
+    
+    BarChartDataSet *set3 = [[BarChartDataSet alloc] initWithYVals:yVals3 label:@"Company C"];
+    [set3 setColor:[UIColor colorWithRed:242/255.f green:247/255.f blue:158/255.f alpha:1.f]];
+    set3.valueFont = [UIFont systemFontOfSize:10.f];
+    set3.valueTextColor = [UIColor colorWithRed:60/255.f green:220/255.f blue:78/255.f alpha:1.f];
+    
+    BarChartDataSet *set4 = [[BarChartDataSet alloc] initWithYVals:yVals4 label:@"Company D"];
+    [set4 setColor:[UIColor colorWithRed:242/255.f green:247/255.f blue:158/255.f alpha:1.f]];
+    set4.valueFont = [UIFont systemFontOfSize:10.f];
+    set4.valueTextColor = [UIColor colorWithRed:60/255.f green:220/255.f blue:78/255.f alpha:1.f];
+    
+    BarChartData *d = [[BarChartData alloc] init];
+    [d addDataSet:set1];
+    [d addDataSet:set2];
+    [d addDataSet:set3];
+    [d addDataSet:set4];
+    
+    return d;
+}
+
+@end


### PR DESCRIPTION
I got one implementation for grouped bar chart support in CombinedChartView today to address issue #252 

I add a new demo view controller called GroupedCombinedChartViewController, to illustrate multiple bars + multiple lines

I have no intention to merge this PR, as you must have many suggestions and questions :-) 

I want to start a discussion about the implementations, and perhaps we can find a good one.

My idea is to add a few properties as the bar chart renderer and transformers, and use bars transformers to locate the xIndex and dataSet to highlight. Other like line/bubble, just use the xIndex and dataSet to highlight their data points.

Pros:
Straightforward, easy to understand and implement

Cons:
I have to create a CombinedChartHighlighter and copy the code from BarChartHighlighter, as I cannot create _highlighters (like CombinedChartRenderer does) nor I can subclass BarChartHighlighter, but I did need the code to calcuate bar stuff.