### PR TITLE
Fixes Xcode 8.3 beta build issue

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -58,7 +58,7 @@ open class ChartDataEntryBase: NSObject
             return false
         }
         
-        if (object! as AnyObject).data !== data && !((object! as AnyObject).data??.isEqual(self.data))!
+        if (object! as AnyObject).data as AnyObject? !== data && !((object! as AnyObject).data??.isEqual(self.data))!
         {
             return false
         }


### PR DESCRIPTION
This fixes the following build error in Xcode 8.3 beta
>/.../Charts/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift:61:40: Binary operator '!==' cannot be applied to operands of type 'AnyObject?!' and 'AnyObject?'