### PR TITLE
ChartUtils Crash (Fixes #1737)

### DIFF
--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -51,7 +51,7 @@ open class ChartUtils
         
         let i = roundToNextSignificant(number: Double(number))
         
-        if i.isInfinite
+        if i.isNaN || i.isInfinite
         {
             return 0
         }


### PR DESCRIPTION
Check that i is valid after rounding to prevent a crash.
