### PR TITLE
fix #2222 move default backgroundColor to initialize()

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -197,10 +197,6 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
-
-		#if os(iOS)
-			self.backgroundColor = NSUIColor.clear
-		#endif
         initialize()
     }
     
@@ -218,6 +214,10 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     
     internal func initialize()
     {
+        #if os(iOS)
+            self.backgroundColor = NSUIColor.clear
+        #endif
+
         _animator = Animator()
         _animator.delegate = self
 


### PR DESCRIPTION
fix #2222 
move default backgroundColor to initialize() as `initWithCoder` also needs it
I checked initialize() is only called in init(), so it seems safe to move there, to avoid duplicated code.
