### PR TITLE
Added a check against NaN

### DIFF
--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -51,7 +51,7 @@ open class ChartUtils
         
         let i = roundToNextSignificant(number: Double(number))
         
-        if i.isInfinite
+        if i.isInfinite || i.isNaN
         {
             return 0
         }


### PR DESCRIPTION
There needs to be a check against NaN after ChartUtils::roundToNextSignificant() returns.
