### PR TITLE
Updated Width Constraints - Fixes #1770

### DIFF
--- a/ChartsDemo/Classes/Demos/MultipleBarChartViewController.xib
+++ b/ChartsDemo/Classes/Demos/MultipleBarChartViewController.xib
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,6 +25,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zdz-nd-u7k">
+                    <rect key="frame" x="289" y="4" width="78" height="35"/>
                     <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="17"/>
                     <inset key="contentEdgeInsets" minX="10" minY="7" maxX="10" maxY="7"/>
                     <state key="normal" title="Options">
@@ -32,29 +36,32 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oqd-Ej-1xl" customClass="BarChartView" customModule="Charts">
+                    <rect key="frame" x="0.0" y="47" width="375" height="501"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="500" translatesAutoresizingMaskIntoConstraints="NO" id="Xhn-cI-Tqm">
+                    <rect key="frame" x="6" y="573" width="325" height="31"/>
                     <connections>
                         <action selector="slidersValueChanged:" destination="-1" eventType="valueChanged" id="VlG-hf-e0E"/>
                     </connections>
                 </slider>
                 <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="200" translatesAutoresizingMaskIntoConstraints="NO" id="IuK-nU-ZPT">
+                    <rect key="frame" x="6" y="611" width="325" height="31"/>
                     <connections>
                         <action selector="slidersValueChanged:" destination="-1" eventType="valueChanged" id="y5C-Ny-GVF"/>
                     </connections>
                 </slider>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="500" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vDG-Fm-61Z">
+                    <rect key="frame" x="337" y="611.5" width="30" height="30"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="70" id="EAG-hU-sTu"/>
                         <constraint firstAttribute="height" constant="30" id="GB4-g0-PGO"/>
                     </constraints>
                     <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="15"/>
                     <textInputTraits key="textInputTraits"/>
                 </textField>
                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="500" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="It4-Tc-0qK">
+                    <rect key="frame" x="337" y="573.5" width="30" height="30"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="70" id="SsZ-2p-GDE"/>
                         <constraint firstAttribute="height" constant="30" id="Yzk-h7-HPb"/>
                     </constraints>
                     <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="15"/>
@@ -65,6 +72,7 @@
             <constraints>
                 <constraint firstItem="Oqd-Ej-1xl" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="47" id="3NA-if-rAO"/>
                 <constraint firstItem="IuK-nU-ZPT" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="66R-JE-JSc"/>
+                <constraint firstItem="It4-Tc-0qK" firstAttribute="width" secondItem="vDG-Fm-61Z" secondAttribute="width" id="6Ew-lk-dgF"/>
                 <constraint firstItem="Oqd-Ej-1xl" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="6Mc-iO-BuY"/>
                 <constraint firstItem="IuK-nU-ZPT" firstAttribute="top" secondItem="Xhn-cI-Tqm" secondAttribute="bottom" constant="8" id="Aa8-g3-hZn"/>
                 <constraint firstAttribute="bottom" secondItem="IuK-nU-ZPT" secondAttribute="bottom" constant="26" id="B7P-HB-AG2"/>


### PR DESCRIPTION
Removed width constraint on slider-text-x and slider-text-y, so width  can adjust automatically based on set text. Also added equal-width
constraint on slider-text-x in relation to slider-text-y, so the width
of both will always be the same.