### PR TITLE
Fix a crash when using markers with a PieChart

### DIFF
--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -530,7 +530,7 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
             let highlight = _indicesToHighlight[i]
             let xIndex = highlight.xIndex
 
-            let deltaX = _xAxis.axisRange
+            let deltaX = _xAxis?.axisRange ?? Double(_data?.xVals.count ?? 0 ) - 1
             if xIndex <= Int(deltaX) && xIndex <= Int(CGFloat(deltaX) * _animator.phaseX)
             {
                 let e = _data?.getEntryForHighlight(highlight)


### PR DESCRIPTION
fa5d01f introduced a crash when using a MarkerView with a PieChartView – because PieChartView no longer has an `_xAxis`, any attempt to call `drawMarkers` will crash [here](https://github.com/danielgindi/Charts/blob/b1dcdbd25f4b3bff3fba9c9593fcede1bb148617/Charts/Classes/Charts/ChartViewBase.swift#L533). I'm not sure if this is the ideal fix with how you've been refactoring the ChartView classes, but it does restore the ability to use markers with a pie chart.