### PR TITLE
fix #1691 drawTransparentCircleHole bug

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -665,10 +665,10 @@ open class LineChartRenderer: LineRadarRenderer
                     context.addEllipse(in: rect)
                     
                     // Cut hole in path
-                    context.addArc(center: pt, radius: circleHoleRadius, startAngle: 0.0, endAngle: CGFloat(M_PI_2), clockwise: true)
+                    context.addArc(center: pt, radius: circleHoleRadius, startAngle: 0.0, endAngle: CGFloat(M_PI * 2), clockwise: false)
                     
                     // Fill in-between
-                    context.fillPath()
+                    context.fillPath(using: .evenOdd)
                 }
                 else
                 {


### PR DESCRIPTION
fix #1691
1. `M_PI_2` is Pi / 2, not Pi \* 2
   
   > public var M_PI_2: Double { get } /\* pi/2           */
2. `clockwise` in `UIKit` and `CoreGraphics` is flipped(compared to UIBezierPath), though 0 to M_PI \* 2 does not get affected by clockwise.
   
   > The clockwise parameter determines the direction in which the arc is created; the actual direction of the final path is dependent on the current transformation matrix of the graphics context. For example, on iOS, a UIView flips the Y-coordinate by scaling the Y values by -1. In a flipped coordinate system, specifying a clockwise arc results in a counterclockwise arc after the transformation is applied.
3. using even odd rule to fill between two arcs, not default.

BTW, I hate the new Apple API doc:( 
The mentioned APIs above do not have any words, while the old doc has rich information. Have to use CGContextAddArc etc. to get the discussion
