### PR TITLE
Allow PieChartView to hide labels for tiny slices

### DIFF
--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -25,6 +25,7 @@ public class PieChartView: PieRadarChartViewBase
     private var _circleBox = CGRect()
     
     private var _drawXLabelsEnabled = true
+    private var _drawXLabelsMinimumAngle: Double = 0
     
     /// array that holds the width of each pie-slice in degrees
     private var _drawAngles = [CGFloat]()
@@ -510,6 +511,19 @@ public class PieChartView: PieRadarChartViewBase
         set
         {
             _drawXLabelsEnabled = newValue
+            setNeedsDisplay()
+        }
+    }
+    
+    public var drawSliceTextMinimumAngle: Double
+    {
+        get
+        {
+            return _drawXLabelsMinimumAngle
+        }
+        set
+        {
+            _drawXLabelsMinimumAngle = newValue
             setNeedsDisplay()
         }
     }

--- a/Charts/Classes/Charts/PieChartView.swift
+++ b/Charts/Classes/Charts/PieChartView.swift
@@ -25,7 +25,7 @@ public class PieChartView: PieRadarChartViewBase
     private var _circleBox = CGRect()
     
     private var _drawXLabelsEnabled = true
-    private var _drawXLabelsMinimumAngle: Double = 0
+    private var _drawXLabelsMinimumAngle: CGFloat = 0
     
     /// array that holds the width of each pie-slice in degrees
     private var _drawAngles = [CGFloat]()
@@ -515,7 +515,7 @@ public class PieChartView: PieRadarChartViewBase
         }
     }
     
-    public var drawSliceTextMinimumAngle: Double
+    public var drawSliceTextMinimumAngle: CGFloat
     {
         get
         {

--- a/Charts/Classes/Renderers/PieChartRenderer.swift
+++ b/Charts/Classes/Renderers/PieChartRenderer.swift
@@ -360,10 +360,10 @@ public class PieChartRenderer: ChartDataRendererBase
                 let sliceXBase = cos(transformedAngle * ChartUtils.Math.FDEG2RAD)
                 let sliceYBase = sin(transformedAngle * ChartUtils.Math.FDEG2RAD)
                 
-                let drawXOutside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawXVals && xValuePosition == .OutsideSlice
-                let drawYOutside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawYVals && yValuePosition == .OutsideSlice
-                let drawXInside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawXVals && xValuePosition == .InsideSlice
-                let drawYInside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawYVals && yValuePosition == .InsideSlice
+                let drawXOutside = sliceAngle > drawSliceTextMinimumAngle && drawXVals && xValuePosition == .OutsideSlice
+                let drawYOutside = sliceAngle > drawSliceTextMinimumAngle && drawYVals && yValuePosition == .OutsideSlice
+                let drawXInside = sliceAngle > drawSliceTextMinimumAngle && drawXVals && xValuePosition == .InsideSlice
+                let drawYInside = sliceAngle > drawSliceTextMinimumAngle && drawYVals && yValuePosition == .InsideSlice
                 
                 if drawXOutside || drawYOutside
                 {

--- a/Charts/Classes/Renderers/PieChartRenderer.swift
+++ b/Charts/Classes/Renderers/PieChartRenderer.swift
@@ -297,6 +297,7 @@ public class PieChartRenderer: ChartDataRendererBase
         let yValueSum = (data as! PieChartData).yValueSum
         
         let drawXVals = chart.isDrawSliceTextEnabled
+        let drawSliceTextMinimumAngle = chart.drawSliceTextMinimumAngle
         let usePercentValuesEnabled = chart.usePercentValuesEnabled
         
         var angle: CGFloat = 0.0
@@ -359,10 +360,10 @@ public class PieChartRenderer: ChartDataRendererBase
                 let sliceXBase = cos(transformedAngle * ChartUtils.Math.FDEG2RAD)
                 let sliceYBase = sin(transformedAngle * ChartUtils.Math.FDEG2RAD)
                 
-                let drawXOutside = drawXVals && xValuePosition == .OutsideSlice
-                let drawYOutside = drawYVals && yValuePosition == .OutsideSlice
-                let drawXInside = drawXVals && xValuePosition == .InsideSlice
-                let drawYInside = drawYVals && yValuePosition == .InsideSlice
+                let drawXOutside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawXVals && xValuePosition == .OutsideSlice
+                let drawYOutside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawYVals && yValuePosition == .OutsideSlice
+                let drawXInside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawXVals && xValuePosition == .InsideSlice
+                let drawYInside = Double(sliceAngle) > drawSliceTextMinimumAngle && drawYVals && yValuePosition == .InsideSlice
                 
                 if drawXOutside || drawYOutside
                 {

--- a/ChartsDemo/Classes/Demos/PieChartViewController.m
+++ b/ChartsDemo/Classes/Demos/PieChartViewController.m
@@ -35,6 +35,7 @@
     self.options = @[
                      @{@"key": @"toggleValues", @"label": @"Toggle Y-Values"},
                      @{@"key": @"toggleXValues", @"label": @"Toggle X-Values"},
+                     @{@"key": @"toggleXValuesMinimumAngle", @"label": @"Toggle X-Values Minimum Angle"},
                      @{@"key": @"togglePercent", @"label": @"Toggle Percent"},
                      @{@"key": @"toggleHole", @"label": @"Toggle Hole"},
                      @{@"key": @"animateX", @"label": @"Animate X"},
@@ -49,6 +50,7 @@
     [self setupPieChartView:_chartView];
     
     _chartView.delegate = self;
+    _chartView.drawSliceTextMinimumAngle = 20;
     
     _sliderX.value = 3.0;
     _sliderY.value = 100.0;
@@ -130,6 +132,17 @@
         _chartView.drawSliceTextEnabled = !_chartView.isDrawSliceTextEnabled;
         
         [_chartView setNeedsDisplay];
+        return;
+    }
+    
+    if ([key isEqualToString:@"toggleXValuesMinimumAngle"])
+    {
+        if (_chartView.drawSliceTextMinimumAngle == 0){
+            _chartView.drawSliceTextMinimumAngle = 20;
+        } else {
+            _chartView.drawSliceTextMinimumAngle = 0;
+        }
+        
         return;
     }
     

--- a/ChartsDemo/Classes/Demos/PieChartViewController.m
+++ b/ChartsDemo/Classes/Demos/PieChartViewController.m
@@ -119,7 +119,7 @@
     pFormatter.percentSymbol = @" %";
     [data setValueFormatter:pFormatter];
     [data setValueFont:[UIFont fontWithName:@"HelveticaNeue-Light" size:11.f]];
-    [data setValueTextColor:UIColor.whiteColor];
+    [data setValueTextColor:UIColor.blackColor];
     
     _chartView.data = data;
     [_chartView highlightValues:nil];


### PR DESCRIPTION
Right now, if you have a labelled pie chart with a large number of tiny sections, the labels are very likely to overlap in a visually unappealing way. This commit adds a basic property to auto-hide labels for any pie chart section below a certain size – e.g. only show pie chart labels for pie sections that span at least 20º.

I also updated the color of the labels in the PieChart demo from white to black for legibility.

Before:
<img width="578" alt="screen shot 2016-04-12 at 11 58 33 am" src="https://cloud.githubusercontent.com/assets/81912/14466732/1b188f2c-00a6-11e6-8fbd-406c95cad21b.png">

After:
<img width="578" alt="screen shot 2016-04-12 at 11 58 29 am" src="https://cloud.githubusercontent.com/assets/81912/14466733/1f4d1f2c-00a6-11e6-8b33-420f60d3573c.png">
