### PR TITLE
remove the Axis labelCount limit

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -243,7 +243,7 @@ open class AxisBase: ComponentBase
     
     open func setLabelCount(_ count: Int, force: Bool)
     {
-        self.labelCount = count
+        _labelCount = count
         forceLabelsEnabled = force
     }
     


### PR DESCRIPTION
remove the Axis labelCount limit when user invoke `setLabelCount(_ count: Int, force: Bool)`.
set lableCount forcefully, but the display is limited what will confuse user.
remain the limit in setLabelCount not forcefully, THX!