### PR TITLE
Fix decimals crash in ChartsUtil

### DIFF
--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		06165F2F1D8110E600722320 /* Charts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06165F241D8110E600722320 /* Charts.framework */; };
+		06761B5E1D98176000D5CE09 /* ChartUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06761B5D1D98176000D5CE09 /* ChartUtilsTests.swift */; };
 		06B11FAF1D811B7000D14B02 /* Charts.h in Headers */ = {isa = PBXBuildFile; fileRef = 06B11FAE1D811B7000D14B02 /* Charts.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		06B120431D811B8900D14B02 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B11FB11D811B8900D14B02 /* Animator.swift */; };
 		06B120441D811B8900D14B02 /* ChartAnimationEasing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B11FB21D811B8900D14B02 /* ChartAnimationEasing.swift */; };
@@ -182,6 +183,7 @@
 		06165F241D8110E600722320 /* Charts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Charts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		06165F2E1D8110E600722320 /* ChartsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChartsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		063FF0401D8CC9940094A042 /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
+		06761B5D1D98176000D5CE09 /* ChartUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ChartUtilsTests.swift; path = Tests/Charts/ChartUtilsTests.swift; sourceTree = SOURCE_ROOT; };
 		06B11FAC1D811B6600D14B02 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "Source/Supporting Files/Info.plist"; sourceTree = "<group>"; };
 		06B11FAE1D811B7000D14B02 /* Charts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Charts.h; path = "Source/Supporting Files/Charts.h"; sourceTree = "<group>"; };
 		06B11FB11D811B8900D14B02 /* Animator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animator.swift; sourceTree = "<group>"; };
@@ -402,6 +404,7 @@
 			children = (
 				06B120C71D811BFC00D14B02 /* BarChartTests.swift */,
 				06B120C91D811BFC00D14B02 /* LineChartTests.swift */,
+				06761B5D1D98176000D5CE09 /* ChartUtilsTests.swift */,
 				06B1210D1D811FF200D14B02 /* Supporting Files */,
 			);
 			path = ChartsTests;
@@ -1160,6 +1163,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06761B5E1D98176000D5CE09 /* ChartUtilsTests.swift in Sources */,
 				06B120CC1D811BFC00D14B02 /* LineChartTests.swift in Sources */,
 				06B120CA1D811BFC00D14B02 /* BarChartTests.swift in Sources */,
 			);

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -50,6 +50,12 @@ open class ChartUtils
         }
         
         let i = roundToNextSignificant(number: Double(number))
+        
+        if i.isNaN || i.isInfinite
+        {
+            return 0
+        }
+        
         return Int(ceil(-log10(i))) + 2
     }
     

--- a/Tests/Charts/ChartUtilsTests.swift
+++ b/Tests/Charts/ChartUtilsTests.swift
@@ -1,0 +1,83 @@
+//
+//  ChartUtilsTests.swift
+//  Charts
+//
+//  Created by Pierre-Marc Airoldi on 2016-09-25.
+//
+//
+
+import XCTest
+@testable import Charts
+
+class ChartUtilsTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testDecimalWithNaN() {
+        
+        let number = Double.nan
+        
+        let actual = ChartUtils.decimals(number)
+        let expected = 0
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testDecimalWithInfinite() {
+        
+        let number = Double.infinity
+        
+        let actual = ChartUtils.decimals(number)
+        let expected = 0
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testDecimalWithZero() {
+        
+        let number = 0.0
+        
+        let actual = ChartUtils.decimals(number)
+        let expected = 0
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testDecimalWithMaxValue() {
+        
+        let number = DBL_MAX
+        
+        let actual = ChartUtils.decimals(number)
+        let expected = 0
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testDecimalWithMinValue() {
+        
+        let number = DBL_MIN
+        
+        let actual = ChartUtils.decimals(number)
+        let expected = 310 // Don't think this is supposed to be this value maybe 0?
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testDecimalWithNormalValue() {
+        
+        let number = 13.123123
+        
+        let actual = ChartUtils.decimals(number)
+        let expected = 1 // Don't think this is supposed to be this value maybe 6?
+        
+        XCTAssertEqual(expected, actual)
+    }
+}


### PR DESCRIPTION
Closes #1550, #1540, #1491

I added some tests based on the crash mentioned in #1550 and there was a crash when using DBL_MAX as the input of the `decimals` function. 

There are still some abnormalities in the `decimals` function I believe. In MPAndroidCharts I ran the same tests and it returns 2 not zero for all these cases except for the ones that crash and return negative Int max.

This pull request fixes the crash but I don't think the `decimals` function does what we want it to do.

@danielgindi, @PhilJay what is this function actually supposed to do?