### PR TITLE
Add missing imports for iOS 7 support

### DIFF
--- a/Charts/Classes/Utils/ChartSelectionDetail.swift
+++ b/Charts/Classes/Utils/ChartSelectionDetail.swift
@@ -13,6 +13,7 @@
 //
 
 import Foundation
+import CoreGraphics.CGBase
 
 public class ChartSelectionDetail: NSObject
 {


### PR DESCRIPTION
Same like  #45. This can cause compile failure in iOS 7 like #44. I just ran into this problem.