### PR TITLE
ChartDataSet index o.o.b. check

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -184,6 +184,10 @@ open class ChartDataSet: ChartBaseDataSet
     /// if `i` is out of bounds, it may throw an out-of-bounds exception
     open override func entryForIndex(_ i: Int) -> ChartDataEntry?
     {
+        guard i >= 0 && i < _values.count else {
+            return nil
+        }
+        
         return _values[i]
     }
     


### PR DESCRIPTION
Return nil for index out of bounds to prevent crash on empty datasets (Fixes #1945)

Signed-off-by: Wytse van der Velde <w.h.vandervelde@gmail.com>