### PR TITLE
Skip drawing of circles by index for line charts (Fixes #1795)

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
@@ -152,6 +152,9 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     /// If true, drawing circles is enabled
     open var drawCirclesEnabled = true
     
+    /// Prevent circle drawing by index.
+    open var circleIndexesNotToDraw = [Int]()
+    
     /// - returns: `true` if drawing circles for this DataSet is enabled, `false` ifnot
     open var isDrawCirclesEnabled: Bool { return drawCirclesEnabled }
     

--- a/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
@@ -67,6 +67,9 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     /// - returns: `true` if drawing circles for this DataSet is enabled, `false` ifnot
     var isDrawCirclesEnabled: Bool { get }
     
+    /// Prevent circle drawing by index.
+    var circleIndexesNotToDraw: [Int] { get set }
+    
     /// The color of the inner circle (the circle-hole).
     var circleHoleColor: NSUIColor? { get set }
     

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -636,6 +636,10 @@ open class LineChartRenderer: LineRadarRenderer
             {
                 guard let e = dataSet.entryForIndex(j) else { break }
 
+                guard !dataSet.circleIndexesNotToDraw.contains(j) else {
+                    continue
+                }
+                
                 pt.x = CGFloat(e.x)
                 pt.y = CGFloat(e.y * phaseY)
                 pt = pt.applying(valueToPixelMatrix)


### PR DESCRIPTION
Drawing of circles is skipped by providing indexes that should not be drawn. Indexes are set on the dataset and the renderer skips those.