### PR TITLE
Update Podspec RealmSwift Dependency to 2.1.1 to be in line with Cartfile

### DIFF
--- a/Charts.podspec
+++ b/Charts.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.subspec "Realm" do |ss|
     ss.source_files  = "Source/ChartsRealm/**/*.swift"
     ss.dependency "Charts/Core"
-    ss.dependency "RealmSwift", "~> 1.1"
+    ss.dependency "RealmSwift", "~> 2.1.1"
   end
 end


### PR DESCRIPTION
Bumped the dependency version from 1.1 to 2.1.1 because it was preventing me from using the latest RealmSwift(2.1.2) with Charts, but thought it would be a good idea to keep it in line with what's in the Cartfile