### PR TITLE
remove build for ci tests procedure, use `clean test` directly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,12 +126,12 @@ task :ci, [:platform] do |_task, args|
   platform = arg_to_key(args[:platform]) if args.has_key?(:platform)
 
   if test_platforms.include?(platform)
-    execute 'clean build test', platform
+    execute 'clean test', platform
   elsif build_platforms.include?(platform)
     execute 'clean build', platform
   else
     test_platforms.each do |platform|
-      execute 'clean build test', platform
+      execute 'clean test', platform
     end
     build_platforms.each do |platform|
       execute 'clean build', platform


### PR DESCRIPTION
remove build for ci tests procedure, use `clean test` directly

Seems travis is building Charts twice due to `build` and `test`. But sometimes, on my machine it's just once and sometimes twice.