### PR TITLE
RunLoopMood changes for Swift 3.0 & Xcode 8.0 Beta 3

### DIFF
--- a/Charts/Classes/Animation/ChartAnimator.swift
+++ b/Charts/Classes/Animation/ChartAnimator.swift
@@ -71,7 +71,7 @@ public class ChartAnimator: NSObject
     {
         if (_displayLink != nil)
         {
-            _displayLink.remove(from: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+            _displayLink.remove(from: RunLoop.main, forMode: RunLoopMode.commonModes)
             _displayLink = nil
             
             _enabledX = false
@@ -196,7 +196,7 @@ public class ChartAnimator: NSObject
         if (_enabledX || _enabledY)
         {
             _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
-            _displayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+            _displayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
         }
     }
     
@@ -262,7 +262,7 @@ public class ChartAnimator: NSObject
             if _displayLink === nil
             {
                 _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
-                _displayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+                _displayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
             }
         }
     }
@@ -306,7 +306,7 @@ public class ChartAnimator: NSObject
             if _displayLink === nil
             {
                 _displayLink = NSUIDisplayLink(target: self, selector: #selector(ChartAnimator.animationLoop))
-                _displayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+                _displayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
             }
         }
     }

--- a/Charts/Classes/Charts/BarLineChartViewBase.swift
+++ b/Charts/Classes/Charts/BarLineChartViewBase.swift
@@ -824,7 +824,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
                     _decelerationVelocity = recognizer.velocity(in: self)
                     
                     _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(BarLineChartViewBase.decelerationLoop))
-                    _decelerationDisplayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+                    _decelerationDisplayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
                 }
                 
                 _isDragging = false
@@ -875,7 +875,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         if (_decelerationDisplayLink !== nil)
         {
-            _decelerationDisplayLink.remove(from: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+            _decelerationDisplayLink.remove(from: RunLoop.main, forMode: RunLoopMode.commonModes)
             _decelerationDisplayLink = nil
         }
     }
@@ -1439,7 +1439,7 @@ public class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChar
     {
         _customViewPortEnabled = true
         
-        if (Thread.isMainThread())
+        if (Thread.isMainThread)
         {
             self._viewPortHandler.restrainViewPort(offsetLeft: left, offsetTop: top, offsetRight: right, offsetBottom: bottom)
             prepareOffsetMatrix()

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -543,7 +543,7 @@ public class PieRadarChartViewBase: ChartViewBase
             {
                 _decelerationLastTime = CACurrentMediaTime()
                 _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(PieRadarChartViewBase.decelerationLoop))
-                _decelerationDisplayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+                _decelerationDisplayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
             }
         }
     }
@@ -788,7 +788,7 @@ public class PieRadarChartViewBase: ChartViewBase
     {
         if (_decelerationDisplayLink !== nil)
         {
-            _decelerationDisplayLink.remove(from: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+            _decelerationDisplayLink.remove(from: RunLoop.main, forMode: RunLoopMode.commonModes)
             _decelerationDisplayLink = nil
         }
     }
@@ -944,7 +944,7 @@ public class PieRadarChartViewBase: ChartViewBase
                 {
                     _decelerationLastTime = CACurrentMediaTime()
                     _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(PieRadarChartViewBase.decelerationLoop))
-                    _decelerationDisplayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+                    _decelerationDisplayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
                 }
             }
         }

--- a/Charts/Classes/Jobs/AnimatedViewPortJob.swift
+++ b/Charts/Classes/Jobs/AnimatedViewPortJob.swift
@@ -71,14 +71,14 @@ public class AnimatedViewPortJob: ChartViewPortJob
         updateAnimationPhase(_startTime)
         
         _displayLink = NSUIDisplayLink(target: self, selector: #selector(AnimatedViewPortJob.animationLoop))
-        _displayLink.add(to: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+        _displayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
     }
     
     public func stop(finish: Bool)
     {
         if (_displayLink != nil)
         {
-            _displayLink.remove(from: RunLoop.main(), forMode: RunLoopMode.commonModes.rawValue)
+            _displayLink.remove(from: RunLoop.main, forMode: RunLoopMode.commonModes)
             _displayLink = nil
             
             if finish

--- a/Charts/Classes/Utils/ChartPlatform.swift
+++ b/Charts/Classes/Utils/ChartPlatform.swift
@@ -264,7 +264,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
             stop()
         }
 
-		public func add(to runloop: RunLoop, forMode: String)
+		public func add(to runloop: RunLoop, forMode: RunLoopMode)
         {
             if displayLink != nil
             {
@@ -272,11 +272,11 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
             }
             else if timer != nil
             {
-                runloop.add(timer!, forMode: RunLoopMode(rawValue: forMode))
+                runloop.add(timer!, forMode: forMode)
             }
 		}
 
-		public func remove(from runloop: RunLoop, forMode: String)
+		public func remove(from runloop: RunLoop, forMode: RunLoopMode)
         {
             stop()
 		}


### PR DESCRIPTION
- RunLoop.main is now a class var instead of a method
- Thread.isMainThread is now a class var instead of a method
- display link method now take the RunLoopMode struct instead of a string

It should be this way:
`_displayLink.remove(from: RunLoop.main, forMode: RunLoopMode.commonModes)`

This way is just redundant:
`_displayLink.remove(from: RunLoop.main, forMode: RunLoopMode(rawValue: RunLoopMode.commonModes.rawValue))`

