### PR TITLE
Draw one more cubic point at left side to keep the cubic shape while scrolling

### DIFF
--- a/Charts/Classes/Renderers/LineChartRenderer.swift
+++ b/Charts/Classes/Renderers/LineChartRenderer.swift
@@ -103,7 +103,7 @@ public class LineChartRenderer: LineRadarChartRenderer
             else { return }
         
         let diff = (entryFrom == entryTo) ? 1 : 0
-        let minx = max(dataSet.entryIndex(entry: entryFrom) - diff, 0)
+        let minx = max(dataSet.entryIndex(entry: entryFrom) - diff - 1, 0)
         let maxx = min(max(minx + 2, dataSet.entryIndex(entry: entryTo) + 1), entryCount)
         
         let phaseX = max(0.0, min(1.0, animator.phaseX))


### PR DESCRIPTION
For cubie bezier lines:

Because it involves prevPrev, prev, cur, next (two different control points's X), when we zoom in and scroll, sometimes the cubic shape will change like below image:

before:
![before](https://cloud.githubusercontent.com/assets/4375169/15069006/881141e0-13ad-11e6-9238-6b4b0b8ad608.jpeg)

after:
![after](https://cloud.githubusercontent.com/assets/4375169/15069013/90e237ac-13ad-11e6-8380-47d0836d0f65.jpeg)

So I propse we draw one more cubic point at left side to keep the cubic shape while scrolling.

I didn't see the symptom on drawHorizontalCubic (because same control point.x?), so I didn't touch it.