### PR TITLE
update iso-snapshot-test-case to master to have the fix for now

### DIFF
--- a/Charts/Cartfile.private
+++ b/Charts/Cartfile.private
@@ -1,1 +1,1 @@
-github "facebook/ios-snapshot-test-case" ~> 2.1
+github "facebook/ios-snapshot-test-case" "master"


### PR DESCRIPTION
hopefully this fix the ios-test-case bug for a long time, according to #1082 @ikesyo's fix
once the fix is tagged, we can change back to >~ format, use master for now