### PR TITLE
Proposal: simplify horizontal bar chart Y axis Label offset calculation

### DIFF
--- a/Charts/Classes/Charts/HorizontalBarChartView.swift
+++ b/Charts/Classes/Charts/HorizontalBarChartView.swift
@@ -34,6 +34,10 @@ public class HorizontalBarChartView: BarChartView
         _xAxisRenderer = ChartXAxisRendererHorizontalBarChart(viewPortHandler: _viewPortHandler, xAxis: _xAxis, transformer: _leftAxisTransformer, chart: self)
         
         self.highlighter = HorizontalBarChartHighlighter(chart: self)
+        
+        // default horizontal bar chart yAxis label offset
+        _leftAxis.yOffset = 2.5
+        _rightAxis.yOffset = 2.5
     }
     
     internal override func calculateOffsets()

--- a/Charts/Classes/Components/ChartYAxis.swift
+++ b/Charts/Classes/Components/ChartYAxis.swift
@@ -218,8 +218,8 @@ public class ChartYAxis: ChartAxisBase
     {
         let label = getLongestLabel() as NSString
         var size = label.sizeWithAttributes([NSFontAttributeName: labelFont])
-        size.width += xOffset * 2.0
-        size.height += yOffset * 2.0
+        size.width += xOffset
+        size.height += yOffset
         size.width = max(minWidth, min(size.width, maxWidth > 0.0 ? maxWidth : size.width))
         return size
     }

--- a/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartYAxisRendererHorizontalBarChart.swift
@@ -75,7 +75,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         transformer.pointValuesToPixel(&positions)
         
         let lineHeight = yAxis.labelFont.lineHeight
-        let baseYOffset: CGFloat = 2.5
+        let baseYOffset: CGFloat = yAxis.yOffset
         
         let dependency = yAxis.axisDependency
         let labelPosition = yAxis.labelPosition
@@ -109,7 +109,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
         // And here we pull the line back up
         yPos -= lineHeight
         
-        drawYLabels(context: context, fixedPosition: yPos, positions: positions, offset: yAxis.yOffset)
+        drawYLabels(context: context, fixedPosition: yPos, positions: positions)
     }
     
     private var _axisLineSegmentsBuffer = [CGPoint](count: 2, repeatedValue: CGPoint())
@@ -157,7 +157,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
     }
 
     /// draws the y-labels on the specified x-position
-    public func drawYLabels(context context: CGContext, fixedPosition: CGFloat, positions: [CGPoint], offset: CGFloat)
+    public func drawYLabels(context context: CGContext, fixedPosition: CGFloat, positions: [CGPoint])
     {
         guard let yAxis = yAxis else { return }
         
@@ -173,7 +173,7 @@ public class ChartYAxisRendererHorizontalBarChart: ChartYAxisRenderer
                 return
             }
             
-            ChartUtils.drawText(context: context, text: text, point: CGPoint(x: positions[i].x, y: fixedPosition - offset), align: .Center, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
+            ChartUtils.drawText(context: context, text: text, point: CGPoint(x: positions[i].x, y: fixedPosition), align: .Center, attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
         }
     }
 


### PR DESCRIPTION
Context:
I notice in `renderAxisLabels`, there is a hard coded `baseYOffset = 2.5`, and when turnning the legend off, the horizontal bar chart's y axis labels will be partially cut off. This is because `yOffset` is set to 0 by default, and we hard code 2.5 offset. This is not discovered when legend enabled because we have enough space for the label.

I found in recent changes, we have below change for `getRequiredHeightSpace()` that impacted the label height:

```
     public func getRequiredHeightSpace() -> CGFloat
     {
-        return requiredSize().height + 2.5 * 2.0 + yOffset
+        return requiredSize().height
     }
```

So to align the idea, while fixing bug:
1. replace horizontal bar chart `renderAxisLabels()` duplicated `baseYOffset = 2.5` with `yAxis.yOffset`. We can use `yOffset` to adjust, so `drawYLabels()` does not need offset as well.
2. we could also reduce requiredSize `yOffset` to 1x in `requiredSize()`, we can use `extraOffset` to adjust the rest half

I am not sure if I missed anything especially on Android side, so please review carefully.

PS: if we want to go this way, I will record new tests later.
