### PR TITLE
Check NaN, avoid a bunch of warning for 32 bit device

### DIFF
--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -224,6 +224,10 @@ open class YAxisRenderer: AxisRendererBase
             let viewPortHandler = self.viewPortHandler
             else { return }
         
+        guard
+            !position.y.isNaN
+            else { return }
+        
         context.beginPath()
         context.move(to: CGPoint(x: viewPortHandler.contentLeft, y: position.y))
         context.addLine(to: CGPoint(x: viewPortHandler.contentRight, y: position.y))


### PR DESCRIPTION
Add check position y not NaN for 32 bit device. Here is a part of log i get from console

```
Jan  3 23:47:15  XXX[54205] <Error>: CGContextAddLineToPoint: no current point.
Jan  3 23:47:15  XXX[54205] <Error>: Error: this application, or a library it uses, has passed an invalid numeric value (NaN, or not-a-number) to CoreGraphics API and this value is being ignored.Please fix this problem.
Jan  3 23:47:15  IKE[54205] <Error>: Backtrace:
	  <CGFloatValidateWithLog+99>
	   <CGPathMoveToPoint+86>
	    <CGContextMoveToPoint+92>
	     <_TFE12CoreGraphicsCSo9CGContext4movefT2toVSC7CGPoint_T_+39>
	      <_TFC6Charts13YAxisRenderer12drawGridLinefT7contextCSo9CGContext8positionVSC7CGPoint_T_+180>
	       <_TFC6Charts13YAxisRenderer15renderGridLinesfT7contextCSo9CGContext_T_+2207>
	        <_TFC6Charts20BarLineChartViewBase4drawfVSC6CGRectT_+5383>
	         <_TToFC6Charts20BarLineChartViewBase4drawfVSC6CGRectT_+123>
	          <-[UIView(CALayerDelegate) drawLayer:inContext:]+513>
	           <-[CALayer drawInContext:]+279>
	            <_ZL16backing_callbackP9CGContextPv+96>
	             <CABackingStoreUpdate_+2644>
	              <___ZN2CA5Layer8display_Ev_block_invoke+106>
	               <x_blame_allocations+15>
	                <_ZN2CA5Layer8display_Ev+1703>
	                 <-[CALayer _display]+33>
	                  <_ZN2CA5Layer7displayEv+142>
	                   <-[CALayer display]+33>
	                    <_ZN2CA5Layer17display_if_neededEPNS_11TransactionE+326>
	                     <_ZN2CA5Layer28layout_and_display_if_neededEPNS_11TransactionE+38>
	                      <_ZN2CA7Context18commit_transactionEPNS_11TransactionE+317>
	                       <_ZN2CA11Transaction6commitEv+561>
	                        <_ZN2CA11Transaction17observer_callbackEP19__CFRunLoopObservermPv+92>
	                         <__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__+30>
	                          <__CFRunLoopDoObservers+398>
	                           <__CFRunLoopRun+1340>
	                            <CFRunLoopRunSpecific+470>
	                             <CFRunLoopRunInMode+123>
	                              <GSEventRunModal+192>
	                               <GSEventRun+104>
	                                <UIApplicationMain+160>
	                                 <main+145>
Jan  3 23:47:15  XXX[54205] <Error>: CGContextAddLineToPoint: no current point.
```