### PR TITLE
Fix: extra offsets added in PieRadarChartViewBase

### DIFF
--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -217,12 +217,12 @@ open class PieRadarChartViewBase: ChartViewBase
             legendRight += self.requiredBaseOffset
             legendTop += self.requiredBaseOffset
             legendBottom += self.requiredBaseOffset
+            
+            legendTop += self.extraTopOffset
+            legendRight += self.extraRightOffset
+            legendBottom += self.extraBottomOffset
+            legendLeft += self.extraLeftOffset
         }
-        
-        legendTop += self.extraTopOffset
-        legendRight += self.extraRightOffset
-        legendBottom += self.extraBottomOffset
-        legendLeft += self.extraLeftOffset
         
         var minOffset = self.minOffset
         


### PR DESCRIPTION
calculateOffsets() function adds extra offsets: 

```
    legendTop += self.extraTopOffset
    legendRight += self.extraRightOffset
    legendBottom += self.extraBottomOffset
    legendLeft += self.extraLeftOffset
    ...
    let offsetLeft = max(minOffset, legendLeft)
    let offsetTop = max(minOffset, legendTop)
    let offsetRight = max(minOffset, legendRight)
    let offsetBottom = max(minOffset, max(self.requiredBaseOffset, legendBottom))
```

Then, diameter reduces by extra offsets. 

```
open var diameter: CGFloat
    {
        var content = _viewPortHandler.contentRect
        content.origin.x += extraLeftOffset
        content.origin.y += extraTopOffset
        content.size.width -= extraLeftOffset + extraRightOffset
        content.size.height -= extraTopOffset + extraBottomOffset
        return min(content.width, content.height)
    }
```

So pie chart becomes smaller then it was expected.
