### PR TITLE
Bugfix for fix #1488, #1564

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -50,7 +50,7 @@ open class AxisBase: ComponentBase
     /// This is useful especially for grouped BarChart.
     open var centerAxisLabelsEnabled: Bool
     {
-        get { return _centerAxisLabelsEnabled && entryCount > 1 }
+        get { return _centerAxisLabelsEnabled && entryCount > 0 }
         set { _centerAxisLabelsEnabled = newValue }
     }
     

--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -129,9 +129,8 @@ open class AxisRendererBase: Renderer
             // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
             interval = floor(10.0 * Double(intervalMagnitude))
         }
-        
-        let centeringEnabled = axis.centerAxisLabelsEnabled
-        var n = centeringEnabled ? 1 : 0
+
+        var n = axis.centerAxisLabelsEnabled ? 1 : 0
         
         // force label count
         if axis.isForceLabelsEnabled
@@ -158,7 +157,7 @@ open class AxisRendererBase: Renderer
         
             var first = interval == 0.0 ? 0.0 : ceil(yMin / interval) * interval
             
-            if centeringEnabled
+            if axis.centerAxisLabelsEnabled
             {
                 first -= interval
             }
@@ -204,16 +203,12 @@ open class AxisRendererBase: Renderer
             axis.decimals = 0
         }
         
-        if centeringEnabled
+        if axis.centerAxisLabelsEnabled
         {
             axis.centeredEntries.reserveCapacity(n)
             axis.centeredEntries.removeAll()
             
-            var offset: Double = 0.0
-            if axis.entries.count > 1
-            {
-                offset = (axis.entries[1] - axis.entries[0]) / 2.0
-            }
+            let offset: Double = interval / 2.0
             
             for i in 0 ..< n
             {

--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -130,7 +130,7 @@ open class AxisRendererBase: Renderer
             interval = floor(10.0 * Double(intervalMagnitude))
         }
 
-        var n = axis.centerAxisLabelsEnabled ? 1 : 0
+        var n = 1
         
         // force label count
         if axis.isForceLabelsEnabled


### PR DESCRIPTION
Attempt to fix #1488, #1564
@danielgindi I need you carefully review this and give details about existing implementation about centerAxisLabels feature. My changes may lack of information and cause more issues, though I have tesed it in time line chart, bar chart, combined chart, multiple bar chart, line chart.

1. I removed the dependency of getting initial `n` value, because `first` and `last` will be equal after zooming a lot
2. I change `centerAxisLabelsEnabled` condition, if entry count > 0, we could turn on centerAxisLabel. I need context why it's `> 1`.
3. I removed using local variable `centeringEnabled`, because `axis.entries` would be changed but `centeringEnabled` keeps reading old entryCount, which seems a dirty read issue
4. I use `offset: Double = interval / 2.0` instead of `offset = (axis.entries[1] - axis.entries[0]) / 2.0`, because `axis.entries[1] - axis.entries[0]` always equals to interval, and when there is only one entry, we still need a valid offset instead of 0
