### PR TITLE
[Pending rebase] Some lines in line chart not rendering for sparse data

### DIFF
--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -176,6 +176,48 @@ public class ChartDataSet: NSObject
         return nil
     }
     
+    
+    /// - returns: the first entry object with an x-index lower than the specified x-index or,
+    /// if there are no entries with a lower x-index, the closest entry to that index.
+    /// returns nil if there are no entries at all
+    public func entryBeforeXIndex(x: Int) -> ChartDataEntry?
+    {
+        // find closest/adjacent entry to this x-index
+        var valIndex = self.entryIndex(xIndex: x)
+        guard valIndex > -1 else { return nil }
+        
+        var entry = _yVals[valIndex]
+        
+        // Find the next entry with an x-index lower than the specified one. This will usually only take one iteration.
+        // NB: This assumes that chart entries are sorted by x index (which is the case in many places in this project).
+        while(valIndex > 0 && entry.xIndex >= x) {
+            valIndex -= 1
+            entry = _yVals[valIndex]
+        }
+        return entry
+    }
+    
+    /// - returns: the first entry object with an x-index higher than the specified x-index or,
+    /// if there are no entries with a lower x-index, the closest entry to that index.
+    /// returns nil if there are no entries at all
+    public func entryAfterXIndex(x: Int) -> ChartDataEntry?
+    {
+        // find closest/adjacent entry to this x-index
+        var valIndex = self.entryIndex(xIndex: x)
+        guard valIndex > -1 else { return nil }
+        
+        var entry = _yVals[valIndex]
+        
+        // Find the next entry with an x-index higher than the specified one. This will usually only take one iteration.
+        // NB: This assumes that chart entries are sorted by x index (which is the case in many places in this project).
+        while(valIndex < _yVals.count - 1 && entry.xIndex <= x) {
+            valIndex += 1
+            entry = _yVals[valIndex]
+        }
+        return entry
+    }
+    
+    
     public func entriesForXIndex(x: Int) -> [ChartDataEntry]
     {
         var entries = [ChartDataEntry]()

--- a/Charts/Classes/Data/ChartDataSet.swift
+++ b/Charts/Classes/Data/ChartDataSet.swift
@@ -190,7 +190,8 @@ public class ChartDataSet: NSObject
         
         // Find the next entry with an x-index lower than the specified one. This will usually only take one iteration.
         // NB: This assumes that chart entries are sorted by x index (which is the case in many places in this project).
-        while(valIndex > 0 && entry.xIndex >= x) {
+        while(valIndex > 0 && entry.xIndex >= x)
+        {
             valIndex -= 1
             entry = _yVals[valIndex]
         }
@@ -210,7 +211,8 @@ public class ChartDataSet: NSObject
         
         // Find the next entry with an x-index higher than the specified one. This will usually only take one iteration.
         // NB: This assumes that chart entries are sorted by x index (which is the case in many places in this project).
-        while(valIndex < _yVals.count - 1 && entry.xIndex <= x) {
+        while(valIndex < _yVals.count - 1 && entry.xIndex <= x)
+        {
             valIndex += 1
             entry = _yVals[valIndex]
         }

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -239,8 +239,8 @@ public class LineChartRenderer: LineScatterCandleRadarChartRenderer
         
         CGContextSaveGState(context)
         
-        let entryFrom = dataSet.entryForXIndex(_minX)!
-        let entryTo = dataSet.entryForXIndex(_maxX)!
+        let entryFrom = dataSet.entryBeforeXIndex(_minX)!
+        let entryTo = dataSet.entryAfterXIndex(_maxX)!
         
         let diff = (entryFrom == entryTo) ? 1 : 0
         let minx = max(dataSet.entryIndex(entry: entryFrom, isEqual: true) - diff, 0)


### PR DESCRIPTION
For sparse data sets (that is, if there is not an entry for every x-index), when zoomed in and panning around, sometimes the outer lines of the line chart would disappear.

See this (sorry for the mediocre quality, I thought GIF is more appropriate here than a video):
![charts-bug](https://cloud.githubusercontent.com/assets/76049/12576552/ccb83fa8-c414-11e5-81cf-614e269dd641.gif)

In this demo, I use 15-minute intervals for the x-values, but there is not an entry for every x-index (thus "sparse data set").

I've had a look at the code and also fixed the issue. The following is an in-depth explanation of the issue at the code level:
In fact, ChartRendererBase took precautions to set _minX and _maxX to be always outside of the visible viewport, however, if the data set is sparse, this is not enough: If there is no entry at _minX, dataSet.entryForXIndex(_minX) will often return an entry with xIndex > _minX (not always, though, because of the nature of binary search). Fixed this by adding two more entry query functions to ChartDataSet: entryBeforeXIndex and entryAfterXIndex, which are guaranteed to return entries with a lower/higher x-index (if they exist).
