### PR TITLE
Fixed, If the last value is the max or min, the range will be wrong

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -109,8 +109,7 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    open override 
-    (fromX: Double, toX: Double)
+    open override calcMinMaxY(fromX: Double, toX: Double)
     {
         if _values.count == 0
         {

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -124,7 +124,7 @@ open class ChartDataSet: ChartBaseDataSet
         
         if indexTo <= indexFrom { return }
         
-        for i in indexFrom..<indexTo
+        for i in indexFrom...indexTo
         {
             // only recalculate y
             calcMinMaxY(entry: _values[i])

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -109,7 +109,8 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    open override func calcMinMaxY(fromX: Double, toX: Double)
+    open override 
+    (fromX: Double, toX: Double)
     {
         if _values.count == 0
         {
@@ -122,7 +123,7 @@ open class ChartDataSet: ChartBaseDataSet
         let indexFrom = entryIndex(x: fromX, closestToY: Double.nan, rounding: .down)
         let indexTo = entryIndex(x: toX, closestToY: Double.nan, rounding: .up)
         
-        if indexTo <= indexFrom { return }
+        if indexTo < indexFrom { return }
         
         for i in indexFrom...indexTo
         {

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -109,7 +109,7 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    open override calcMinMaxY(fromX: Double, toX: Double)
+    open override func calcMinMaxY(fromX: Double, toX: Double)
     {
         if _values.count == 0
         {


### PR DESCRIPTION
The last entry is ignored.
If the last value is the max or min, the range will be wrong

