### PR TITLE
Allow PieChartView to hide labels for tiny slices - Swift 3

### DIFF
--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -659,4 +659,18 @@ open class PieChartView: PieRadarChartViewBase
             }
         }
     }
+    
+    
+    //Limit the X label size in slice
+    private var _limitXLableSizeInSlice: Bool = false
+    public var limitXLableSizeInSlice: Bool {
+        get {
+            return _limitXLableSizeInSlice
+        }
+        set {
+            _limitXLableSizeInSlice = newValue
+            setNeedsDisplay()
+        }
+    }
+
 }

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -480,51 +480,67 @@ open class PieChartRenderer: DataRenderer
                  
                     if drawXInside && drawYInside
                     {
-                        ChartUtils.drawText(
-                            context: context,
-                            text: valueText,
-                            point: CGPoint(x: x, y: y),
-                            align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
-                        )
+                        let attributes = [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                        let size = pe!.label!.size(attributes: attributes)
                         
-                        if j < data.entryCount && pe?.label != nil
-                        {
+                        if chart.limitXLableSizeInSlice == true && size.width > ((labelRadius * sliceAngle * ChartUtils.Math.FDEG2RAD) + 10) {
+                        } else {
                             ChartUtils.drawText(
                                 context: context,
-                                text: pe!.label!,
-                                point: CGPoint(x: x, y: y + lineHeight),
+                                text: valueText,
+                                point: CGPoint(x: x, y: y),
                                 align: .center,
-                                attributes: [
-                                    NSFontAttributeName: entryLabelFont ?? valueFont,
-                                    NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
                             )
+                            
+                        }
+                        if j < data.entryCount && pe?.label != nil
+                        {
+                            if chart.limitXLableSizeInSlice == true && size.width > ((labelRadius * sliceAngle * ChartUtils.Math.FDEG2RAD) + 10) {
+                            } else {
+                                ChartUtils.drawText(
+                                    context: context,
+                                    text: pe!.label!,
+                                    point: CGPoint(x: x, y: y + lineHeight),
+                                    align: .center,
+                                    attributes: [
+                                        NSFontAttributeName: entryLabelFont ?? valueFont,
+                                        NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                )
+                                
+                            }
                         }
                     }
                     else if drawXInside
                     {
-                        if j < data.entryCount && pe?.label != nil
-                        {
+                        let attributes = [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                        let size = pe!.label!.size(attributes: attributes)
+                        
+                        if chart.limitXLableSizeInSlice == true && size.width > ((labelRadius * sliceAngle * ChartUtils.Math.FDEG2RAD) + 10) {
+                        } else {
                             ChartUtils.drawText(
                                 context: context,
                                 text: pe!.label!,
                                 point: CGPoint(x: x, y: y + lineHeight / 2.0),
                                 align: .center,
-                                attributes: [
-                                    NSFontAttributeName: entryLabelFont ?? valueFont,
-                                    NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                attributes: attributes
                             )
                         }
                     }
                     else if drawYInside
                     {
-                        ChartUtils.drawText(
-                            context: context,
-                            text: valueText,
-                            point: CGPoint(x: x, y: y + lineHeight / 2.0),
-                            align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
-                        )
+                        let attributes = [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                        let size = pe!.label!.size(attributes: attributes)
+                        if chart.limitXLableSizeInSlice == true && size.width > ((labelRadius * sliceAngle * ChartUtils.Math.FDEG2RAD) + 10) {
+                        } else {
+                            ChartUtils.drawText(
+                                context: context,
+                                text: valueText,
+                                point: CGPoint(x: x, y: y + lineHeight / 2.0),
+                                align: .center,
+                                attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            )
+                        }
                     }
                 }
                 


### PR DESCRIPTION
This refer to pull request _#944 - Allow PieChartView to hide labels for tiny slices_ but in swift 3