### PR TITLE
#1880 Fix pinch zoom handling at scale limits

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -629,9 +629,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                     let scaleX = canZoomMoreX ? recognizer.nsuiScale : 1.0
                     let scaleY = canZoomMoreY ? recognizer.nsuiScale : 1.0
                     
-                    var matrix = CGAffineTransform(translationX: location.x, y: location.y)
-                    matrix = matrix.scaledBy(x: scaleX, y: scaleY)
-                    matrix = matrix.translatedBy(x: -location.x, y: -location.y)
+                    var matrix = _viewPortHandler.clippedZoom(scaleX: scaleX, scaleY: scaleY, x: location.x, y: location.y)
                     
                     matrix = _viewPortHandler.touchMatrix.concatenating(matrix)
                     

--- a/Source/Charts/Utils/ViewPortHandler.swift
+++ b/Source/Charts/Utils/ViewPortHandler.swift
@@ -226,6 +226,41 @@ open class ViewPortHandler: NSObject
         return matrix
     }
     
+    /// Calculates an incremental transform to the viewport based on a scale amount and anchor location
+    /// Min/max scale are taken into account to clip the resulting scale and translation values accordingly
+    /// `limitTransAndScale` will eventually clip these values independent of one another,
+    /// but we need to make sure they are aligned to avoid unwanted translation at min/max zoom levels
+    open func clippedZoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
+    {
+        var clippedScaleX = scaleX
+        
+        let newScaleX = scaleX * self.scaleX
+        if newScaleX < minScaleX
+        {
+            clippedScaleX = clippedScaleX * minScaleX / newScaleX
+        }
+        else if newScaleX > maxScaleX
+        {
+            clippedScaleX = clippedScaleX * maxScaleX / newScaleX
+        }
+        
+        var clippedScaleY = scaleY
+        let newScaleY = scaleY * self.scaleY
+        if newScaleY < minScaleY
+        {
+            clippedScaleY = clippedScaleY * minScaleY / newScaleY
+        }
+        else if newScaleY > maxScaleY
+        {
+            clippedScaleY = clippedScaleY * maxScaleY / newScaleY
+        }
+        
+        var matrix = CGAffineTransform(translationX: x, y: y)
+        matrix = matrix.scaledBy(x: clippedScaleX, y: clippedScaleY)
+        matrix = matrix.translatedBy(x: -x, y: -y)
+        return matrix
+    }
+
     /// Resets all zooming and dragging and makes the chart fit exactly it's bounds.
     open func fitScreen() -> CGAffineTransform
     {


### PR DESCRIPTION
# **Summary**
Fix for issue [#1880](https://github.com/danielgindi/Charts/issues/1880) - Chart x offset changes when finished zooming in

Revised handling of pinch gesture recognizer in `BarLineChartViewBase` to avoid misaligned scale/translation values in transform applied to `viewPortHandler.touchMatrix`.

# **Cause of Issue**
The observed behavior when pinching to zoom a bar/line chart was that, when the min/max scale were reached on a particular axis, the offset on that axis would instantaneously shift by some amount. This behavior was caused by `ViewPortHandler.limitTransAndScale()`, which correctly clipped the scale to the appropriate min/max values, but did not account for the difference in translation that that clipping should have introduced.

For example, if a user attempts to zoom the chart out past its minimum X-axis scale, the `tx` value of `touchMatrix` will initially result in a `minimumVisibleX` value that is too low (causing the unwanted change in X offset).

# **Description of Fix**
Prior to concatenating `touchMatrix` with the incremental transform calculated in the chart's pinch gesture handler, potentially resulting in a transform that must be clipped to the chart's scale limits, we now concatenate an already-clipped incremental transform. This calculation is performed in `ViewPortHandler.clippedZoom()` and generates a transform that, when concatenated with `touchMatrix`, will result in a transform that does not need to be clipped to the scale limits. At the min/max scales, both the scale and translation of `touchMatrix` will reflect the expected value.

