### PR TITLE
Bar and Pie Chart Icons [Dup #629?]

### DIFF
--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -23,6 +23,9 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     /// if set to true, all values are drawn above their bars, instead of below their top
     private var _drawValueAboveBarEnabled = true
 
+    /// if set to true, all icons are drawn above their bars, instead of below their top
+    private var _drawIconAboveBarEnabled = true
+
     /// if set to true, a grey area is darawn behind each bar that indicates the maximum value
     private var _drawBarShadowEnabled = false
     
@@ -147,6 +150,17 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
         }
     }
     
+    /// if set to true, all icons are drawn above their bars, instead of below their top
+    public var drawIconAboveBarEnabled: Bool
+        {
+        get { return _drawIconAboveBarEnabled; }
+        set
+        {
+            _drawIconAboveBarEnabled = newValue
+            setNeedsDisplay()
+        }
+    }
+    
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
     public var drawBarShadowEnabled: Bool
     {
@@ -167,6 +181,8 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     
     /// - returns: true if drawing values above bars is enabled, false if not
     public var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
+    
+    public var isDrawIconAboveBarEnabled: Bool { return drawIconAboveBarEnabled }
     
     /// - returns: true if drawing shadows (maxvalue) for each bar is enabled, false if not
     public var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }

--- a/Charts/Classes/Charts/CombinedChartView.swift
+++ b/Charts/Classes/Charts/CombinedChartView.swift
@@ -195,6 +195,13 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
         get { return (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled }
         set { (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled = newValue }
     }
+
+    /// if set to true, all icons are drawn above their bars, instead of below their top
+    public var drawIconAboveBarEnabled: Bool
+        {
+        get { return (renderer as! CombinedChartRenderer!).drawIconAboveBarEnabled }
+        set { (renderer as! CombinedChartRenderer!).drawIconAboveBarEnabled = newValue }
+    }
     
     /// if set to true, a grey area is darawn behind each bar that indicates the maximum value
     public var drawBarShadowEnabled: Bool
@@ -208,6 +215,9 @@ public class CombinedChartView: BarLineChartViewBase, LineChartDataProvider, Bar
     
     /// - returns: true if drawing values above bars is enabled, false if not
     public var isDrawValueAboveBarEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled; }
+    
+    /// - returns: true if drawing icons above bars is enabled, false if not
+    public var isDrawIconAboveBarEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawIconAboveBarEnabled; }
     
     /// - returns: true if drawing shadows (maxvalue) for each bar is enabled, false if not
     public var isDrawBarShadowEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawBarShadowEnabled; }

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -32,6 +32,7 @@ public class ChartDataSet: NSObject
     public var label: String? = "DataSet"
     public var visible = true
     public var drawValuesEnabled = true
+    public var drawIconsEnabled = true
     
     /// the color used for the value-text
     public var valueTextColor: UIColor = UIColor.blackColor()
@@ -505,6 +506,11 @@ public class ChartDataSet: NSObject
         return drawValuesEnabled
     }
     
+    public var isDrawIconsEnabled: Bool
+        {
+            return drawIconsEnabled
+    }
+
     /// Checks if this DataSet contains the specified Entry.
     /// - returns: true if contains the entry, false if not.
     public func contains(e: ChartDataEntry) -> Bool

--- a/Charts/Classes/Interfaces/BarChartDataProvider.swift
+++ b/Charts/Classes/Interfaces/BarChartDataProvider.swift
@@ -21,5 +21,6 @@ public protocol BarChartDataProvider: BarLineScatterCandleBubbleChartDataProvide
     
     var isDrawBarShadowEnabled: Bool { get }
     var isDrawValueAboveBarEnabled: Bool { get }
+    var isDrawIconAboveBarEnabled: Bool { get }
     var isDrawHighlightArrowEnabled: Bool { get }
 }

--- a/Charts/Classes/Renderers/CombinedChartRenderer.swift
+++ b/Charts/Classes/Renderers/CombinedChartRenderer.swift
@@ -24,6 +24,9 @@ public class CombinedChartRenderer: ChartDataRendererBase
     /// if set to true, all values are drawn above their bars, instead of below their top
     public var drawValueAboveBarEnabled = true
     
+    /// if set to true, all icons are drawn above their bars, instead of below their top
+    public var drawIconAboveBarEnabled = true
+    
     /// if set to true, a grey area is darawn behind each bar that indicates the maximum value
     public var drawBarShadowEnabled = true
     

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -244,6 +244,30 @@ public class ChartUtils
         drawMultilineText(context: context, text: text, knownTextSize: rect.size, point: point, attributes: attributes, constrainedToSize: constrainedToSize, anchor: anchor, angleRadians: angleRadians)
     }
     
+    public class func drawImage(context context: CGContext, image: UIImage, point: CGPoint, expectedSize: CGSize)
+    {
+        var drawOffset = CGPoint()
+        drawOffset.x += point.x
+        drawOffset.x -= expectedSize.width / 2
+        drawOffset.y += point.y
+        drawOffset.y -= expectedSize.height / 2
+
+        UIGraphicsPushContext(context)
+
+        if image.size.width != expectedSize.width && image.size.height != expectedSize.height {
+            UIGraphicsBeginImageContextWithOptions(expectedSize, false, 0.0)
+            image.drawInRect(CGRect(origin: CGPointZero, size: expectedSize))
+            let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            scaledImage.drawAtPoint(drawOffset)
+        }
+        else {
+            image.drawAtPoint(drawOffset)
+        }
+
+        UIGraphicsPopContext()
+    }
+    
     /// - returns: an angle between 0.0 < 360.0 (not less than zero, less than 360)
     internal class func normalizedAngleFromAngle(var angle: CGFloat) -> CGFloat
     {

--- a/ChartsDemo/Classes/Demos/BarChartViewController.m
+++ b/ChartsDemo/Classes/Demos/BarChartViewController.m
@@ -112,7 +112,9 @@
     {
         double mult = (range + 1);
         double val = (double) (arc4random_uniform(mult));
-        [yVals addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        BarChartDataEntry *entry = [[BarChartDataEntry alloc] initWithValue:val xIndex:i];
+        entry.data = @"Icon-29@2x.png";
+        [yVals addObject: entry];
     }
     
     BarChartDataSet *set1 = [[BarChartDataSet alloc] initWithYVals:yVals label:@"DataSet"];

--- a/ChartsDemo/Classes/Demos/MultipleBarChartViewController.m
+++ b/ChartsDemo/Classes/Demos/MultipleBarChartViewController.m
@@ -103,13 +103,19 @@
     for (int i = 0; i < count; i++)
     {
         double val = (double) (arc4random_uniform(mult) + 3.0);
-        [yVals1 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        BarChartDataEntry *entry = [[BarChartDataEntry alloc] initWithValue:val xIndex:i];
+        entry.data = @"Icon-29@2x.png";
+        [yVals1 addObject: entry];
         
         val = (double) (arc4random_uniform(mult) + 3.0);
-        [yVals2 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        BarChartDataEntry *entry2 = [[BarChartDataEntry alloc] initWithValue:val xIndex:i];
+        entry2.data = @"Icon-29@2x.png";
+        [yVals2 addObject: entry2];
         
         val = (double) (arc4random_uniform(mult) + 3.0);
-        [yVals3 addObject:[[BarChartDataEntry alloc] initWithValue:val xIndex:i]];
+        BarChartDataEntry *entry3 = [[BarChartDataEntry alloc] initWithValue:val xIndex:i];
+        entry3.data = @"Icon-29@2x.png";
+        [yVals3 addObject: entry3];
     }
     
     BarChartDataSet *set1 = [[BarChartDataSet alloc] initWithYVals:yVals1 label:@"Company A"];

--- a/ChartsDemo/Classes/Demos/PieChartViewController.m
+++ b/ChartsDemo/Classes/Demos/PieChartViewController.m
@@ -108,7 +108,9 @@
     // IMPORTANT: In a PieChart, no values (Entry) should have the same xIndex (even if from different DataSets), since no values can be drawn above each other.
     for (int i = 0; i < count; i++)
     {
-        [yVals1 addObject:[[BarChartDataEntry alloc] initWithValue:(arc4random_uniform(mult) + mult / 5) xIndex:i]];
+        ChartDataEntry *entry = [[BarChartDataEntry alloc] initWithValue:(arc4random_uniform(mult) + mult / 5) xIndex:i];
+        entry.data = @"Icon-29@2x.png";
+        [yVals1 addObject: entry];
     }
     
     NSMutableArray *xVals = [[NSMutableArray alloc] init];

--- a/ChartsDemo/Classes/Demos/StackedBarChartViewController.m
+++ b/ChartsDemo/Classes/Demos/StackedBarChartViewController.m
@@ -103,7 +103,9 @@
         double val2 = (double) (arc4random_uniform(mult) + mult / 3);
         double val3 = (double) (arc4random_uniform(mult) + mult / 3);
         
-        [yVals addObject:[[BarChartDataEntry alloc] initWithValues:@[@(val1), @(val2), @(val3)] xIndex:i]];
+        BarChartDataEntry *entry = [[BarChartDataEntry alloc] initWithValues:@[@(val1), @(val2), @(val3)] xIndex:i];
+        entry.data = [NSArray arrayWithObjects: @"Icon-29@2x.png", @"Icon-29@2x.png", @"Icon-29@2x.png", nil];
+        [yVals addObject: entry];
     }
     
     BarChartDataSet *set1 = [[BarChartDataSet alloc] initWithYVals:yVals label:@"Statistics Vienna 2014"];


### PR DESCRIPTION
Bar and Pie Charts now support icons.

Added ability to draw icons on Bar and Pie charts when an image name is specified in ChartDataEntry.data. Added Boolean flags 'isDrawIconEnabled`and`isDrawIconAboveBarEnabled` (similar to the existing drawValues logic). Icon size is dependent on bar width or size of pie slice.
