### PR TITLE
Make sure we render the last y Label on LineCharts (Fixes #1585)

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -549,7 +549,7 @@ open class LineChartRenderer: LineRadarRenderer
                 
                 _xBounds.set(chart: dataProvider, dataSet: dataSet, animator: animator)
                 
-                for j in stride(from: _xBounds.min, to: Int(ceil(Double(_xBounds.max - _xBounds.min) * phaseX + Double(_xBounds.min))), by: 1)
+                for j in stride(from: _xBounds.min, through: Int(ceil(Double(_xBounds.max - _xBounds.min) * phaseX + Double(_xBounds.min))), by: 1)
                 {
                     guard let e = dataSet.entryForIndex(j) else { break }
                     


### PR DESCRIPTION
The wrong stride termination was causing us to not render the last text value.
Verified the issue in the `ChartsDemo` example, but have not looked closely
at other chart types.