### PR TITLE
Bug fix: Move fill before stroke for drawLinear()

### DIFF
--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -322,6 +322,12 @@ public class LineChartRenderer: LineRadarChartRenderer
         let minx = max(dataSet.entryIndex(entry: entryFrom) - diff, 0)
         let maxx = min(max(minx + 2, dataSet.entryIndex(entry: entryTo) + 1), entryCount)
         
+        // if drawing filled is enabled
+        if (dataSet.isDrawFilledEnabled && entryCount > 0)
+        {
+            drawLinearFill(context: context, dataSet: dataSet, minx: minx, maxx: maxx, trans: trans)
+        }
+        
         CGContextSaveGState(context)
         
         CGContextSetLineCap(context, dataSet.lineCapType)
@@ -461,12 +467,6 @@ public class LineChartRenderer: LineRadarChartRenderer
         }
         
         CGContextRestoreGState(context)
-        
-        // if drawing filled is enabled
-        if (dataSet.isDrawFilledEnabled && entryCount > 0)
-        {
-            drawLinearFill(context: context, dataSet: dataSet, minx: minx, maxx: maxx, trans: trans)
-        }
     }
     
     public func drawLinearFill(context context: CGContext, dataSet: ILineChartDataSet, minx: Int, maxx: Int, trans: ChartTransformer)


### PR DESCRIPTION
move fill before stroke for drawLinear(). if we fill after stroke, half of the stroke, line width will be covered by the fill path.

so if the fill color has some transparency, half of the line will not be solid, like:
![fill](https://cloud.githubusercontent.com/assets/4375169/14847779/183443fc-0c9d-11e6-9eae-dd55a673f823.png)

PS: I have checked drawCubicBezier and drawHorizontalBezier is filling before stroking.