### PR TITLE
Fix bar layout bug, pie callback bug

### DIFF
--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -39,7 +39,7 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
         {
             _xAxis.calculate(
                 min: data.xMin - data.barWidth / 2.0,
-                max: data.xMax - data.barWidth / 2.0)
+                max: data.xMax + data.barWidth / 2.0)
         }
         else
         {

--- a/Charts/Classes/Charts/PieRadarChartViewBase.swift
+++ b/Charts/Classes/Charts/PieRadarChartViewBase.swift
@@ -829,7 +829,7 @@ public class PieRadarChartViewBase: ChartViewBase
             let location = recognizer.locationInView(self)
             
             let high = self.getHighlightByTouchPoint(location)
-            self.highlightValue(high)
+            self.highlightValue(highlight: high, callDelegate: true)
         }
     }
     


### PR DESCRIPTION
Fixing two issues:

1. BarChart right/left bar cut in half (Issue #1446) notes that if you turn on `fitBars`, the last bar will be cropped out.

2. Tapping on a pie chart slice would not trigger any delegate callbacks (no issue). This is fixed by explicitly requesting callbacks in PieRadarChartViewBase’s tap event.