### PR TITLE
Enhancement - Added the parameter eventParentEnabled to Pie and Radar Charts-  🤓 👻

### DIFF
--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -27,6 +27,9 @@ public class PieRadarChartViewBase: ChartViewBase
     /// flag that indicates if rotation is enabled or not
     public var rotationEnabled = true
     
+    /// flat that indicates if the the events will submit to the parent
+    public var eventParentEnabled =  true;
+    
     /// Sets the minimum offset (padding) around the chart, defaults to 0.0
     public var minOffset = CGFloat(0.0)
 
@@ -402,6 +405,8 @@ public class PieRadarChartViewBase: ChartViewBase
     
     public var isRotationEnabled: Bool { return rotationEnabled; }
     
+    public var isEventParentEnabled: Bool {return eventParentEnabled; }
+    
     /// flag that indicates if rotation is done with two fingers or one.
     /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
     /// 
@@ -514,7 +519,7 @@ public class PieRadarChartViewBase: ChartViewBase
             }
         }
         
-        if (!_isRotating)
+        if (!_isRotating && eventParentEnabled)
         {
             super.touchesBegan(touches, withEvent: event)
         }
@@ -544,7 +549,7 @@ public class PieRadarChartViewBase: ChartViewBase
             }
         }
         
-        if (!_isRotating)
+        if (!_isRotating && eventParentEnabled)
         {
             super.touchesMoved(touches, withEvent: event)
         }
@@ -552,7 +557,7 @@ public class PieRadarChartViewBase: ChartViewBase
     
     public override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?)
     {
-        if (!_isRotating)
+        if (!_isRotating && eventParentEnabled)
         {
             super.touchesEnded(touches, withEvent: event)
         }


### PR DESCRIPTION
Hi @PhilJay and @danielgindi and congrats for all the work, this is my little contribution.

**Disabling the rotate on the Pie and Radar to using that gesture for something different**

In my application I have to use the horizontal scroll to show a menu on a view which has a pie o radar chart, I can disable the gestures on the rest of the charts but in the case of Pie or Radar, I can't. o I added the attribute just to know if the user wants to the chart rotate or use the scroll for anything else.

Somethig like this:

![screen shot 2016-01-22 at 6 39 54 pm](https://cloud.githubusercontent.com/assets/5713880/12526893/53618418-c138-11e5-9bc5-3e246f661ddb.jpg)

If I turn down the even parent handler, I can use the drag inside the chart to move my view and show the menu. 😎


