### PR TITLE
Negative bar now represented by negative range (Fixes #1726)

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -150,8 +150,8 @@ open class BarChartDataEntry: ChartDataEntry
             
             if value < 0
             {
-                _ranges?.append(Range(from: negRemain, to: negRemain + abs(value)))
-                negRemain += abs(value)
+                _ranges?.append(Range(from: negRemain, to: negRemain + value))
+                negRemain += value
             }
             else
             {


### PR DESCRIPTION
Try to fix #1726
Positive ranges were previously created for the negative side of the bar. Therefore, tapping on the positive side of a bar would initiate a search for a range that contains the specified point, which in turn returns the first range at index 0 and represents the negative side of the bar. This range is then used to highlight the positive portion of the bar. As an example, if the positive side has a range of 0 to 13, and the negative side has a range of 0 to 12 (because again, the current implementation treats negative ranges as positive), the range of 0 to 12 will be used to highlight the positive side, because that range comes first in the array [Range(0, 12), Range(0, 13)]. This is why we see that weird highlight, which is missing one unit of highlight.

Notice that this issue goes away when you tap the very edge of the bar that has this weird highlight. Using the aforementioned example, if you tap the very edge of the positive bar, such that the y-value is greater than 12, then you get the full highlight because Range(0, 12) does not contain that y-value, but Range(0, 13) does.
