### PR TITLE
For #985: use round instead of floor for highestVisibleXIndex

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1952,6 +1952,6 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
             data = _data
             else { return Int(round(pt.x)) }
 
-        return min(data.xValCount - 1, Int(floor(pt.x)))
+        return min(data.xValCount - 1, Int(round(pt.x)))
     }
 }


### PR DESCRIPTION
For #985:
I had regression on my side:

pt.x now is 25.0, if we print it, but in the memory, it looks like 24.999999993, so floor(pt.x) would be 24, while it should be 25.0?

So I checked #785, #794, I think they are ONLY related to lowestVisibleXIndex, because old code has "+1" appended. The latest code removed +1.
However, I think highestVisibleXIndex should stick to round as mentioned above.

@danielgindi did you meet any out of range issue because of using round? e.g. round(25.6) -> 26 while it should be 25.
This is kind of tricky, and we may want to review this carefully.

If you need a gitter chat, let me know