### PR TITLE
Run view port jobs afterwards (Fixes #2395)

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -912,14 +912,16 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             {
                 _viewPortHandler.setChartDimens(width: bounds.size.width, height: bounds.size.height)
                 
+                // This may cause the chart view to mutate properties affecting the view port -- lets do this
+                // before we try to run any pending jobs on the view port itself
+                notifyDataSetChanged()
+
                 // Finish any pending viewport changes
                 while (!_viewportJobs.isEmpty)
                 {
                     let job = _viewportJobs.remove(at: 0)
                     job.doJob()
                 }
-                
-                notifyDataSetChanged()
             }
         }
     }


### PR DESCRIPTION
`notifyDataSetChanged()` may actually mutate some of the view port properties — stomping all over what the view port jobs just accomplished.

This behavior is apparent when calling `moveViewToX()` on the chart view that has no frame yet. Prior to this change, calling `moveViewToX()` had no affect on a chart a chart that has no frame. That's because once the chart view was assigned a frame, `notifyDataSetChanged()` call would actually mutate the view port's properties stomping all over what the view port jobs just finished doing.