### PR TITLE
remove brew upgrade carthage for travis and update ios-snapshot-test-case to 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 
 before_install:
   - brew update
-  - brew upgrade carthage
   - cd Charts && carthage bootstrap
 
 script:

--- a/Charts/Cartfile.private
+++ b/Charts/Cartfile.private
@@ -1,1 +1,1 @@
-github "facebook/ios-snapshot-test-case" "master"
+github "facebook/ios-snapshot-test-case" ~> 2.1.2

--- a/Charts/Cartfile.resolved
+++ b/Charts/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "facebook/ios-snapshot-test-case" "040817b1295a91fc239d8433a087d7b50bfa5dd6"
+github "facebook/ios-snapshot-test-case" "2.1.2"


### PR DESCRIPTION
update ios-snapshot-test-case to 2.1.2
remove brew upgrade carthage, because travis seems updated carthage

```
$ brew upgrade carthage
Error: carthage 0.17.2 already installed

The command "brew upgrade carthage" failed and exited with 1 during .

Your build has been stopped.

/Users/travis/build.sh: line 109: shell_session_update: command not found
```