### PR TITLE
Don't override project settings in targets

### DIFF
--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -1282,7 +1282,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dcg.Charts;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -1301,7 +1300,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dcg.Charts;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;


### PR DESCRIPTION
Project settings don't need to be set to iOS. Due to having a single target they need to be macOS which has been set in the project's main settings.

Please read the article [here](http://promisekit.org/news/2016/08/Multiplatform-Single-Scheme-Xcode-Projects/) for more info.