### PR TITLE
'backgroundColor' is inaccessible due to 'internal' protection level …

### DIFF
--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -445,7 +445,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 			super.touchesCancelled(with: event!)
         }
         
-		var backgroundColor: NSUIColor?
+		open var backgroundColor: NSUIColor?
         {
             get
             {
@@ -455,6 +455,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
             }
             set
             {
+                self.wantsLayer = true
                 self.layer?.backgroundColor = newValue == nil ? nil : newValue!.cgColor
             }
         }


### PR DESCRIPTION
…on mac OS X #2135