### PR TITLE
remove deprecation warnings in XCode 8.3 

### DIFF
--- a/Source/Charts/Animation/ChartAnimationEasing.swift
+++ b/Source/Charts/Animation/ChartAnimationEasing.swift
@@ -211,17 +211,17 @@ internal struct EasingFunctions
     
     internal static let EaseInSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( -cos(position * M_PI_2) + 1.0 )
+        return Double( -cos(position * (Double.pi/2)) + 1.0 )
     }
     
     internal static let EaseOutSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( sin(position * M_PI_2) )
+        return Double( sin(position * (Double.pi/2)) )
     }
     
     internal static let EaseInOutSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( -0.5 * (cos(M_PI * position) - 1.0) )
+        return Double( -0.5 * (cos(Double.pi * position) - 1.0) )
     }
     
     internal static let EaseInExpo = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -286,9 +286,9 @@ internal struct EasingFunctions
         }
         
         var p = duration * 0.3
-        var s = p / (2.0 * M_PI) * asin(1.0)
+        var s = p / (2.0 * Double.pi) * asin(1.0)
         position -= 1.0
-        return Double( -(pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * M_PI) / p)) )
+        return Double( -(pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p)) )
     }
     
     internal static let EaseOutElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -304,8 +304,8 @@ internal struct EasingFunctions
         }
         
         var p = duration * 0.3
-        var s = p / (2.0 * M_PI) * asin(1.0)
-        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * M_PI) / p) + 1.0 )
+        var s = p / (2.0 * Double.pi) * asin(1.0)
+        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) + 1.0 )
     }
     
     internal static let EaseInOutElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -321,14 +321,14 @@ internal struct EasingFunctions
         }
         
         var p = duration * (0.3 * 1.5)
-        var s = p / (2.0 * M_PI) * asin(1.0)
+        var s = p / (2.0 * Double.pi) * asin(1.0)
         if position < 1.0
         {
             position -= 1.0
-            return Double( -0.5 * (pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * M_PI) / p)) )
+            return Double( -0.5 * (pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p)) )
         }
         position -= 1.0
-        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * M_PI) / p) * 0.5 + 1.0 )
+        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) * 0.5 + 1.0 )
     }
     
     internal static let EaseInBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in

--- a/Source/Charts/Animation/ChartAnimationEasing.swift
+++ b/Source/Charts/Animation/ChartAnimationEasing.swift
@@ -211,17 +211,17 @@ internal struct EasingFunctions
     
     internal static let EaseInSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( -cos(position * (Double.pi/2)) + 1.0 )
+        return Double( -cos(position * (.pi/2)) + 1.0 )
     }
     
     internal static let EaseOutSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( sin(position * (Double.pi/2)) )
+        return Double( sin(position * (.pi/2)) )
     }
     
     internal static let EaseInOutSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( -0.5 * (cos(Double.pi * position) - 1.0) )
+        return Double( -0.5 * (cos(.pi * position) - 1.0) )
     }
     
     internal static let EaseInExpo = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -286,9 +286,9 @@ internal struct EasingFunctions
         }
         
         var p = duration * 0.3
-        var s = p / (2.0 * Double.pi) * asin(1.0)
+        var s = p / (2.0 * .pi) * asin(1.0)
         position -= 1.0
-        return Double( -(pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p)) )
+        return Double( -(pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * .pi) / p)) )
     }
     
     internal static let EaseOutElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -304,8 +304,8 @@ internal struct EasingFunctions
         }
         
         var p = duration * 0.3
-        var s = p / (2.0 * Double.pi) * asin(1.0)
-        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) + 1.0 )
+        var s = p / (2.0 * .pi) * asin(1.0)
+        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * .pi) / p) + 1.0 )
     }
     
     internal static let EaseInOutElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -321,14 +321,14 @@ internal struct EasingFunctions
         }
         
         var p = duration * (0.3 * 1.5)
-        var s = p / (2.0 * Double.pi) * asin(1.0)
+        var s = p / (2.0 * .pi) * asin(1.0)
         if position < 1.0
         {
             position -= 1.0
-            return Double( -0.5 * (pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p)) )
+            return Double( -0.5 * (pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * .pi) / p)) )
         }
         position -= 1.0
-        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) * 0.5 + 1.0 )
+        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * .pi) / p) * 0.5 + 1.0 )
     }
     
     internal static let EaseInBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in

--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -13,14 +13,14 @@ import Foundation
 
 open class ChartData: NSObject
 {
-    internal var _yMax: Double = -DBL_MAX
-    internal var _yMin: Double = DBL_MAX
-    internal var _xMax: Double = -DBL_MAX
-    internal var _xMin: Double = DBL_MAX
-    internal var _leftAxisMax: Double = -DBL_MAX
-    internal var _leftAxisMin: Double = DBL_MAX
-    internal var _rightAxisMax: Double = -DBL_MAX
-    internal var _rightAxisMin: Double = DBL_MAX
+    internal var _yMax: Double = -.greatestFiniteMagnitude
+    internal var _yMin: Double = .greatestFiniteMagnitude
+    internal var _xMax: Double = -.greatestFiniteMagnitude
+    internal var _xMin: Double = .greatestFiniteMagnitude
+    internal var _leftAxisMax: Double = -.greatestFiniteMagnitude
+    internal var _leftAxisMin: Double = .greatestFiniteMagnitude
+    internal var _rightAxisMax: Double = -.greatestFiniteMagnitude
+    internal var _rightAxisMin: Double = .greatestFiniteMagnitude
     
     internal var _dataSets = [IChartDataSet]()
     
@@ -71,20 +71,20 @@ open class ChartData: NSObject
     /// calc minimum and maximum y value over all datasets
     open func calcMinMax()
     {
-        _yMax = -DBL_MAX
-        _yMin = DBL_MAX
-        _xMax = -DBL_MAX
-        _xMin = DBL_MAX
+        _yMax = -.greatestFiniteMagnitude
+        _yMin = .greatestFiniteMagnitude
+        _xMax = -.greatestFiniteMagnitude
+        _xMin = .greatestFiniteMagnitude
         
         for set in _dataSets
         {
             calcMinMax(dataSet: set)
         }
         
-        _leftAxisMax = -DBL_MAX
-        _leftAxisMin = DBL_MAX
-        _rightAxisMax = -DBL_MAX
-        _rightAxisMin = DBL_MAX
+        _leftAxisMax = -.greatestFiniteMagnitude
+        _leftAxisMin = .greatestFiniteMagnitude
+        _rightAxisMax = -.greatestFiniteMagnitude
+        _rightAxisMin = .greatestFiniteMagnitude
         
         // left axis
         let firstLeft = getFirstLeft(dataSets: dataSets)
@@ -257,7 +257,7 @@ open class ChartData: NSObject
     {
         if axis == .left
         {
-            if _leftAxisMin == DBL_MAX
+            if _leftAxisMin == .greatestFiniteMagnitude
             {
                 return _rightAxisMin
             }
@@ -268,7 +268,7 @@ open class ChartData: NSObject
         }
         else
         {
-            if _rightAxisMin == DBL_MAX
+            if _rightAxisMin == .greatestFiniteMagnitude
             {
                 return _leftAxisMin
             }
@@ -295,7 +295,7 @@ open class ChartData: NSObject
     {
         if axis == .left
         {
-            if _leftAxisMax == -DBL_MAX
+            if _leftAxisMax == -.greatestFiniteMagnitude
             {
                 return _rightAxisMax
             }
@@ -306,7 +306,7 @@ open class ChartData: NSObject
         }
         else
         {
-            if _rightAxisMax == -DBL_MAX
+            if _rightAxisMax == -.greatestFiniteMagnitude
             {
                 return _leftAxisMax
             }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -54,7 +54,7 @@ open class ChartDataEntry: ChartDataEntryBase
             return false
         }
         
-        if fabs((object! as AnyObject).x - x) > DBL_EPSILON
+        if fabs((object! as AnyObject).x - x) > Double.ulpOfOne
         {
             return false
         }
@@ -100,12 +100,12 @@ public func ==(lhs: ChartDataEntry, rhs: ChartDataEntry) -> Bool
         return false
     }
     
-    if fabs(lhs.x - rhs.x) > DBL_EPSILON
+    if fabs(lhs.x - rhs.x) > Double.ulpOfOne
     {
         return false
     }
     
-    if fabs(lhs.y - rhs.y) > DBL_EPSILON
+    if fabs(lhs.y - rhs.y) > Double.ulpOfOne
     {
         return false
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -54,7 +54,7 @@ open class ChartDataEntry: ChartDataEntryBase
             return false
         }
         
-        if fabs((object! as AnyObject).x - x) > Double.ulpOfOne
+        if fabs((object! as AnyObject).x - x) > .ulpOfOne
         {
             return false
         }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -100,12 +100,12 @@ public func ==(lhs: ChartDataEntry, rhs: ChartDataEntry) -> Bool
         return false
     }
     
-    if fabs(lhs.x - rhs.x) > Double.ulpOfOne
+    if fabs(lhs.x - rhs.x) > .ulpOfOne
     {
         return false
     }
     
-    if fabs(lhs.y - rhs.y) > Double.ulpOfOne
+    if fabs(lhs.y - rhs.y) > .ulpOfOne
     {
         return false
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -63,7 +63,7 @@ open class ChartDataEntryBase: NSObject
             return false
         }
         
-        if fabs((object! as AnyObject).y - y) > DBL_EPSILON
+        if fabs((object! as AnyObject).y - y) > Double.ulpOfOne
         {
             return false
         }
@@ -96,7 +96,7 @@ public func ==(lhs: ChartDataEntryBase, rhs: ChartDataEntryBase) -> Bool
         return false
     }
     
-    if fabs(lhs.y - rhs.y) > DBL_EPSILON
+    if fabs(lhs.y - rhs.y) > Double.ulpOfOne
     {
         return false
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -63,7 +63,7 @@ open class ChartDataEntryBase: NSObject
             return false
         }
         
-        if fabs((object! as AnyObject).y - y) > Double.ulpOfOne
+        if fabs((object! as AnyObject).y - y) > .ulpOfOne
         {
             return false
         }
@@ -96,7 +96,7 @@ public func ==(lhs: ChartDataEntryBase, rhs: ChartDataEntryBase) -> Bool
         return false
     }
     
-    if fabs(lhs.y - rhs.y) > Double.ulpOfOne
+    if fabs(lhs.y - rhs.y) > .ulpOfOne
     {
         return false
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -58,16 +58,16 @@ open class ChartDataSet: ChartBaseDataSet
     internal var _values: [ChartDataEntry]!
     
     /// maximum y-value in the value array
-    internal var _yMax: Double = -DBL_MAX
+    internal var _yMax: Double = -.greatestFiniteMagnitude
     
     /// minimum y-value in the value array
-    internal var _yMin: Double = DBL_MAX
+    internal var _yMin: Double = .greatestFiniteMagnitude
     
     /// maximum x-value in the value array
-    internal var _xMax: Double = -DBL_MAX
+    internal var _xMax: Double = -.greatestFiniteMagnitude
     
     /// minimum x-value in the value array
-    internal var _xMin: Double = DBL_MAX
+    internal var _xMin: Double = .greatestFiniteMagnitude
     
     /// *
     /// - note: Calls `notifyDataSetChanged()` after setting a new value.
@@ -98,10 +98,10 @@ open class ChartDataSet: ChartBaseDataSet
             return
         }
         
-        _yMax = -DBL_MAX
-        _yMin = DBL_MAX
-        _xMax = -DBL_MAX
-        _xMin = DBL_MAX
+        _yMax = -.greatestFiniteMagnitude
+        _yMin = .greatestFiniteMagnitude
+        _xMax = -.greatestFiniteMagnitude
+        _xMin = .greatestFiniteMagnitude
         
         for e in _values
         {
@@ -116,8 +116,8 @@ open class ChartDataSet: ChartBaseDataSet
             return
         }
         
-        _yMax = -DBL_MAX
-        _yMin = DBL_MAX
+        _yMax = -.greatestFiniteMagnitude
+        _yMin = .greatestFiniteMagnitude
         
         let indexFrom = entryIndex(x: fromX, closestToY: Double.nan, rounding: .down)
         let indexTo = entryIndex(x: toX, closestToY: Double.nan, rounding: .up)

--- a/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
@@ -98,15 +98,15 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
     {
         _dataSets.removeAll()
         
-        _yMax = -DBL_MAX
-        _yMin = DBL_MAX
-        _xMax = -DBL_MAX
-        _xMin = DBL_MAX
+        _yMax = -.greatestFiniteMagnitude
+        _yMin = .greatestFiniteMagnitude
+        _xMax = -.greatestFiniteMagnitude
+        _xMin = .greatestFiniteMagnitude
         
-        _leftAxisMax = -DBL_MAX
-        _leftAxisMin = DBL_MAX
-        _rightAxisMax = -DBL_MAX
-        _rightAxisMin = DBL_MAX
+        _leftAxisMax = -.greatestFiniteMagnitude
+        _leftAxisMin = .greatestFiniteMagnitude
+        _rightAxisMax = -.greatestFiniteMagnitude
+        _rightAxisMin = .greatestFiniteMagnitude
         
         let allData = self.allData
         

--- a/Source/Charts/Highlight/RadarHighlighter.swift
+++ b/Source/Charts/Highlight/RadarHighlighter.swift
@@ -25,7 +25,7 @@ open class RadarHighlighter: PieRadarHighlighter
         let distanceToCenter = Double(chart.distanceToCenter(x: x, y: y) / chart.factor)
         
         var closest: Highlight? = nil
-        var distance = DBL_MAX
+        var distance = Double.greatestFiniteMagnitude
         
         for high in highlights
         {

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -130,7 +130,7 @@ open class PieChartRenderer: DataRenderer
         for j in 0 ..< entryCount
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
-            if ((abs(e.y) > DBL_EPSILON))
+            if ((abs(e.y) > Double.ulpOfOne))
             {
                 visibleAngleCount += 1
             }
@@ -148,7 +148,7 @@ open class PieChartRenderer: DataRenderer
             guard let e = dataSet.entryForIndex(j) else { continue }
             
             // draw only if the value is greater than zero
-            if (abs(e.y) > DBL_EPSILON)
+            if (abs(e.y) > Double.ulpOfOne)
             {
                 if !chart.needsHighlight(index: j)
                 {
@@ -691,7 +691,7 @@ open class PieChartRenderer: DataRenderer
             for j in 0 ..< entryCount
             {
                 guard let e = set.entryForIndex(j) else { continue }
-                if ((abs(e.y) > DBL_EPSILON))
+                if ((abs(e.y) > Double.ulpOfOne))
                 {
                     visibleAngleCount += 1
                 }

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -130,7 +130,7 @@ open class PieChartRenderer: DataRenderer
         for j in 0 ..< entryCount
         {
             guard let e = dataSet.entryForIndex(j) else { continue }
-            if ((abs(e.y) > Double.ulpOfOne))
+            if ((abs(e.y) > .ulpOfOne))
             {
                 visibleAngleCount += 1
             }
@@ -148,7 +148,7 @@ open class PieChartRenderer: DataRenderer
             guard let e = dataSet.entryForIndex(j) else { continue }
             
             // draw only if the value is greater than zero
-            if (abs(e.y) > Double.ulpOfOne)
+            if (abs(e.y) > .ulpOfOne)
             {
                 if !chart.needsHighlight(index: j)
                 {
@@ -691,7 +691,7 @@ open class PieChartRenderer: DataRenderer
             for j in 0 ..< entryCount
             {
                 guard let e = set.entryForIndex(j) else { continue }
-                if ((abs(e.y) > Double.ulpOfOne))
+                if ((abs(e.y) > .ulpOfOne))
                 {
                     visibleAngleCount += 1
                 }

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -22,10 +22,10 @@ open class ChartUtils
     
     internal struct Math
     {
-        internal static let FDEG2RAD = CGFloat(M_PI / 180.0)
-        internal static let FRAD2DEG = CGFloat(180.0 / M_PI)
-        internal static let DEG2RAD = M_PI / 180.0
-        internal static let RAD2DEG = 180.0 / M_PI
+        internal static let FDEG2RAD = CGFloat(Double.pi / 180.0)
+        internal static let FRAD2DEG = CGFloat(180.0 / Double.pi)
+        internal static let DEG2RAD = Double.pi / 180.0
+        internal static let RAD2DEG = 180.0 / Double.pi
     }
     
     internal class func roundToNextSignificant(number: Double) -> Double
@@ -67,7 +67,7 @@ open class ChartUtils
         }
         else
         {
-            return number + DBL_EPSILON
+            return number + Double.ulpOfOne
         }
     }
     

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -22,10 +22,10 @@ open class ChartUtils
     
     internal struct Math
     {
-        internal static let FDEG2RAD = CGFloat(Double.pi / 180.0)
-        internal static let FRAD2DEG = CGFloat(180.0 / Double.pi)
-        internal static let DEG2RAD = Double.pi / 180.0
-        internal static let RAD2DEG = 180.0 / Double.pi
+        internal static let FDEG2RAD = CGFloat(.pi / 180.0)
+        internal static let FRAD2DEG = CGFloat(180.0 / .pi)
+        internal static let DEG2RAD = .pi / 180.0
+        internal static let RAD2DEG = 180.0 / .pi
     }
     
     internal class func roundToNextSignificant(number: Double) -> Double
@@ -67,7 +67,7 @@ open class ChartUtils
         }
         else
         {
-            return number + Double.ulpOfOne
+            return number + .ulpOfOne
         }
     }
     


### PR DESCRIPTION
Remove deprecations related to M_PI, M_PI_2, DBL_MAX, and DBL_EPSILON, which are deprecated in Swift 3.0.