### PR TITLE
ChartMarker subclassing in Objective C

### DIFF
--- a/Charts/Charts.xcodeproj/project.pbxproj
+++ b/Charts/Charts.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		050273441D50E15B00CE581B /* ChartMarkerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050273431D50E15B00CE581B /* ChartMarkerProtocol.swift */; };
 		06AEE7A71BDC3F8B009875AE /* Charts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA8EC401A9D14DC00CE82E1 /* Charts.framework */; };
 		06AEE7AE1BDC3FC6009875AE /* LineChartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AEE7AD1BDC3FC6009875AE /* LineChartTests.swift */; };
 		06AEE7C21BDC4277009875AE /* FBSnapshotTestCase.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 06AEE7C11BDC4277009875AE /* FBSnapshotTestCase.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -385,6 +386,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		050273431D50E15B00CE581B /* ChartMarkerProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartMarkerProtocol.swift; sourceTree = "<group>"; };
 		06AEE7A21BDC3F8B009875AE /* ChartsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChartsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		06AEE7A61BDC3F8B009875AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		06AEE7AD1BDC3FC6009875AE /* LineChartTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineChartTests.swift; sourceTree = "<group>"; };
@@ -719,6 +721,7 @@
 				5B6A546A1AA5C23F000F57C2 /* ChartMarker.swift */,
 				5BA8EC6D1A9D151C00CE82E1 /* ChartXAxis.swift */,
 				5BA8EC6E1A9D151C00CE82E1 /* ChartYAxis.swift */,
+				050273431D50E15B00CE581B /* ChartMarkerProtocol.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1066,6 +1069,7 @@
 				5B6654DB1BB0A86F00890030 /* ChartXAxisValueFormatter.swift in Sources */,
 				5B6A54A31AA66B7C000F57C2 /* LineChartView.swift in Sources */,
 				5B6A54891AA66A1A000F57C2 /* PieChartRenderer.swift in Sources */,
+				050273441D50E15B00CE581B /* ChartMarkerProtocol.swift in Sources */,
 				5B6A54991AA66B14000F57C2 /* BarChartView.swift in Sources */,
 				659400B41BF463C1004F9C27 /* CandleChartDataSet.swift in Sources */,
 				5B680D231A9D17C30026A057 /* ChartYAxis.swift in Sources */,

--- a/Charts/Classes/Charts/ChartViewBase.swift
+++ b/Charts/Classes/Charts/ChartViewBase.swift
@@ -126,7 +126,7 @@ public class ChartViewBase: NSUIView, ChartDataProvider, ChartAnimatorDelegate
     public var drawMarkers = true
     
     /// the view that represents the marker
-    public var marker: ChartMarker?
+    public var marker: ChartMarkerProtocol?
     
     private var _interceptTouchEvents = false
     

--- a/Charts/Classes/Components/ChartMarker.swift
+++ b/Charts/Classes/Components/ChartMarker.swift
@@ -15,7 +15,7 @@ import Foundation
 import CoreGraphics
 
 
-public class ChartMarker: NSObject
+public class ChartMarker: NSObject, ChartMarkerProtocol
 {
     /// The marker image to render
     public var image: NSUIImage?
@@ -30,11 +30,6 @@ public class ChartMarker: NSObject
         {
             return image!.size
         }
-    }
-    
-    public override init()
-    {
-        super.init()
     }
     
     /// Returns the offset for drawing at the specific `point`

--- a/Charts/Classes/Components/ChartMarkerProtocol.swift
+++ b/Charts/Classes/Components/ChartMarkerProtocol.swift
@@ -1,0 +1,26 @@
+//
+//  ChartMarkerProtocol.swift
+//  Charts
+//
+//  Created by Dean Yeazel on 8/2/16.
+//  Copyright © 2016 dcg. All rights reserved.
+//
+
+import Foundation
+
+/// An interface for providing custom markers.
+
+@objc
+public protocol ChartMarkerProtocol
+{
+    
+    /// Draws the ChartMarker on the given position on the given context
+    func draw(context context: CGContext, point: CGPoint)
+    
+    /// This method enables a custom ChartMarker to update it's content everytime the MarkerView is redrawn according to the data entry it points to.
+    ///
+    /// - parameter highlight: the highlight object contains information about the highlighted value such as it's dataset-index, the selected range or stack-index (only stacked bar entries).
+    func refreshContent(entry entry: ChartDataEntry, highlight: ChartHighlight)
+    
+    var size: CGSize { get }
+}


### PR DESCRIPTION
I'd like to propose changing ChartMarker to using a protocol so that it can be subclassed in Objective-C. I've added the ChartMarkerProtocol and modified ChartMarker to implement this protocol.