### PR TITLE
add BarLineChartViewBase.resetZoom()

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1036,7 +1036,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         setNeedsDisplay()
     }
 
-    /// Zooms out by 0.7, from the charts center. center.
+    /// Zooms out by 0.7, from the charts center.
     public func zoomOut()
     {
         let center = _viewPortHandler.contentCenter
@@ -1047,6 +1047,12 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
         calculateOffsets()
         setNeedsDisplay()
+    }
+
+    /// Zooms out to original size, centered.
+    public func resetZoom() {
+
+        zoom(0, scaleY: 0, x: 0, y: 0)
     }
 
     /// Zooms in or out by the given scale factor. x and y are the coordinates


### PR DESCRIPTION
Matches the existing zoomIn()/zoomOut() convenience methods.
