### PR TITLE
Bug fixing with one line, updating ChartViewBase.swift

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -155,7 +155,10 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     
     /// flag that indicates if offsets calculation has already been done or not
     fileprivate var _offsetsCalculated = false
-    
+	
+    /// if `true` , when call clear(), also set lastHighlighted to nil
+    open var clearLastHighlightedEnabled = false
+	
     /// array of Highlight objects that reference the highlighted slices in the chart
     internal var _indicesToHighlight = [Highlight]()
     
@@ -276,7 +279,10 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         _data = nil
         _offsetsCalculated = false
         _indicesToHighlight.removeAll()
-	lastHighlighted = nil
+	if clearLastHighlightedEnabled
+	{
+	    lastHighlighted = nil
+	}
         setNeedsDisplay()
     }
     

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -276,6 +276,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         _data = nil
         _offsetsCalculated = false
         _indicesToHighlight.removeAll()
+	lastHighlighted = nil
         setNeedsDisplay()
     }
     


### PR DESCRIPTION
fixing a bug: when clearing chart, the 'lastHighlighted' var isn't set to nil. This will cause user to tap twice to highlight the new value, if the new value's index is the same as the old lastHighlighted's.