### PR TITLE
Adds NSPhotoLibraryUsageDescription to plist of ChartsDemo

### DIFF
--- a/ChartsDemo/Supporting Files/Info.plist
+++ b/ChartsDemo/Supporting Files/Info.plist
@@ -32,5 +32,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app requires access to the photo library to store shots of charts there.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Adds NSPhotoLibraryUsageDescription to plist of ChartsDemo to prevent crash on iOS 10 on try to store shot of char to photo library.