### PR TITLE
fix ChartHighlight init data in function of highlightValue

### DIFF
--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -499,7 +499,7 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
                 if self is BarLineChartViewBase
                     && (self as! BarLineChartViewBase).isHighlightFullBarEnabled
                 {
-                    h = ChartHighlight(xIndex: h!.xIndex, value: Double.NaN, dataIndex: -1, dataSetIndex: -1, stackIndex: -1)
+                    h = ChartHighlight(xIndex: h!.xIndex, value: Double.NaN, dataIndex: 0, dataSetIndex: 0, stackIndex: -1)
                 }
                 
                 _indicesToHighlight = [h!]


### PR DESCRIPTION
If dataIndex and dataSetIndex set -1 when initialize ChartHighlight(), it will be crash because of  out of bound of array in function of drawMarkers() and class of  ChartViewBase. 