### PR TITLE
Improved lowestVisibleXIndex

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1921,7 +1921,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         var pt = CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentBottom)
         getTransformer(.Left).pixelToValue(&pt)
-        return (pt.x <= 0.0) ? 0 : Int(round(pt.x + 1.0))
+        return (pt.x <= 0.0) ? 0 : Int(round(pt.x))
     }
     
     /// - returns: the highest x-index (value on the x-axis) that is still visible on the chart.


### PR DESCRIPTION
Improved lowestVisibleXIndex so that the line chart does not ignore first x value and returns 0 for lowestVisibleXIndex instead of 1. Could be related to issue #785

Chart I'm using is of type LineChartView, the params setup for drawing:
chart.descriptionText = "weight (lbs)"
chart.legend.enabled = false
chart.minOffset = CGFloat(50)
chart.leftAxis.startAtZeroEnabled = false
chart.leftAxis.drawGridLinesEnabled = false
chart.rightAxis.enabled = true
chart.rightAxis.drawLabelsEnabled = false
chart.rightAxis.drawGridLinesEnabled = false
chart.xAxis.drawGridLinesEnabled = false
**chart.autoScaleMinMaxEnabled = true**
chart.drawBordersEnabled = true
chart.drawGridBackgroundEnabled = true

My Chart before the change: 
<img width="430" alt="screen shot 2016-03-03 at 9 49 19 am" src="https://cloud.githubusercontent.com/assets/9628216/13500309/06a18dd6-e130-11e5-8bb0-632f5b79b604.png">
It was not possible to scroll up or zoom out, to see the first point. It seemed to be drawn out of bounds.

After my fix:
<img width="438" alt="screen shot 2016-03-03 at 10 13 21 am" src="https://cloud.githubusercontent.com/assets/9628216/13500319/152e562c-e130-11e5-9b30-b3470e33ea9b.png">
