### PR TITLE
Added callback for pan gesture has ended or canceled

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -799,6 +799,11 @@ public class BarLineChartViewBase: ChartViewBase, UIGestureRecognizerDelegate
                 _outerScrollView?.scrollEnabled = true
                 _outerScrollView = nil
             }
+            
+            if (delegate !== nil)
+            {
+                delegate?.chartPanEnded?(self)
+            }
         }
     }
     

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -32,6 +32,9 @@ public protocol ChartViewDelegate
     
     // Callbacks when the chart is moved / translated via drag gesture.
     optional func chartTranslated(chartView: ChartViewBase, dX: CGFloat, dY: CGFloat)
+    
+    // Callbacks when the chart pan gesture is ended or canceled.
+    optional func chartPanEnded(chartView: ChartViewBase)
 }
 
 public class ChartViewBase: UIView, ChartAnimatorDelegate

--- a/Charts/Classes/Data/ScatterChartDataSet.swift
+++ b/Charts/Classes/Data/ScatterChartDataSet.swift
@@ -29,6 +29,8 @@ public class ScatterChartDataSet: LineScatterCandleChartDataSet
     public var scatterShapeSize = CGFloat(15.0)
     public var scatterShape = ScatterShape.Square
     public var customScatterShape: CGPath?
+    public var valueIsIndex = false
+    public var drawLinesEnabled = false
 
     // MARK: NSCopying
     

--- a/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
+++ b/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		5BD47E661ABB424E008FCEC6 /* BarChartViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BD47E641ABB424E008FCEC6 /* BarChartViewController.xib */; };
 		5BD8F0741AB89CE500566E05 /* LineChart1ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD8F0721AB89CE500566E05 /* LineChart1ViewController.m */; };
 		5BD8F0751AB89CE500566E05 /* LineChart1ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BD8F0731AB89CE500566E05 /* LineChart1ViewController.xib */; };
+		5BDD9C711B8F5190004DC578 /* IndependentScatterChartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BDD9C6F1B8F518F004DC578 /* IndependentScatterChartViewController.m */; };
+		5BDD9C721B8F5190004DC578 /* IndependentScatterChartViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BDD9C701B8F5190004DC578 /* IndependentScatterChartViewController.xib */; };
 		5BDEDC411ABB7F73007D3A60 /* HorizontalBarChartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BDEDC3F1ABB7F73007D3A60 /* HorizontalBarChartViewController.m */; };
 		5BDEDC421ABB7F73007D3A60 /* HorizontalBarChartViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5BDEDC401ABB7F73007D3A60 /* HorizontalBarChartViewController.xib */; };
 		5BDEDC471ABB871E007D3A60 /* CombinedChartViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BDEDC451ABB871E007D3A60 /* CombinedChartViewController.m */; };
@@ -142,6 +144,9 @@
 		5BD8F0711AB89CE500566E05 /* LineChart1ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineChart1ViewController.h; sourceTree = "<group>"; };
 		5BD8F0721AB89CE500566E05 /* LineChart1ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LineChart1ViewController.m; sourceTree = "<group>"; };
 		5BD8F0731AB89CE500566E05 /* LineChart1ViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LineChart1ViewController.xib; sourceTree = "<group>"; };
+		5BDD9C6E1B8F518F004DC578 /* IndependentScatterChartViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndependentScatterChartViewController.h; sourceTree = "<group>"; };
+		5BDD9C6F1B8F518F004DC578 /* IndependentScatterChartViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndependentScatterChartViewController.m; sourceTree = "<group>"; };
+		5BDD9C701B8F5190004DC578 /* IndependentScatterChartViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IndependentScatterChartViewController.xib; sourceTree = "<group>"; };
 		5BDEDC3E1ABB7F73007D3A60 /* HorizontalBarChartViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HorizontalBarChartViewController.h; sourceTree = "<group>"; };
 		5BDEDC3F1ABB7F73007D3A60 /* HorizontalBarChartViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HorizontalBarChartViewController.m; sourceTree = "<group>"; };
 		5BDEDC401ABB7F73007D3A60 /* HorizontalBarChartViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HorizontalBarChartViewController.xib; sourceTree = "<group>"; };
@@ -340,6 +345,9 @@
 				5BEAED151ABBFB340013F194 /* ScatterChartViewController.h */,
 				5BEAED161ABBFB340013F194 /* ScatterChartViewController.m */,
 				5BEAED171ABBFB340013F194 /* ScatterChartViewController.xib */,
+				5BDD9C6E1B8F518F004DC578 /* IndependentScatterChartViewController.h */,
+				5BDD9C6F1B8F518F004DC578 /* IndependentScatterChartViewController.m */,
+				5BDD9C701B8F5190004DC578 /* IndependentScatterChartViewController.xib */,
 				5BEAED3D1ABC1AC60013F194 /* SinusBarChartViewController.h */,
 				5BEAED3E1ABC1AC60013F194 /* SinusBarChartViewController.m */,
 				5BEAED3F1ABC1AC60013F194 /* SinusBarChartViewController.xib */,
@@ -432,6 +440,7 @@
 				5B4316361AB8D8B70009FCAA /* Default-667h@2x.png in Resources */,
 				5BEAED2D1ABC160F0013F194 /* CandleStickChartViewController.xib in Resources */,
 				5BD47E611ABB3C91008FCEC6 /* LineChart2ViewController.xib in Resources */,
+				5BDD9C721B8F5190004DC578 /* IndependentScatterChartViewController.xib in Resources */,
 				5BEAED131ABBFB2B0013F194 /* AnotherBarChartViewController.xib in Resources */,
 				5BEAED411ABC1AC60013F194 /* SinusBarChartViewController.xib in Resources */,
 				5BEAED371ABC192F0013F194 /* RadarChartViewController.xib in Resources */,
@@ -490,6 +499,7 @@
 				5B57BBB51A9B26AA0036A6CC /* main.m in Sources */,
 				5BEAED361ABC192F0013F194 /* RadarChartViewController.m in Sources */,
 				5B9624411B38608C007763E2 /* NegativeStackedBarChartViewController.m in Sources */,
+				5BDD9C711B8F5190004DC578 /* IndependentScatterChartViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ChartsDemo/Classes/DemoListViewController.m
+++ b/ChartsDemo/Classes/DemoListViewController.m
@@ -19,6 +19,7 @@
 #import "CombinedChartViewController.h"
 #import "PieChartViewController.h"
 #import "ScatterChartViewController.h"
+#import "IndependentScatterChartViewController.h"
 #import "StackedBarChartViewController.h"
 #import "NegativeStackedBarChartViewController.h"
 #import "AnotherBarChartViewController.h"
@@ -80,6 +81,11 @@
                           @"title": @"Scatter Chart",
                           @"subtitle": @"A simple demonstration of the scatter chart.",
                           @"class": ScatterChartViewController.class
+                          },
+                      @{
+                          @"title": @"Independent Scatter Chart",
+                          @"subtitle": @"A simple demonstration of the scatter chart where XY pairs need not be ordered.",
+                          @"class": IndependentScatterChartViewController.class
                           },
                       @{
                           @"title": @"Bubble Chart",

--- a/ChartsDemo/Classes/Demos/IndependentScatterChartViewController.h
+++ b/ChartsDemo/Classes/Demos/IndependentScatterChartViewController.h
@@ -1,0 +1,20 @@
+//
+//  IndependentScatterChartViewController.h
+//  ChartsDemo
+//
+//  Created by Daniel Cohen Gindi on 17/3/15.
+//
+//  Copyright 2015 Daniel Cohen Gindi & Philipp Jahoda
+//  A port of MPAndroidChart for iOS
+//  Licensed under Apache License 2.0
+//
+//  https://github.com/danielgindi/ios-charts
+//
+
+#import <UIKit/UIKit.h>
+#import "DemoBaseViewController.h"
+#import <Charts/Charts.h>
+
+@interface IndependentScatterChartViewController : DemoBaseViewController
+
+@end

--- a/ChartsDemo/Classes/Demos/IndependentScatterChartViewController.m
+++ b/ChartsDemo/Classes/Demos/IndependentScatterChartViewController.m
@@ -1,0 +1,252 @@
+//
+//  ScatterChartViewController.m
+//  ChartsDemo
+//
+//  Created by Daniel Cohen Gindi on 17/3/15.
+//
+//  Copyright 2015 Daniel Cohen Gindi & Philipp Jahoda
+//  A port of MPAndroidChart for iOS
+//  Licensed under Apache License 2.0
+//
+//  https://github.com/danielgindi/ios-charts
+//
+
+#import "IndependentScatterChartViewController.h"
+#import "ChartsDemo-Swift.h"
+
+@interface IndependentScatterChartViewController () <ChartViewDelegate>
+
+@property (nonatomic, strong) IBOutlet ScatterChartView *chartView;
+@property (nonatomic, strong) IBOutlet UISlider *sliderX;
+@property (nonatomic, strong) IBOutlet UISlider *sliderY;
+@property (nonatomic, strong) IBOutlet UITextField *sliderTextX;
+@property (nonatomic, strong) IBOutlet UITextField *sliderTextY;
+
+@end
+
+@implementation IndependentScatterChartViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    self.title = @"Scatter Bar Chart";
+    
+    self.options = @[
+                     @{@"key": @"toggleValues", @"label": @"Toggle Values"},
+                     @{@"key": @"toggleHighlight", @"label": @"Toggle Highlight"},
+                     @{@"key": @"toggleStartZero", @"label": @"Toggle StartZero"},
+                     @{@"key": @"animateX", @"label": @"Animate X"},
+                     @{@"key": @"animateY", @"label": @"Animate Y"},
+                     @{@"key": @"animateXY", @"label": @"Animate XY"},
+                     @{@"key": @"saveToGallery", @"label": @"Save to Camera Roll"},
+                     @{@"key": @"togglePinchZoom", @"label": @"Toggle PinchZoom"},
+                     @{@"key": @"toggleAutoScaleMinMax", @"label": @"Toggle auto scale min/max"},
+                     ];
+    
+    _chartView.delegate = self;
+    
+    _chartView.descriptionText = @"";
+    _chartView.noDataTextDescription = @"You need to provide data for the chart.";
+    
+    _chartView.drawGridBackgroundEnabled = NO;
+    _chartView.highlightEnabled = YES;
+    _chartView.dragEnabled = YES;
+    [_chartView setScaleEnabled:YES];
+    _chartView.maxVisibleValueCount = 200;
+    _chartView.pinchZoomEnabled = YES;
+    
+    ChartLegend *l = _chartView.legend;
+    l.position = ChartLegendPositionRightOfChart;
+    l.font = [UIFont fontWithName:@"HelveticaNeue-Light" size:10.f];
+    
+    ChartYAxis *yl = _chartView.leftAxis;
+    yl.labelFont = [UIFont fontWithName:@"HelveticaNeue-Light" size:10.f];
+    
+    _chartView.rightAxis.enabled = NO;
+    
+    ChartXAxis *xl = _chartView.xAxis;
+    xl.labelFont = [UIFont fontWithName:@"HelveticaNeue-Light" size:10.f];
+    xl.drawGridLinesEnabled = NO;
+    
+    _sliderX.value = 45.0;
+    _sliderY.value = 100.0;
+    [self slidersValueChanged:nil];
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (void)setDataCount:(int)count range:(double)range
+{
+    NSMutableArray *xVals = [[NSMutableArray alloc] init];
+    
+    for (int i = 0; i < count; i++)
+    {
+        [xVals addObject:[@(i) stringValue]];
+    }
+    
+    NSMutableArray *yVals1 = [[NSMutableArray alloc] init];
+    NSMutableArray *yVals2 = [[NSMutableArray alloc] init];
+    NSMutableArray *yVals3 = [[NSMutableArray alloc] init];
+    
+    for (int i = 0; i < count; i++)
+    {
+        double val = (double) (arc4random_uniform(range)) + 3;
+        double valx = (double) (arc4random_uniform(count));
+        [yVals1 addObject:[[ChartDataEntry alloc] initWithValue:val xIndex: valx]];
+        
+        val = (double) (arc4random_uniform(range)) + 3;
+        [yVals2 addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:i]];
+        
+        val = (double) (arc4random_uniform(range)) + 3;
+        [yVals3 addObject:[[ChartDataEntry alloc] initWithValue:val xIndex:i]];
+    }
+    
+    ScatterChartDataSet *set1 = [[ScatterChartDataSet alloc] initWithYVals:yVals1 label:@"DS 1"];
+    set1.scatterShape = ScatterShapeSquare;
+    [set1 setColor:ChartColorTemplates.colorful[0]];
+    ScatterChartDataSet *set2 = [[ScatterChartDataSet alloc] initWithYVals:yVals2 label:@"DS 2"];
+    set2.scatterShape = ScatterShapeCircle;
+    [set2 setColor:ChartColorTemplates.colorful[1]];
+    ScatterChartDataSet *set3 = [[ScatterChartDataSet alloc] initWithYVals:yVals3 label:@"DS 3"];
+    set3.scatterShape = ScatterShapeCross;
+    [set3 setColor:ChartColorTemplates.colorful[2]];
+    
+    set1.scatterShapeSize = 8.0;
+    set2.scatterShapeSize = 8.0;
+    set3.scatterShapeSize = 8.0;
+    
+    set1.drawLinesEnabled   = YES;
+    set1.valueIsIndex       = YES;
+    set2.valueIsIndex       = YES;
+    set3.valueIsIndex       = YES;
+    
+    NSMutableArray *dataSets = [[NSMutableArray alloc] init];
+    [dataSets addObject:set1];
+    [dataSets addObject:set2];
+    [dataSets addObject:set3];
+    
+    ScatterChartData *data = [[ScatterChartData alloc] initWithXVals:xVals dataSets:dataSets];
+    [data setValueFont:[UIFont fontWithName:@"HelveticaNeue-Light" size:7.f]];
+    
+    _chartView.data = data;
+}
+
+- (void)optionTapped:(NSString *)key
+{
+    if ([key isEqualToString:@"toggleValues"])
+    {
+        for (ChartDataSet *set in _chartView.data.dataSets)
+        {
+            set.drawValuesEnabled = !set.isDrawValuesEnabled;
+        }
+        
+        [_chartView setNeedsDisplay];
+    }
+    
+    if ([key isEqualToString:@"toggleFilled"])
+    {
+        for (LineChartDataSet *set in _chartView.data.dataSets)
+        {
+            set.drawFilledEnabled = !set.isDrawFilledEnabled;
+        }
+        
+        [_chartView setNeedsDisplay];
+    }
+    
+    if ([key isEqualToString:@"toggleCircles"])
+    {
+        for (LineChartDataSet *set in _chartView.data.dataSets)
+        {
+            set.drawCirclesEnabled = !set.isDrawCirclesEnabled;
+        }
+        
+        [_chartView setNeedsDisplay];
+    }
+    
+    if ([key isEqualToString:@"toggleCubic"])
+    {
+        for (LineChartDataSet *set in _chartView.data.dataSets)
+        {
+            set.drawCubicEnabled = !set.isDrawCubicEnabled;
+        }
+        
+        [_chartView setNeedsDisplay];
+    }
+    
+    if ([key isEqualToString:@"toggleHighlight"])
+    {
+        _chartView.highlightEnabled = !_chartView.isHighlightEnabled;
+        
+        [_chartView setNeedsDisplay];
+    }
+    
+    if ([key isEqualToString:@"toggleStartZero"])
+    {
+        _chartView.leftAxis.startAtZeroEnabled = !_chartView.leftAxis.isStartAtZeroEnabled;
+        _chartView.rightAxis.startAtZeroEnabled = !_chartView.rightAxis.isStartAtZeroEnabled;
+        
+        [_chartView notifyDataSetChanged];
+    }
+    
+    if ([key isEqualToString:@"animateX"])
+    {
+        [_chartView animateWithXAxisDuration:3.0];
+    }
+    
+    if ([key isEqualToString:@"animateY"])
+    {
+        [_chartView animateWithYAxisDuration:3.0];
+    }
+    
+    if ([key isEqualToString:@"animateXY"])
+    {
+        [_chartView animateWithXAxisDuration:3.0 yAxisDuration:3.0];
+    }
+    
+    if ([key isEqualToString:@"saveToGallery"])
+    {
+        [_chartView saveToCameraRoll];
+    }
+    
+    if ([key isEqualToString:@"togglePinchZoom"])
+    {
+        _chartView.pinchZoomEnabled = !_chartView.isPinchZoomEnabled;
+        
+        [_chartView setNeedsDisplay];
+    }
+    
+    if ([key isEqualToString:@"toggleAutoScaleMinMax"])
+    {
+        _chartView.autoScaleMinMaxEnabled = !_chartView.isAutoScaleMinMaxEnabled;
+        [_chartView notifyDataSetChanged];
+    }
+}
+
+#pragma mark - Actions
+
+- (IBAction)slidersValueChanged:(id)sender
+{
+    _sliderTextX.text = [@((int)_sliderX.value + 1) stringValue];
+    _sliderTextY.text = [@((int)_sliderY.value) stringValue];
+    
+    [self setDataCount:(_sliderX.value + 1) range:_sliderY.value];
+}
+
+#pragma mark - ChartViewDelegate
+
+- (void)chartValueSelected:(ChartViewBase * __nonnull)chartView entry:(ChartDataEntry * __nonnull )entry dataSetIndex:(NSInteger)dataSetIndex highlight:(ChartHighlight * __nonnull)highlight
+{
+    NSLog(@"chartValueSelected");
+}
+
+- (void)chartValueNothingSelected:(ChartViewBase * __nonnull)chartView
+{
+    NSLog(@"chartValueNothingSelected");
+}
+
+@end

--- a/ChartsDemo/Classes/Demos/IndependentScatterChartViewController.xib
+++ b/ChartsDemo/Classes/Demos/IndependentScatterChartViewController.xib
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IndependentScatterChartViewController">
+            <connections>
+                <outlet property="chartView" destination="Oqd-Ej-1xl" id="tSA-aU-J9W"/>
+                <outlet property="sliderTextX" destination="It4-Tc-0qK" id="esc-84-jQT"/>
+                <outlet property="sliderTextY" destination="vDG-Fm-61Z" id="lzU-1J-rZl"/>
+                <outlet property="sliderX" destination="Xhn-cI-Tqm" id="Bnt-sB-nHc"/>
+                <outlet property="sliderY" destination="IuK-nU-ZPT" id="LcN-C4-Zs8"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zdz-nd-u7k">
+                    <rect key="frame" x="289" y="4" width="78" height="35"/>
+                    <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="17"/>
+                    <inset key="contentEdgeInsets" minX="10" minY="7" maxX="10" maxY="7"/>
+                    <state key="normal" title="Options">
+                        <color key="titleColor" red="0.29803921570000003" green="0.56078431370000004" blue="0.74117647060000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="optionsButtonTapped:" destination="-1" eventType="touchUpInside" id="ig5-8o-JhO"/>
+                    </connections>
+                </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oqd-Ej-1xl" customClass="ScatterChartView" customModule="Charts">
+                    <rect key="frame" x="0.0" y="47" width="375" height="501"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                </view>
+                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="500" translatesAutoresizingMaskIntoConstraints="NO" id="Xhn-cI-Tqm">
+                    <rect key="frame" x="6" y="573" width="285" height="31"/>
+                    <connections>
+                        <action selector="slidersValueChanged:" destination="-1" eventType="valueChanged" id="VlG-hf-e0E"/>
+                    </connections>
+                </slider>
+                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="200" translatesAutoresizingMaskIntoConstraints="NO" id="IuK-nU-ZPT">
+                    <rect key="frame" x="6" y="611" width="285" height="31"/>
+                    <connections>
+                        <action selector="slidersValueChanged:" destination="-1" eventType="valueChanged" id="y5C-Ny-GVF"/>
+                    </connections>
+                </slider>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="500" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vDG-Fm-61Z">
+                    <rect key="frame" x="297" y="611" width="70" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="70" id="EAG-hU-sTu"/>
+                        <constraint firstAttribute="height" constant="30" id="GB4-g0-PGO"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="15"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="500" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="It4-Tc-0qK">
+                    <rect key="frame" x="297" y="573" width="70" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="70" id="SsZ-2p-GDE"/>
+                        <constraint firstAttribute="height" constant="30" id="Yzk-h7-HPb"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="15"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+            </subviews>
+            <color key="backgroundColor" red="0.94117647059999998" green="0.94117647059999998" blue="0.94117647059999998" alpha="1" colorSpace="calibratedRGB"/>
+            <constraints>
+                <constraint firstItem="Oqd-Ej-1xl" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="47" id="3NA-if-rAO"/>
+                <constraint firstItem="IuK-nU-ZPT" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="66R-JE-JSc"/>
+                <constraint firstItem="Oqd-Ej-1xl" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="6Mc-iO-BuY"/>
+                <constraint firstItem="IuK-nU-ZPT" firstAttribute="top" secondItem="Xhn-cI-Tqm" secondAttribute="bottom" constant="8" id="Aa8-g3-hZn"/>
+                <constraint firstAttribute="bottom" secondItem="IuK-nU-ZPT" secondAttribute="bottom" constant="26" id="B7P-HB-AG2"/>
+                <constraint firstItem="vDG-Fm-61Z" firstAttribute="centerY" secondItem="IuK-nU-ZPT" secondAttribute="centerY" id="FQM-m5-jqx"/>
+                <constraint firstAttribute="trailing" secondItem="vDG-Fm-61Z" secondAttribute="trailing" constant="8" id="JaG-vb-Ax6"/>
+                <constraint firstItem="Xhn-cI-Tqm" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="LkY-Dx-7d6"/>
+                <constraint firstItem="Zdz-nd-u7k" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="4" id="QYu-uI-rC8"/>
+                <constraint firstItem="It4-Tc-0qK" firstAttribute="leading" secondItem="Xhn-cI-Tqm" secondAttribute="trailing" constant="8" id="TmF-V6-O8f"/>
+                <constraint firstAttribute="trailing" secondItem="It4-Tc-0qK" secondAttribute="trailing" constant="8" id="eKh-bB-c2R"/>
+                <constraint firstAttribute="trailing" secondItem="Zdz-nd-u7k" secondAttribute="trailing" constant="8" id="hkP-f4-aXC"/>
+                <constraint firstItem="Xhn-cI-Tqm" firstAttribute="centerY" secondItem="It4-Tc-0qK" secondAttribute="centerY" id="jxE-OZ-bpN"/>
+                <constraint firstAttribute="trailing" secondItem="Oqd-Ej-1xl" secondAttribute="trailing" id="mC3-xy-2CS"/>
+                <constraint firstItem="Xhn-cI-Tqm" firstAttribute="top" secondItem="Oqd-Ej-1xl" secondAttribute="bottom" constant="25" id="r0S-JG-wnp"/>
+                <constraint firstItem="vDG-Fm-61Z" firstAttribute="leading" secondItem="IuK-nU-ZPT" secondAttribute="trailing" constant="8" id="zz3-mA-tmf"/>
+            </constraints>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina47"/>
+            <point key="canvasLocation" x="157.5" y="222.5"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
Added the method in ChartViewBase protocol. Method is called within BarLineChartViewBase.swift in the panGestureRecognized function.

This is a required functionality if something is done outside of Charts while the pan gesture is occurring, which uses data retrieved during the pan gesture. 

Example: During the pan gesture I want to display the currently highlighted value in a chart on a label in my view. This can be done with the current callbacks. If I want that value to be removed when the pan gesture is ended, because nothing is actively being selected by the user, there is currently no callback for that. 

