### PR TITLE
fix #2356 crash if floor(10.0 * intervalMagnitude) is 0.0

### DIFF
--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -127,7 +127,8 @@ open class AxisRendererBase: Renderer
         if intervalSigDigit > 5
         {
             // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
-            interval = floor(10.0 * Double(intervalMagnitude))
+            // if it's 0.0 after floor(), we use the old value
+            interval = floor(10.0 * intervalMagnitude) == 0.0 ? interval : floor(10.0 * intervalMagnitude)
         }
         
         var n = axis.centerAxisLabelsEnabled ? 1 : 0

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -60,9 +60,9 @@ open class YAxisRendererRadarChart: YAxisRenderer
         
         if intervalSigDigit > 5
         {
-            // Use one order of magnitude higher, to avoid intervals like 0.9 or
-            // 90
-            interval = floor(10 * intervalMagnitude)
+            // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
+            // if it's 0.0 after floor(), we use the old value
+            interval = floor(10.0 * intervalMagnitude) == 0.0 ? interval : floor(10.0 * intervalMagnitude)
         }
         
         let centeringEnabled = axis.isCenterAxisLabelsEnabled


### PR DESCRIPTION
For #2356 

This is a corner case when `interval` and `intervalMagnitude` meet certain conditions, like `interval=0.06` and `intervalMagnitude=0.01` will lead `floor(10.0 * intervalMagnitude)` to `0.0`, and crash at `axis.decimals = Int(ceil(-log10(interval)))`

I added a check if it's 0, then we keep the current interval. 

@danielgindi Need you to review this as this is a fundamental change.
The problem is I don't know whether to keep the interval value, or we use `intervalMagnitude * 5` such as to get 0.05 rather than 0.06 or 0.08.

Or, do we have other options?
