### PR TITLE
Fixed limit lines on xAxis position for bar charts with several data sets.

### DIFF
--- a/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
@@ -168,7 +168,9 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
         guard let
             xAxis = xAxis,
             barData = chart?.data as? BarChartData
-            else { return }
+            else {
+                return
+        }
         
         var limitLines = xAxis.limitLines
         

--- a/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererBarChart.swift
@@ -162,4 +162,44 @@ public class ChartXAxisRendererBarChart: ChartXAxisRenderer
         
         CGContextRestoreGState(context)
     }
+    
+    public override func renderLimitLines(context context: CGContext)
+    {
+        guard let
+            xAxis = xAxis,
+            barData = chart?.data as? BarChartData
+            else { return }
+        
+        var limitLines = xAxis.limitLines
+        
+        if (limitLines.count == 0)
+        {
+            return
+        }
+        
+        CGContextSaveGState(context)
+        
+        let trans = transformer.valueToPixelMatrix
+        
+        var position = CGPoint(x: 0.0, y: 0.0)
+        
+        for i in 0 ..< limitLines.count
+        {
+            let l = limitLines[i]
+            
+            if !l.isEnabled
+            {
+                continue
+            }
+            
+            position.x = CGFloat(l.limit * Double(barData.dataSetCount)) + CGFloat(l.limit) * barData.groupSpace - 0.5 + (CGFloat(barData.dataSetCount) + barData.groupSpace) / 2.0
+            position.y = 0.0
+            position = CGPointApplyAffineTransform(position, trans)
+            
+            renderLimitLineLine(context: context, limitLine: l, position: position)
+            renderLimitLineLabel(context: context, limitLine: l, position: position, yOffset: 2.0 + l.yOffset)
+        }
+        
+        CGContextRestoreGState(context)
+    }
 }

--- a/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
+++ b/Charts/Classes/Renderers/ChartXAxisRendererHorizontalBarChart.swift
@@ -241,7 +241,12 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
     
     public override func renderLimitLines(context context: CGContext)
     {
-        guard let xAxis = xAxis else { return }
+        guard let
+            xAxis = xAxis,
+            barData = chart?.data as? BarChartData
+            else {
+                return
+        }
         
         var limitLines = xAxis.limitLines
         
@@ -266,7 +271,7 @@ public class ChartXAxisRendererHorizontalBarChart: ChartXAxisRendererBarChart
             }
 
             position.x = 0.0
-            position.y = CGFloat(l.limit)
+            position.y = CGFloat(l.limit * Double(barData.dataSetCount)) + CGFloat(l.limit) * barData.groupSpace - 0.5 + (CGFloat(barData.dataSetCount) + barData.groupSpace) / 2.0
             position = CGPointApplyAffineTransform(position, trans)
             
             _limitLineSegmentsBuffer[0].x = viewPortHandler.contentLeft


### PR DESCRIPTION
Limit lines on xAxis position are calculated wrong when bar chart has more than one data set.
![beforev3](https://cloud.githubusercontent.com/assets/2915299/14921759/8594cafc-0e3c-11e6-9218-2ade306e7a2a.jpg)
Same for horizontal bar charts.
![beforeh3](https://cloud.githubusercontent.com/assets/2915299/14921828/d64772d8-0e3c-11e6-8032-4f349fd427b4.jpg)
I looked how grid lines position are calculated, and did similar calculations for limit lines.
![afterv3](https://cloud.githubusercontent.com/assets/2915299/14921940/7fef1db8-0e3d-11e6-8a49-49c144cd62d0.jpg)
![afterh3](https://cloud.githubusercontent.com/assets/2915299/14921945/83a960c6-0e3d-11e6-8410-3edb2d893ad1.jpg)
