### PR TITLE
Fix chart crash when dataSets is an empty array.

### DIFF
--- a/Charts/Classes/Renderers/AxisRendererBase.swift
+++ b/Charts/Classes/Renderers/AxisRendererBase.swift
@@ -103,18 +103,14 @@ public class AxisRendererBase: Renderer
         let labelCount = axis.labelCount
         let range = abs(yMax - yMin)
         
-        if labelCount == 0 || range <= 0
+        if labelCount == 0 || range <= 0 || isinf(range)
         {
             axis.entries = [Double]()
             return
         }
         
         // Find out how much spacing (in y value space) between axis values
-        var rawInterval = range / Double(labelCount)
-        if isinf(rawInterval)
-        {
-            rawInterval = range > 0.0 && !isinf(range) ? range : 1.0
-        }
+        let rawInterval = range / Double(labelCount)
         var interval = ChartUtils.roundToNextSignificant(number: Double(rawInterval))
         
         // If granularity is enabled, then do not allow the interval to go below specified granularity.

--- a/Charts/Classes/Utils/ChartUtils.swift
+++ b/Charts/Classes/Utils/ChartUtils.swift
@@ -44,12 +44,18 @@ public class ChartUtils
     
     internal class func decimals(number: Double) -> Int
     {
-        if (number == 0.0)
+        if (isinf(number) || isnan(number) || number == 0)
         {
             return 0
         }
         
         let i = roundToNextSignificant(number: Double(number))
+        
+        if isinf(i)
+        {
+            return 0
+        }
+        
         return Int(ceil(-log10(i))) + 2
     }
     


### PR DESCRIPTION
Swift 2.3 version of #1558 