### PR TITLE
Property circleHoleRadius added to ILineChartDataSet protocol. 

### DIFF
--- a/Charts/Classes/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/LineChartDataSet.swift
@@ -40,6 +40,7 @@ public class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     // MARK: - Styling functions and accessors
     
     private var _cubicIntensity = CGFloat(0.2)
+    private var _circleHoleRadius = CGFloat(4.0)
     
     /// Intensity for cubic lines (min = 0.05, max = 1)
     ///
@@ -78,6 +79,18 @@ public class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     
     /// The radius of the drawn circles.
     public var circleRadius = CGFloat(8.0)
+    
+    /// The radius of the drawn circles.
+    public var circleHoleRadius : CGFloat {
+        get {
+            return _circleHoleRadius;
+        }
+        set {
+            if newValue < self.circleRadius {
+                _circleHoleRadius = newValue
+            }
+        }
+    }
     
     public var circleColors = [NSUIColor]()
     

--- a/Charts/Classes/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Charts/Classes/Data/Implementations/Standard/LineChartDataSet.swift
@@ -40,7 +40,6 @@ public class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     // MARK: - Styling functions and accessors
     
     private var _cubicIntensity = CGFloat(0.2)
-    private var _circleHoleRadius = CGFloat(4.0)
     
     /// Intensity for cubic lines (min = 0.05, max = 1)
     ///
@@ -80,13 +79,19 @@ public class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     /// The radius of the drawn circles.
     public var circleRadius = CGFloat(8.0)
     
-    /// The radius of the drawn circles.
-    public var circleHoleRadius : CGFloat {
-        get {
+    private var _circleHoleRadius = CGFloat(4.0)
+    
+    /// The hole radius of the drawn circles (new value is set only if it is less than circleRadius value)
+    public var circleHoleRadius : CGFloat
+    {
+        get
+        {
             return _circleHoleRadius;
         }
-        set {
-            if newValue < self.circleRadius {
+        set
+        {
+            if newValue < self.circleRadius
+            {
                 _circleHoleRadius = newValue
             }
         }

--- a/Charts/Classes/Data/Interfaces/ILineChartDataSet.swift
+++ b/Charts/Classes/Data/Interfaces/ILineChartDataSet.swift
@@ -41,6 +41,9 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     /// The radius of the drawn circles.
     var circleRadius: CGFloat { get set }
     
+    /// The hole radius of the drawn circles.
+    var circleHoleRadius: CGFloat { get set }
+    
     var circleColors: [NSUIColor] { get set }
     
     /// - returns: the color at the given index of the DataSet's circle-color array.

--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -585,8 +585,8 @@ public class LineChartRenderer: LineRadarChartRenderer
             
             let circleRadius = dataSet.circleRadius
             let circleDiameter = circleRadius * 2.0
-            let circleHoleDiameter = circleRadius
-            let circleHoleRadius = circleHoleDiameter / 2.0
+            let circleHoleRadius = dataSet.circleHoleRadius
+            let circleHoleDiameter = circleHoleRadius * 2.0
             let isDrawCircleHoleEnabled = dataSet.isDrawCircleHoleEnabled
             
             guard let

--- a/ChartsRealm/Classes/Data/RealmLineDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmLineDataSet.swift
@@ -30,6 +30,7 @@ public class RealmLineDataSet: RealmLineRadarDataSet, ILineChartDataSet
     // MARK: - Styling functions and accessors
     
     private var _cubicIntensity = CGFloat(0.2)
+    private var _circleHoleRadius = CGFloat(4.0)
     
     /// Intensity for cubic lines (min = 0.05, max = 1)
     ///
@@ -68,6 +69,18 @@ public class RealmLineDataSet: RealmLineRadarDataSet, ILineChartDataSet
 
     /// The radius of the drawn circles.
     public var circleRadius = CGFloat(8.0)
+    
+    /// The radius of the drawn circles.
+    public var circleHoleRadius : CGFloat {
+        get {
+            return _circleHoleRadius;
+        }
+        set {
+            if newValue < self.circleRadius {
+                _circleHoleRadius = newValue
+            }
+        }
+    }
     
     public var circleColors = [NSUIColor]()
     

--- a/ChartsRealm/Classes/Data/RealmLineDataSet.swift
+++ b/ChartsRealm/Classes/Data/RealmLineDataSet.swift
@@ -30,7 +30,6 @@ public class RealmLineDataSet: RealmLineRadarDataSet, ILineChartDataSet
     // MARK: - Styling functions and accessors
     
     private var _cubicIntensity = CGFloat(0.2)
-    private var _circleHoleRadius = CGFloat(4.0)
     
     /// Intensity for cubic lines (min = 0.05, max = 1)
     ///
@@ -70,13 +69,19 @@ public class RealmLineDataSet: RealmLineRadarDataSet, ILineChartDataSet
     /// The radius of the drawn circles.
     public var circleRadius = CGFloat(8.0)
     
-    /// The radius of the drawn circles.
-    public var circleHoleRadius : CGFloat {
-        get {
+    private var _circleHoleRadius = CGFloat(4.0)
+    
+    /// The hole radius of the drawn circles (new value is set only if it is less than circleRadius value)
+    public var circleHoleRadius : CGFloat
+    {
+        get
+        {
             return _circleHoleRadius;
         }
-        set {
-            if newValue < self.circleRadius {
+        set
+        {
+            if newValue < self.circleRadius
+            {
                 _circleHoleRadius = newValue
             }
         }


### PR DESCRIPTION
Property circleHoleRadius added to ILineChartDataSet protocol. The new circleHoleRadius value is set only if it is less than circleRadius. Otherwise a default value (4.0) is used.