### PR TITLE
Fix NSCopying implementation in CandleChartDataEntry

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
@@ -81,9 +81,9 @@ open class CandleChartDataEntry: ChartDataEntry
     {
         let copy = super.copyWithZone(zone) as! CandleChartDataEntry
         copy.high = high
-        copy.high = low
-        copy.high = open
-        copy.high = close
+        copy.low = low
+        copy.open = open
+        copy.close = close
         return copy
     }
 }


### PR DESCRIPTION
Fix few typos in `copyWithZone` method. 