### PR TITLE
Swift 3: Don't confuse ChartRange with Range

### DIFF
--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -90,7 +90,7 @@
 		06B120901D811B8900D14B02 /* PieHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B120071D811B8900D14B02 /* PieHighlighter.swift */; };
 		06B120911D811B8900D14B02 /* PieRadarHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B120081D811B8900D14B02 /* PieRadarHighlighter.swift */; };
 		06B120921D811B8900D14B02 /* RadarHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B120091D811B8900D14B02 /* RadarHighlighter.swift */; };
-		06B120931D811B8900D14B02 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B1200A1D811B8900D14B02 /* Range.swift */; };
+		06B120931D811B8900D14B02 /* ChartRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B1200A1D811B8900D14B02 /* ChartRange.swift */; };
 		06B120941D811B8900D14B02 /* BarChartDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B1200C1D811B8900D14B02 /* BarChartDataProvider.swift */; };
 		06B120951D811B8900D14B02 /* BarLineScatterCandleBubbleChartDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B1200D1D811B8900D14B02 /* BarLineScatterCandleBubbleChartDataProvider.swift */; };
 		06B120961D811B8900D14B02 /* BubbleChartDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B1200E1D811B8900D14B02 /* BubbleChartDataProvider.swift */; };
@@ -267,7 +267,7 @@
 		06B120071D811B8900D14B02 /* PieHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieHighlighter.swift; sourceTree = "<group>"; };
 		06B120081D811B8900D14B02 /* PieRadarHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PieRadarHighlighter.swift; sourceTree = "<group>"; };
 		06B120091D811B8900D14B02 /* RadarHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadarHighlighter.swift; sourceTree = "<group>"; };
-		06B1200A1D811B8900D14B02 /* Range.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Range.swift; sourceTree = "<group>"; };
+		06B1200A1D811B8900D14B02 /* ChartRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartRange.swift; sourceTree = "<group>"; };
 		06B1200C1D811B8900D14B02 /* BarChartDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarChartDataProvider.swift; sourceTree = "<group>"; };
 		06B1200D1D811B8900D14B02 /* BarLineScatterCandleBubbleChartDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarLineScatterCandleBubbleChartDataProvider.swift; sourceTree = "<group>"; };
 		06B1200E1D811B8900D14B02 /* BubbleChartDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BubbleChartDataProvider.swift; sourceTree = "<group>"; };
@@ -594,7 +594,7 @@
 				06B120071D811B8900D14B02 /* PieHighlighter.swift */,
 				06B120081D811B8900D14B02 /* PieRadarHighlighter.swift */,
 				06B120091D811B8900D14B02 /* RadarHighlighter.swift */,
-				06B1200A1D811B8900D14B02 /* Range.swift */,
+				06B1200A1D811B8900D14B02 /* ChartRange.swift */,
 			);
 			name = Highlight;
 			path = Source/Charts/Highlight;
@@ -1084,7 +1084,7 @@
 				06B120641D811B8900D14B02 /* CandleChartData.swift in Sources */,
 				06B120AA1D811B8900D14B02 /* LegendRenderer.swift in Sources */,
 				06B120B41D811B8900D14B02 /* CrossShapeRenderer.swift in Sources */,
-				06B120931D811B8900D14B02 /* Range.swift in Sources */,
+				06B120931D811B8900D14B02 /* ChartRange.swift in Sources */,
 				06B120A21D811B8900D14B02 /* AxisRendererBase.swift in Sources */,
 				06B1208E1D811B8900D14B02 /* HorizontalBarHighlighter.swift in Sources */,
 				06B1206E1D811B8900D14B02 /* LineRadarChartDataSet.swift in Sources */,

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -17,7 +17,7 @@ open class BarChartDataEntry: ChartDataEntry
     fileprivate var _yVals: [Double]?
     
     /// the ranges for the individual stack values - automatically calculated
-    fileprivate var _ranges: [Range]?
+    fileprivate var _ranges: [ChartRange]?
     
     /// the sum of all negative values this entry (if stacked) contains
     fileprivate var _negativeSum: Double = 0.0
@@ -119,7 +119,7 @@ open class BarChartDataEntry: ChartDataEntry
         _positiveSum = sumPos
     }
     
-    /// Splits up the stack-values of the given bar-entry into Range objects.
+    /// Splits up the stack-values of the given bar-entry into ChartRange objects.
     /// - parameter entry:
     /// - returns:
     open func calcRanges()
@@ -132,7 +132,7 @@ open class BarChartDataEntry: ChartDataEntry
         
         if _ranges == nil
         {
-            _ranges = [Range]()
+            _ranges = [ChartRange]()
         }
         else
         {
@@ -150,12 +150,12 @@ open class BarChartDataEntry: ChartDataEntry
             
             if value < 0
             {
-                _ranges?.append(Range(from: negRemain, to: negRemain - value))
+                _ranges?.append(ChartRange(from: negRemain, to: negRemain - value))
                 negRemain -= value
             }
             else
             {
-                _ranges?.append(Range(from: posRemain, to: posRemain + value))
+                _ranges?.append(ChartRange(from: posRemain, to: posRemain + value))
                 posRemain += value
             }
         }
@@ -180,7 +180,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// - returns: The ranges of the individual stack-entries. Will return null if this entry is not stacked.
-    open var ranges: [Range]?
+    open var ranges: [ChartRange]?
     {
         return _ranges
     }

--- a/Source/Charts/Highlight/BarHighlighter.swift
+++ b/Source/Charts/Highlight/BarHighlighter.swift
@@ -100,7 +100,7 @@ open class BarHighlighter: ChartHighlighter
     /// - parameter entry:
     /// - parameter value:
     /// - returns:
-    open func getClosestStackIndex(ranges: [Range]?, value: Double) -> Int
+    open func getClosestStackIndex(ranges: [ChartRange]?, value: Double) -> Int
     {
         if ranges == nil
         {

--- a/Source/Charts/Highlight/ChartRange.swift
+++ b/Source/Charts/Highlight/ChartRange.swift
@@ -1,5 +1,5 @@
 //
-//  Range.swift
+//  ChartRange.swift
 //  Charts
 //
 //  Copyright 2015 Daniel Cohen Gindi & Philipp Jahoda
@@ -11,8 +11,7 @@
 
 import Foundation
 
-@objc(ChartRange)
-open class Range: NSObject
+@objc open class ChartRange: NSObject
 {
     open var from: Double
     open var to: Double


### PR DESCRIPTION
In Swift 3, [`Range`](https://developer.apple.com/reference/swift/range) is a generic structure. Probably it's connected to [this issue](https://github.com/apple/swift-evolution/blob/master/proposals/0086-drop-foundation-ns.md) (NSRange has been a part of Foundation, it's still present there, but Apple has already started to migrate from NSRange to Range).

When I tried to used it (for example, `Range<Int>` in a function argument type like [here](http://stackoverflow.com/a/26775912/1289683)), the compiler shows two errors:
**Cannot specialize non-generic type 'Range'
'Range' is ambiguous for type lookup in this context**

Unfortunately, I can't paste my project here. The two "Ranges" used to successfully co-exist in it, but it was broken after a major refactoring (I didn't touch any code with Charts or [NS]Ranges, I promise! maybe it was something with bridging headers)...

Anyway, we should not confuse Charts Range and the new Range structure.