### PR TITLE
Small fix for calculating minimum and maximum ChartDataSet values not…

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -124,7 +124,7 @@ open class ChartDataSet: ChartBaseDataSet
         
         if indexTo <= indexFrom { return }
         
-        for i in indexFrom..<indexTo
+        for i in indexFrom...indexTo
         {
             // only recalculate y
             calcMinMaxY(entry: _values[i])


### PR DESCRIPTION
Without this fix, ChartDataSet is calculating minimum and maximum values not for whole value array. The result is that the Bar (in my example) is outside the chart, because maximum value of the last object in array was skipped. 

Before this change : 
![before](https://cloud.githubusercontent.com/assets/19164218/24947624/cecb2f6c-1f67-11e7-8e16-7d6bdd99972d.PNG)


After this change :
![after](https://cloud.githubusercontent.com/assets/19164218/24947632/d2be895c-1f67-11e7-9922-a2a0eeb8e65d.PNG)

