### PR TITLE
improve comment to warn users how to use setVisibleRange APIs

### DIFF
--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -1186,6 +1186,9 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     }
     
     /// Sets the size of the area (range on the x-axis) that should be maximum visible at once (no further zomming out allowed).
+    ///
+    /// If you call this method, chart must have data or it has no effect
+    ///
     /// If this is e.g. set to 10, no more than 10 values on the x-axis can be viewed at once without scrolling.
     public func setVisibleXRangeMaximum(maxXRange: CGFloat)
     {
@@ -1194,6 +1197,9 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     }
     
     /// Sets the size of the area (range on the x-axis) that should be minimum visible at once (no further zooming in allowed).
+    ///
+    /// If you call this method, chart must have data or it has no effect
+    ///
     /// If this is e.g. set to 10, no less than 10 values on the x-axis can be viewed at once without scrolling.
     public func setVisibleXRangeMinimum(minXRange: CGFloat)
     {
@@ -1202,6 +1208,9 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     }
 
     /// Limits the maximum and minimum value count that can be visible by pinching and zooming.
+    ///
+    /// If you call this method, chart must have data or it has no effect
+    ///
     /// e.g. minRange=10, maxRange=100 no less than 10 values and no more that 100 values can be viewed
     /// at once without scrolling
     public func setVisibleXRange(minXRange minXRange: CGFloat, maxXRange: CGFloat)
@@ -1212,6 +1221,8 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     }
     
     /// Sets the size of the area (range on the y-axis) that should be maximum visible at once.
+    ///
+    /// If you call this method, chart must have data or it has no effect
     /// 
     /// - parameter yRange:
     /// - parameter axis: - the axis for which this limit should apply


### PR DESCRIPTION
Seeing some users don't know how to use setVisibleRange APIs (can only be called after we have data, otherwise no effect). For now, add the API description for this