### PR TITLE
Corrected multiple comments to use correct Swift syntax

### DIFF
--- a/Source/Charts/Animation/Animator.swift
+++ b/Source/Charts/Animation/Animator.swift
@@ -19,10 +19,10 @@ import CoreGraphics
 @objc(ChartAnimatorDelegate)
 public protocol AnimatorDelegate
 {
-    /// Called when the Animator has stepped.
+    // Called when the Animator has stepped.
     func animatorUpdated(_ animator: Animator)
-    
-    /// Called when the Animator has stopped.
+
+    // Called when the Animator has stopped.
     func animatorStopped(_ animator: Animator)
 }
 
@@ -32,56 +32,56 @@ open class Animator: NSObject
     open weak var delegate: AnimatorDelegate?
     open var updateBlock: (() -> Void)?
     open var stopBlock: (() -> Void)?
-    
-    /// the phase that is animated and influences the drawn values on the x-axis
+
+    // the phase that is animated and influences the drawn values on the x-axis
     open var phaseX: Double = 1.0
-    
-    /// the phase that is animated and influences the drawn values on the y-axis
+
+    // the phase that is animated and influences the drawn values on the y-axis
     open var phaseY: Double = 1.0
-    
+
     fileprivate var _startTimeX: TimeInterval = 0.0
     fileprivate var _startTimeY: TimeInterval = 0.0
     fileprivate var _displayLink: NSUIDisplayLink?
-    
+
     fileprivate var _durationX: TimeInterval = 0.0
     fileprivate var _durationY: TimeInterval = 0.0
-    
+
     fileprivate var _endTimeX: TimeInterval = 0.0
     fileprivate var _endTimeY: TimeInterval = 0.0
     fileprivate var _endTime: TimeInterval = 0.0
-    
+
     fileprivate var _enabledX: Bool = false
     fileprivate var _enabledY: Bool = false
-    
+
     fileprivate var _easingX: ChartEasingFunctionBlock?
     fileprivate var _easingY: ChartEasingFunctionBlock?
-    
+
     public override init()
     {
         super.init()
     }
-    
+
     deinit
     {
         stop()
     }
-    
+
     open func stop()
     {
         if _displayLink != nil
         {
             _displayLink?.remove(from: RunLoop.main, forMode: RunLoopMode.commonModes)
             _displayLink = nil
-            
+
             _enabledX = false
             _enabledY = false
-            
+
             // If we stopped an animation in the middle, we do not want to leave it like this
             if phaseX != 1.0 || phaseY != 1.0
             {
                 phaseX = 1.0
                 phaseY = 1.0
-                
+
                 if delegate != nil
                 {
                     delegate!.animatorUpdated(self)
@@ -91,7 +91,7 @@ open class Animator: NSObject
                     updateBlock!()
                 }
             }
-            
+
             if delegate != nil
             {
                 delegate!.animatorStopped(self)
@@ -102,7 +102,7 @@ open class Animator: NSObject
             }
         }
     }
-    
+
     fileprivate func updateAnimationPhases(_ currentTime: TimeInterval)
     {
         if _enabledX
@@ -114,7 +114,7 @@ open class Animator: NSObject
             {
                 elapsed = duration
             }
-           
+
             if _easingX != nil
             {
                 phaseX = _easingX!(elapsed, duration)
@@ -124,7 +124,7 @@ open class Animator: NSObject
                 phaseX = Double(elapsed / duration)
             }
         }
-        
+
         if _enabledY
         {
             let elapsedTime: TimeInterval = currentTime - _startTimeY
@@ -134,7 +134,7 @@ open class Animator: NSObject
             {
                 elapsed = duration
             }
-            
+
             if _easingY != nil
             {
                 phaseY = _easingY!(elapsed, duration)
@@ -145,13 +145,13 @@ open class Animator: NSObject
             }
         }
     }
-    
+
     @objc fileprivate func animationLoop()
     {
         let currentTime: TimeInterval = CACurrentMediaTime()
-        
+
         updateAnimationPhases(currentTime)
-        
+
         if delegate != nil
         {
             delegate!.animatorUpdated(self)
@@ -160,23 +160,23 @@ open class Animator: NSObject
         {
             updateBlock!()
         }
-        
+
         if currentTime >= _endTime
         {
             stop()
         }
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingX: an easing function for the animation on the x axis
-    /// - parameter easingY: an easing function for the animation on the y axis
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingX: an easing function for the animation on the x axis
+    // - parameter easingY: an easing function for the animation on the y axis
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
     {
         stop()
-        
+
         _startTimeX = CACurrentMediaTime()
         _startTimeY = _startTimeX
         _durationX = xAxisDuration
@@ -186,64 +186,64 @@ open class Animator: NSObject
         _endTime = _endTimeX > _endTimeY ? _endTimeX : _endTimeY
         _enabledX = xAxisDuration > 0.0
         _enabledY = yAxisDuration > 0.0
-        
+
         _easingX = easingX
         _easingY = easingY
-        
+
         // Take care of the first frame if rendering is already scheduled...
         updateAnimationPhases(_startTimeX)
-        
+
         if _enabledX || _enabledY
         {
             _displayLink = NSUIDisplayLink(target: self, selector: #selector(animationLoop))
             _displayLink?.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
         }
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingOptionX: the easing function for the animation on the x axis
-    /// - parameter easingOptionY: the easing function for the animation on the y axis
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingOptionX: the easing function for the animation on the x axis
+    // - parameter easingOptionY: the easing function for the animation on the y axis
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easingFunctionFromOption(easingOptionX), easingY: easingFunctionFromOption(easingOptionY))
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easing: an easing function for the animation
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easing: an easing function for the animation
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easing, easingY: easing)
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingOption: the easing function for the animation
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingOption: the easing function for the animation
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOption: .easeInOutSine)
     }
-    
-    /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter easing: an easing function for the animation
+
+    // Animates the drawing / rendering of the chart the x-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter easing: an easing function for the animation
     open func animate(xAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _startTimeX = CACurrentMediaTime()
@@ -251,12 +251,12 @@ open class Animator: NSObject
         _endTimeX = _startTimeX + xAxisDuration
         _endTime = _endTimeX > _endTimeY ? _endTimeX : _endTimeY
         _enabledX = xAxisDuration > 0.0
-        
+
         _easingX = easing
-        
+
         // Take care of the first frame if rendering is already scheduled...
         updateAnimationPhases(_startTimeX)
-        
+
         if _enabledX || _enabledY
         {
             if _displayLink == nil
@@ -266,28 +266,28 @@ open class Animator: NSObject
             }
         }
     }
-    
-    /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter easingOption: the easing function for the animation
+
+    // Animates the drawing / rendering of the chart the x-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter easingOption: the easing function for the animation
     open func animate(xAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
-    
-    /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
+
+    // Animates the drawing / rendering of the chart the x-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
     open func animate(xAxisDuration: TimeInterval)
     {
         animate(xAxisDuration: xAxisDuration, easingOption: .easeInOutSine)
     }
-    
-    /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easing: an easing function for the animation
+
+    // Animates the drawing / rendering of the chart the y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easing: an easing function for the animation
     open func animate(yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _startTimeY = CACurrentMediaTime()
@@ -295,12 +295,12 @@ open class Animator: NSObject
         _endTimeY = _startTimeY + yAxisDuration
         _endTime = _endTimeX > _endTimeY ? _endTimeX : _endTimeY
         _enabledY = yAxisDuration > 0.0
-        
+
         _easingY = easing
-        
+
         // Take care of the first frame if rendering is already scheduled...
         updateAnimationPhases(_startTimeY)
-        
+
         if _enabledX || _enabledY
         {
             if _displayLink == nil
@@ -310,19 +310,19 @@ open class Animator: NSObject
             }
         }
     }
-    
-    /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingOption: the easing function for the animation
+
+    // Animates the drawing / rendering of the chart the y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingOption: the easing function for the animation
     open func animate(yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         animate(yAxisDuration: yAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
-    
-    /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter yAxisDuration: duration for animating the y axis
+
+    // Animates the drawing / rendering of the chart the y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter yAxisDuration: duration for animating the y axis
     open func animate(yAxisDuration: TimeInterval)
     {
         animate(yAxisDuration: yAxisDuration, easingOption: .easeInOutSine)

--- a/Source/Charts/Charts/BarChartView.swift
+++ b/Source/Charts/Charts/BarChartView.swift
@@ -12,32 +12,32 @@
 import Foundation
 import CoreGraphics
 
-/// Chart that draws bars.
+// Chart that draws bars.
 open class BarChartView: BarLineChartViewBase, BarChartDataProvider
 {
-    /// if set to true, all values are drawn above their bars, instead of below their top
+    // if set to true, all values are drawn above their bars, instead of below their top
     fileprivate var _drawValueAboveBarEnabled = true
 
-    /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
+    // if set to true, a grey area is drawn behind each bar that indicates the maximum value
     fileprivate var _drawBarShadowEnabled = false
-    
+
     internal override func initialize()
     {
         super.initialize()
-        
+
         renderer = BarChartRenderer(dataProvider: self, animator: _animator, viewPortHandler: _viewPortHandler)
-        
+
         self.highlighter = BarHighlighter(chart: self)
-        
+
         self.xAxis.spaceMin = 0.5
         self.xAxis.spaceMax = 0.5
     }
-    
+
     internal override func calcMinMax()
     {
         guard let data = self.data as? BarChartData
             else { return }
-        
+
         if fitBars
         {
             _xAxis.calculate(
@@ -48,7 +48,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
         {
             _xAxis.calculate(min: data.xMin, max: data.xMax)
         }
-        
+
         // calculate axis range (min / max) according to provided data
         _leftAxis.calculate(
             min: data.getYMin(axis: .left),
@@ -57,8 +57,8 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             min: data.getYMin(axis: .right),
             max: data.getYMax(axis: .right))
     }
-    
-    /// - returns: The Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the BarChart.
+
+    // - returns: The Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the BarChart.
     open override func getHighlightByTouchPoint(_ pt: CGPoint) -> Highlight?
     {
         if _data === nil
@@ -66,12 +66,12 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             Swift.print("Can't select by touch. No data set.")
             return nil
         }
-        
+
         guard let h = self.highlighter?.getHighlight(x: pt.x, y: pt.y)
             else { return nil }
-        
+
         if !isHighlightFullBarEnabled { return h }
-        
+
         // For isHighlightFullBarEnabled, remove stackIndex
         return Highlight(
             x: h.x, y: h.y,
@@ -81,39 +81,39 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             stackIndex: -1,
             axis: h.axis)
     }
-        
-    /// - returns: The bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
+
+    // - returns: The bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
     open func getBarBounds(entry e: BarChartDataEntry) -> CGRect
     {
         guard let
             data = _data as? BarChartData,
             let set = data.getDataSetForEntry(e) as? IBarChartDataSet
             else { return CGRect.null }
-        
+
         let y = e.y
         let x = e.x
-        
+
         let barWidth = data.barWidth
-        
+
         let left = x - barWidth / 2.0
         let right = x + barWidth / 2.0
         let top = y >= 0.0 ? y : 0.0
         let bottom = y <= 0.0 ? y : 0.0
-        
+
         var bounds = CGRect(x: left, y: top, width: right - left, height: bottom - top)
-        
+
         getTransformer(forAxis: set.axisDependency).rectValueToPixel(&bounds)
-        
+
         return bounds
     }
-    
-    /// Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
-    /// Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
-    /// Calls `notifyDataSetChanged()` afterwards.
-    ///
-    /// - parameter fromX: the starting point on the x-axis where the grouping should begin
-    /// - parameter groupSpace: the space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
-    /// - parameter barSpace: the space between individual bars in values (not pixels) e.g. 0.1f for bar width 1f
+
+    // Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
+    // Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
+    // Calls `notifyDataSetChanged()` afterwards.
+    //
+    // - parameter fromX: the starting point on the x-axis where the grouping should begin
+    // - parameter groupSpace: the space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
+    // - parameter barSpace: the space between individual bars in values (not pixels) e.g. 0.1f for bar width 1f
     open func groupBars(fromX: Double, groupSpace: Double, barSpace: Double)
     {
         guard let barData = self.barData
@@ -122,23 +122,23 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             Swift.print("You need to set data for the chart before grouping bars.", terminator: "\n")
             return
         }
-        
+
         barData.groupBars(fromX: fromX, groupSpace: groupSpace, barSpace: barSpace)
         notifyDataSetChanged()
     }
-    
-    /// Highlights the value at the given x-value in the given DataSet. Provide -1 as the dataSetIndex to undo all highlighting.
-    /// - parameter x:
-    /// - parameter dataSetIndex:
-    /// - parameter stackIndex: the index inside the stack - only relevant for stacked entries
+
+    // Highlights the value at the given x-value in the given DataSet. Provide -1 as the dataSetIndex to undo all highlighting.
+    // - parameter x:
+    // - parameter dataSetIndex:
+    // - parameter stackIndex: the index inside the stack - only relevant for stacked entries
     open func highlightValue(x: Double, dataSetIndex: Int, stackIndex: Int)
     {
         highlightValue(Highlight(x: x, dataSetIndex: dataSetIndex, stackIndex: stackIndex))
     }
 
     // MARK: Accessors
-    
-    /// if set to true, all values are drawn above their bars, instead of below their top
+
+    // if set to true, all values are drawn above their bars, instead of below their top
     open var drawValueAboveBarEnabled: Bool
     {
         get { return _drawValueAboveBarEnabled }
@@ -148,8 +148,8 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             setNeedsDisplay()
         }
     }
-    
-    /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
+
+    // if set to true, a grey area is drawn behind each bar that indicates the maximum value
     open var drawBarShadowEnabled: Bool
     {
         get { return _drawBarShadowEnabled }
@@ -159,25 +159,25 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             setNeedsDisplay()
         }
     }
-    
-    /// Adds half of the bar width to each side of the x-axis range in order to allow the bars of the barchart to be fully displayed.
-    /// **default**: false
+
+    // Adds half of the bar width to each side of the x-axis range in order to allow the bars of the barchart to be fully displayed.
+    // **default**: false
     open var fitBars = false
-    
-    /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values (relevant only for stacked).
-    /// If enabled, highlighting operations will highlight the whole bar, even if only a single stack entry was tapped.
+
+    // Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values (relevant only for stacked).
+    // If enabled, highlighting operations will highlight the whole bar, even if only a single stack entry was tapped.
     open var highlightFullBarEnabled: Bool = false
-    
-    /// - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
+
+    // - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
     open var isHighlightFullBarEnabled: Bool { return highlightFullBarEnabled }
-    
+
     // MARK: - BarChartDataProbider
-    
+
     open var barData: BarChartData? { return _data as? BarChartData }
-    
-    /// - returns: `true` if drawing values above bars is enabled, `false` ifnot
+
+    // - returns: `true` if drawing values above bars is enabled, `false` ifnot
     open var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
-    
-    /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
+
+    // - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
     open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
 }

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -16,113 +16,113 @@ import CoreGraphics
     import UIKit
 #endif
 
-/// Base-class of LineChart, BarChart, ScatterChart and CandleStickChart.
+// Base-class of LineChart, BarChart, ScatterChart and CandleStickChart.
 open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartDataProvider, NSUIGestureRecognizerDelegate
 {
-    /// the maximum number of entries to which values will be drawn
-    /// (entry numbers greater than this value will cause value-labels to disappear)
+    // the maximum number of entries to which values will be drawn
+    // (entry numbers greater than this value will cause value-labels to disappear)
     internal var _maxVisibleCount = 100
-    
-    /// flag that indicates if auto scaling on the y axis is enabled
+
+    // flag that indicates if auto scaling on the y axis is enabled
     fileprivate var _autoScaleMinMaxEnabled = false
-    
+
     fileprivate var _pinchZoomEnabled = false
     fileprivate var _doubleTapToZoomEnabled = true
     fileprivate var _dragEnabled = true
-    
+
     fileprivate var _scaleXEnabled = true
     fileprivate var _scaleYEnabled = true
-    
-    /// the color for the background of the chart-drawing area (everything behind the grid lines).
+
+    // the color for the background of the chart-drawing area (everything behind the grid lines).
     open var gridBackgroundColor = NSUIColor(red: 240/255.0, green: 240/255.0, blue: 240/255.0, alpha: 1.0)
-    
+
     open var borderColor = NSUIColor.black
     open var borderLineWidth: CGFloat = 1.0
-    
-    /// flag indicating if the grid background should be drawn or not
+
+    // flag indicating if the grid background should be drawn or not
     open var drawGridBackgroundEnabled = false
-    
-    /// When enabled, the borders rectangle will be rendered.
-    /// If this is enabled, there is no point drawing the axis-lines of x- and y-axis.
+
+    // When enabled, the borders rectangle will be rendered.
+    // If this is enabled, there is no point drawing the axis-lines of x- and y-axis.
     open var drawBordersEnabled = false
-    
-    /// When enabled, the values will be clipped to contentRect, otherwise they can bleed outside the content rect.
+
+    // When enabled, the values will be clipped to contentRect, otherwise they can bleed outside the content rect.
     open var clipValuesToContentEnabled: Bool = false
 
-    /// Sets the minimum offset (padding) around the chart, defaults to 10
+    // Sets the minimum offset (padding) around the chart, defaults to 10
     open var minOffset = CGFloat(10.0)
-    
-    /// Sets whether the chart should keep its position (zoom / scroll) after a rotation (orientation change)
-    /// **default**: false
+
+    // Sets whether the chart should keep its position (zoom / scroll) after a rotation (orientation change)
+    // **default**: false
     open var keepPositionOnRotation: Bool = false
-    
-    /// the object representing the left y-axis
+
+    // the object representing the left y-axis
     internal var _leftAxis: YAxis!
-    
-    /// the object representing the right y-axis
+
+    // the object representing the right y-axis
     internal var _rightAxis: YAxis!
 
     internal var _leftYAxisRenderer: YAxisRenderer!
     internal var _rightYAxisRenderer: YAxisRenderer!
-    
+
     internal var _leftAxisTransformer: Transformer!
     internal var _rightAxisTransformer: Transformer!
-    
+
     internal var _xAxisRenderer: XAxisRenderer!
-    
+
     internal var _tapGestureRecognizer: NSUITapGestureRecognizer!
     internal var _doubleTapGestureRecognizer: NSUITapGestureRecognizer!
     #if !os(tvOS)
     internal var _pinchGestureRecognizer: NSUIPinchGestureRecognizer!
     #endif
     internal var _panGestureRecognizer: NSUIPanGestureRecognizer!
-    
-    /// flag that indicates if a custom viewport offset has been set
+
+    // flag that indicates if a custom viewport offset has been set
     fileprivate var _customViewPortEnabled = false
-    
+
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
     }
-    
+
     public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }
-    
+
     deinit
     {
         stopDeceleration()
     }
-    
+
     internal override func initialize()
     {
         super.initialize()
-        
+
         _leftAxis = YAxis(position: .left)
         _rightAxis = YAxis(position: .right)
-        
+
         _leftAxisTransformer = Transformer(viewPortHandler: _viewPortHandler)
         _rightAxisTransformer = Transformer(viewPortHandler: _viewPortHandler)
-        
+
         _leftYAxisRenderer = YAxisRenderer(viewPortHandler: _viewPortHandler, yAxis: _leftAxis, transformer: _leftAxisTransformer)
         _rightYAxisRenderer = YAxisRenderer(viewPortHandler: _viewPortHandler, yAxis: _rightAxis, transformer: _rightAxisTransformer)
-        
+
         _xAxisRenderer = XAxisRenderer(viewPortHandler: _viewPortHandler, xAxis: _xAxis, transformer: _leftAxisTransformer)
-        
+
         self.highlighter = ChartHighlighter(chart: self)
-        
+
         _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(tapGestureRecognized(_:)))
         _doubleTapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(doubleTapGestureRecognized(_:)))
         _doubleTapGestureRecognizer.nsuiNumberOfTapsRequired = 2
         _panGestureRecognizer = NSUIPanGestureRecognizer(target: self, action: #selector(panGestureRecognized(_:)))
-        
+
         _panGestureRecognizer.delegate = self
-        
+
         self.addGestureRecognizer(_tapGestureRecognizer)
         self.addGestureRecognizer(_doubleTapGestureRecognizer)
         self.addGestureRecognizer(_panGestureRecognizer)
-        
+
         _doubleTapGestureRecognizer.isEnabled = _doubleTapToZoomEnabled
         _panGestureRecognizer.isEnabled = _dragEnabled
 
@@ -133,7 +133,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             _pinchGestureRecognizer.isEnabled = _pinchZoomEnabled || _scaleXEnabled || _scaleYEnabled
         #endif
     }
-    
+
     open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?)
     {
         // Saving current position of chart.
@@ -143,10 +143,10 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             oldPoint = viewPortHandler.contentRect.origin
             getTransformer(forAxis: .left).pixelToValues(&oldPoint!)
         }
-        
+
         // Superclass transforms chart.
         super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
-        
+
         // Restoring old position of chart
         if var newPoint = oldPoint , keepPositionOnRotation
         {
@@ -158,22 +158,22 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             let _ = viewPortHandler.refresh(newMatrix: viewPortHandler.touchMatrix, chart: self, invalidate: true)
         }
     }
-    
+
     open override func draw(_ rect: CGRect)
     {
         super.draw(rect)
-        
+
         if _data === nil
         {
             return
         }
-        
+
         let optionalContext = NSUIGraphicsGetCurrentContext()
         guard let context = optionalContext else { return }
 
         // execute all drawing commands
         drawGridBackground(context: context)
-        
+
 
         if _autoScaleMinMaxEnabled
         {
@@ -184,17 +184,17 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         {
             _leftYAxisRenderer?.computeAxis(min: _leftAxis._axisMinimum, max: _leftAxis._axisMaximum, inverted: _leftAxis.isInverted)
         }
-        
+
         if _rightAxis.isEnabled
         {
             _rightYAxisRenderer?.computeAxis(min: _rightAxis._axisMinimum, max: _rightAxis._axisMaximum, inverted: _rightAxis.isInverted)
         }
-        
+
         if _xAxis.isEnabled
         {
             _xAxisRenderer?.computeAxis(min: _xAxis._axisMinimum, max: _xAxis._axisMaximum, inverted: false)
         }
-        
+
         _xAxisRenderer?.renderAxisLine(context: context)
         _leftYAxisRenderer?.renderAxisLine(context: context)
         _rightYAxisRenderer?.renderAxisLine(context: context)
@@ -203,52 +203,52 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         _xAxisRenderer?.renderGridLines(context: context)
         _leftYAxisRenderer?.renderGridLines(context: context)
         _rightYAxisRenderer?.renderGridLines(context: context)
-        
+
         if _xAxis.isEnabled && _xAxis.isDrawLimitLinesBehindDataEnabled
         {
             _xAxisRenderer?.renderLimitLines(context: context)
         }
-        
+
         if _leftAxis.isEnabled && _leftAxis.isDrawLimitLinesBehindDataEnabled
         {
             _leftYAxisRenderer?.renderLimitLines(context: context)
         }
-        
+
         if _rightAxis.isEnabled && _rightAxis.isDrawLimitLinesBehindDataEnabled
         {
             _rightYAxisRenderer?.renderLimitLines(context: context)
         }
-        
+
         // make sure the data cannot be drawn outside the content-rect
         context.saveGState()
         context.clip(to: _viewPortHandler.contentRect)
         renderer?.drawData(context: context)
-        
+
         // if highlighting is enabled
         if (valuesToHighlight())
         {
             renderer?.drawHighlighted(context: context, indices: _indicesToHighlight)
         }
-        
+
         context.restoreGState()
-        
+
         renderer!.drawExtras(context: context)
-        
+
         if _xAxis.isEnabled && !_xAxis.isDrawLimitLinesBehindDataEnabled
         {
             _xAxisRenderer?.renderLimitLines(context: context)
         }
-        
+
         if _leftAxis.isEnabled && !_leftAxis.isDrawLimitLinesBehindDataEnabled
         {
             _leftYAxisRenderer?.renderLimitLines(context: context)
         }
-        
+
         if _rightAxis.isEnabled && !_rightAxis.isDrawLimitLinesBehindDataEnabled
         {
             _rightYAxisRenderer?.renderLimitLines(context: context)
         }
-        
+
         _xAxisRenderer.renderAxisLabels(context: context)
         _leftYAxisRenderer.renderAxisLabels(context: context)
         _rightYAxisRenderer.renderAxisLabels(context: context)
@@ -257,9 +257,9 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         {
             context.saveGState()
             context.clip(to: _viewPortHandler.contentRect)
-            
+
             renderer!.drawValues(context: context)
-            
+
             context.restoreGState()
         }
         else
@@ -270,59 +270,59 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         _legendRenderer.renderLegend(context: context)
 
         drawDescription(context: context)
-        
+
         drawMarkers(context: context)
     }
-    
+
     fileprivate var _autoScaleLastLowestVisibleX: Double?
     fileprivate var _autoScaleLastHighestVisibleX: Double?
-    
-    /// Performs auto scaling of the axis by recalculating the minimum and maximum y-values based on the entries currently in view.
+
+    // Performs auto scaling of the axis by recalculating the minimum and maximum y-values based on the entries currently in view.
     internal func autoScale()
     {
         guard let data = _data
             else { return }
-        
+
         data.calcMinMaxY(fromX: self.lowestVisibleX, toX: self.highestVisibleX)
-        
+
         _xAxis.calculate(min: data.xMin, max: data.xMax)
-        
+
         // calculate axis range (min / max) according to provided data
-        
+
         if _leftAxis.isEnabled
         {
             _leftAxis.calculate(min: data.getYMin(axis: .left), max: data.getYMax(axis: .left))
         }
-        
+
         if _rightAxis.isEnabled
         {
             _rightAxis.calculate(min: data.getYMin(axis: .right), max: data.getYMax(axis: .right))
         }
-        
+
         calculateOffsets()
     }
-    
+
     internal func prepareValuePxMatrix()
     {
         _rightAxisTransformer.prepareMatrixValuePx(chartXMin: _xAxis._axisMinimum, deltaX: CGFloat(xAxis.axisRange), deltaY: CGFloat(_rightAxis.axisRange), chartYMin: _rightAxis._axisMinimum)
         _leftAxisTransformer.prepareMatrixValuePx(chartXMin: xAxis._axisMinimum, deltaX: CGFloat(xAxis.axisRange), deltaY: CGFloat(_leftAxis.axisRange), chartYMin: _leftAxis._axisMinimum)
     }
-    
+
     internal func prepareOffsetMatrix()
     {
         _rightAxisTransformer.prepareMatrixOffset(inverted: _rightAxis.isInverted)
         _leftAxisTransformer.prepareMatrixOffset(inverted: _leftAxis.isInverted)
     }
-    
+
     open override func notifyDataSetChanged()
     {
         renderer?.initBuffers()
-        
+
         calcMinMax()
-        
+
         _leftYAxisRenderer?.computeAxis(min: _leftAxis._axisMinimum, max: _leftAxis._axisMaximum, inverted: _leftAxis.isInverted)
         _rightYAxisRenderer?.computeAxis(min: _rightAxis._axisMinimum, max: _rightAxis._axisMaximum, inverted: _rightAxis.isInverted)
-        
+
         if let data = _data
         {
             _xAxisRenderer?.computeAxis(
@@ -335,22 +335,22 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 _legendRenderer?.computeLegend(data: data)
             }
         }
-        
+
         calculateOffsets()
-        
+
         setNeedsDisplay()
     }
-    
+
     internal override func calcMinMax()
     {
         // calculate / set x-axis range
         _xAxis.calculate(min: _data?.xMin ?? 0.0, max: _data?.xMax ?? 0.0)
-        
+
         // calculate axis range (min / max) according to provided data
         _leftAxis.calculate(min: _data?.getYMin(axis: .left) ?? 0.0, max: _data?.getYMax(axis: .left) ?? 0.0)
         _rightAxis.calculate(min: _data?.getYMin(axis: .right) ?? 0.0, max: _data?.getYMax(axis: .right) ?? 0.0)
     }
-    
+
     internal func calculateLegendOffsets(offsetLeft: inout CGFloat, offsetTop: inout CGFloat, offsetRight: inout CGFloat, offsetBottom: inout CGFloat)
     {
         // setup offsets for legend
@@ -359,32 +359,32 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             switch _legend.orientation
             {
             case .vertical:
-                
+
                 switch _legend.horizontalAlignment
                 {
                 case .left:
                     offsetLeft += min(_legend.neededWidth, _viewPortHandler.chartWidth * _legend.maxSizePercent) + _legend.xOffset
-                    
+
                 case .right:
                     offsetRight += min(_legend.neededWidth, _viewPortHandler.chartWidth * _legend.maxSizePercent) + _legend.xOffset
-                    
+
                 case .center:
-                    
+
                     switch _legend.verticalAlignment
                     {
                     case .top:
                         offsetTop += min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent) + _legend.yOffset
-                        
+
                     case .bottom:
                         offsetBottom += min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent) + _legend.yOffset
-                        
+
                     default:
                         break
                     }
                 }
-                
+
             case .horizontal:
-                
+
                 switch _legend.verticalAlignment
                 {
                 case .top:
@@ -393,21 +393,21 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                     {
                         offsetTop += xAxis.labelRotatedHeight
                     }
-                    
+
                 case .bottom:
                     offsetBottom += min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent) + _legend.yOffset
                     if xAxis.isEnabled && xAxis.isDrawLabelsEnabled
                     {
                         offsetBottom += xAxis.labelRotatedHeight
                     }
-                    
+
                 default:
                     break
                 }
             }
         }
     }
-    
+
     internal override func calculateOffsets()
     {
         if !_customViewPortEnabled
@@ -416,18 +416,18 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             var offsetRight = CGFloat(0.0)
             var offsetTop = CGFloat(0.0)
             var offsetBottom = CGFloat(0.0)
-            
+
             calculateLegendOffsets(offsetLeft: &offsetLeft,
                                    offsetTop: &offsetTop,
                                    offsetRight: &offsetRight,
                                    offsetBottom: &offsetBottom)
-            
+
             // offsets for y-labels
             if leftAxis.needsOffset
             {
                 offsetLeft += leftAxis.requiredSize().width
             }
-            
+
             if rightAxis.needsOffset
             {
                 offsetRight += rightAxis.requiredSize().width
@@ -436,7 +436,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             if xAxis.isEnabled && xAxis.isDrawLabelsEnabled
             {
                 let xlabelheight = xAxis.labelRotatedHeight + xAxis.yOffset
-                
+
                 // offsets for x-labels
                 if xAxis.labelPosition == .bottom
                 {
@@ -452,7 +452,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                     offsetTop += xlabelheight
                 }
             }
-            
+
             offsetTop += self.extraTopOffset
             offsetRight += self.extraRightOffset
             offsetBottom += self.extraBottomOffset
@@ -464,74 +464,74 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 offsetRight: max(self.minOffset, offsetRight),
                 offsetBottom: max(self.minOffset, offsetBottom))
         }
-        
+
         prepareOffsetMatrix()
         prepareValuePxMatrix()
     }
-    
-    /// draws the grid background
+
+    // draws the grid background
     internal func drawGridBackground(context: CGContext)
     {
         if drawGridBackgroundEnabled || drawBordersEnabled
         {
             context.saveGState()
         }
-        
+
         if drawGridBackgroundEnabled
         {
             // draw the grid background
             context.setFillColor(gridBackgroundColor.cgColor)
             context.fill(_viewPortHandler.contentRect)
         }
-        
+
         if drawBordersEnabled
         {
             context.setLineWidth(borderLineWidth)
             context.setStrokeColor(borderColor.cgColor)
             context.stroke(_viewPortHandler.contentRect)
         }
-        
+
         if drawGridBackgroundEnabled || drawBordersEnabled
         {
             context.restoreGState()
         }
     }
-    
+
     // MARK: - Gestures
-    
+
     fileprivate enum GestureScaleAxis
     {
         case both
         case x
         case y
     }
-    
+
     fileprivate var _isDragging = false
     fileprivate var _isScaling = false
     fileprivate var _gestureScaleAxis = GestureScaleAxis.both
     fileprivate var _closestDataSetToTouch: IChartDataSet!
     fileprivate var _panGestureReachedEdge: Bool = false
     fileprivate weak var _outerScrollView: NSUIScrollView?
-    
-    fileprivate var _lastPanPoint = CGPoint() /// This is to prevent using setTranslation which resets velocity
-    
+
+    fileprivate var _lastPanPoint = CGPoint() // This is to prevent using setTranslation which resets velocity
+
     fileprivate var _decelerationLastTime: TimeInterval = 0.0
     fileprivate var _decelerationDisplayLink: NSUIDisplayLink!
     fileprivate var _decelerationVelocity = CGPoint()
-    
+
     @objc fileprivate func tapGestureRecognized(_ recognizer: NSUITapGestureRecognizer)
     {
         if _data === nil
         {
             return
         }
-        
+
         if recognizer.state == NSUIGestureRecognizerState.ended
         {
             if !self.isHighLightPerTapEnabled { return }
-            
+
             let h = getHighlightByTouchPoint(recognizer.location(in: self))
-            
+
             if h === nil || h!.isEqual(self.lastHighlighted)
             {
                 self.highlightValue(nil, callDelegate: true)
@@ -544,21 +544,21 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         }
     }
-    
+
     @objc fileprivate func doubleTapGestureRecognized(_ recognizer: NSUITapGestureRecognizer)
     {
         if _data === nil
         {
             return
         }
-        
+
         if recognizer.state == NSUIGestureRecognizerState.ended
         {
             if _data !== nil && _doubleTapToZoomEnabled && (data?.entryCount ?? 0) > 0
             {
                 var location = recognizer.location(in: self)
                 location.x = location.x - _viewPortHandler.offsetLeft
-                
+
                 if isTouchInverted()
                 {
                     location.y = -(location.y - _viewPortHandler.offsetTop)
@@ -567,24 +567,24 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 {
                     location.y = -(self.bounds.size.height - location.y - _viewPortHandler.offsetBottom)
                 }
-                
+
                 self.zoom(scaleX: isScaleXEnabled ? 1.4 : 1.0, scaleY: isScaleYEnabled ? 1.4 : 1.0, x: location.x, y: location.y)
             }
         }
     }
-    
+
     #if !os(tvOS)
     @objc fileprivate func pinchGestureRecognized(_ recognizer: NSUIPinchGestureRecognizer)
     {
         if recognizer.state == NSUIGestureRecognizerState.began
         {
             stopDeceleration()
-            
+
             if _data !== nil &&
                 (_pinchZoomEnabled || _scaleXEnabled || _scaleYEnabled)
             {
                 _isScaling = true
-                
+
                 if _pinchZoomEnabled
                 {
                     _gestureScaleAxis = .both
@@ -593,7 +593,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 {
                     let x = abs(recognizer.location(in: self).x - recognizer.nsuiLocationOfTouch(1, inView: self).x)
                     let y = abs(recognizer.location(in: self).y - recognizer.nsuiLocationOfTouch(1, inView: self).y)
-                    
+
                     if _scaleXEnabled != _scaleYEnabled
                     {
                         _gestureScaleAxis = _scaleXEnabled ? .x : .y
@@ -611,7 +611,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             if _isScaling
             {
                 _isScaling = false
-                
+
                 // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
                 calculateOffsets()
                 setNeedsDisplay()
@@ -622,7 +622,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             let isZoomingOut = (recognizer.nsuiScale < 1)
             var canZoomMoreX = isZoomingOut ? _viewPortHandler.canZoomOutMoreX : _viewPortHandler.canZoomInMoreX
             var canZoomMoreY = isZoomingOut ? _viewPortHandler.canZoomOutMoreY : _viewPortHandler.canZoomInMoreY
-            
+
             if _isScaling
             {
                 canZoomMoreX = canZoomMoreX && _scaleXEnabled && (_gestureScaleAxis == .both || _gestureScaleAxis == .x)
@@ -631,7 +631,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 {
                     var location = recognizer.location(in: self)
                     location.x = location.x - _viewPortHandler.offsetLeft
-                    
+
                     if isTouchInverted()
                     {
                         location.y = -(location.y - _viewPortHandler.offsetTop)
@@ -640,41 +640,41 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                     {
                         location.y = -(_viewPortHandler.chartHeight - location.y - _viewPortHandler.offsetBottom)
                     }
-                    
+
                     let scaleX = canZoomMoreX ? recognizer.nsuiScale : 1.0
                     let scaleY = canZoomMoreY ? recognizer.nsuiScale : 1.0
-                    
+
                     var matrix = CGAffineTransform(translationX: location.x, y: location.y)
                     matrix = matrix.scaledBy(x: scaleX, y: scaleY)
                     matrix = matrix.translatedBy(x: -location.x, y: -location.y)
-                    
+
                     matrix = _viewPortHandler.touchMatrix.concatenating(matrix)
-                    
+
                     let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
-                    
+
                     if delegate !== nil
                     {
                         delegate?.chartScaled?(self, scaleX: scaleX, scaleY: scaleY)
                     }
                 }
-                
+
                 recognizer.nsuiScale = 1.0
             }
         }
     }
     #endif
-    
+
     @objc fileprivate func panGestureRecognized(_ recognizer: NSUIPanGestureRecognizer)
     {
         if recognizer.state == NSUIGestureRecognizerState.began && recognizer.nsuiNumberOfTouches() > 0
         {
             stopDeceleration()
-            
+
             if _data === nil
             { // If we have no data, we have nothing to pan and no data to highlight
                 return
             }
-            
+
             // If drag is enabled and we are in a position where there's something to drag:
             //  * If we're zoomed in, then obviously we have something to drag.
             //  * If we have a drag offset - we always have something to drag
@@ -682,12 +682,12 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 (!self.hasNoDragOffset || !self.isFullyZoomedOut)
             {
                 _isDragging = true
-                
+
                 _closestDataSetToTouch = getDataSetByTouchPoint(point: recognizer.nsuiLocationOfTouch(0, inView: self))
-                
+
                 let translation = recognizer.translation(in: self)
                 let didUserDrag = (self is HorizontalBarChartView) ? translation.y != 0.0 : translation.x != 0.0
-                
+
                 // Check to see if user dragged at all and if so, can the chart be dragged by the given amount
                 if didUserDrag && !performPanChange(translation: translation)
                 {
@@ -706,13 +706,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                         _outerScrollView?.nsuiIsScrollEnabled = false
                     }
                 }
-                
+
                 _lastPanPoint = recognizer.translation(in: self)
             }
             else if self.isHighlightPerDragEnabled
             {
                 // We will only handle highlights on NSUIGestureRecognizerState.Changed
-                
+
                 _isDragging = false
             }
         }
@@ -722,17 +722,17 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             {
                 let originalTranslation = recognizer.translation(in: self)
                 let translation = CGPoint(x: originalTranslation.x - _lastPanPoint.x, y: originalTranslation.y - _lastPanPoint.y)
-                
+
                 let _ = performPanChange(translation: translation)
-                
+
                 _lastPanPoint = originalTranslation
             }
             else if isHighlightPerDragEnabled
             {
                 let h = getHighlightByTouchPoint(recognizer.location(in: self))
-                
+
                 let lastHighlighted = self.lastHighlighted
-                
+
                 if ((h === nil && lastHighlighted !== nil) ||
                     (h !== nil && lastHighlighted === nil) ||
                     (h !== nil && lastHighlighted !== nil && !h!.isEqual(lastHighlighted)))
@@ -749,17 +749,17 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 if recognizer.state == NSUIGestureRecognizerState.ended && isDragDecelerationEnabled
                 {
                     stopDeceleration()
-                    
+
                     _decelerationLastTime = CACurrentMediaTime()
                     _decelerationVelocity = recognizer.velocity(in: self)
-                    
+
                     _decelerationDisplayLink = NSUIDisplayLink(target: self, selector: #selector(BarLineChartViewBase.decelerationLoop))
                     _decelerationDisplayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
                 }
-                
+
                 _isDragging = false
             }
-            
+
             if _outerScrollView !== nil
             {
                 _outerScrollView?.nsuiIsScrollEnabled = true
@@ -767,11 +767,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         }
     }
-    
+
     fileprivate func performPanChange(translation: CGPoint) -> Bool
     {
         var translation = translation
-        
+
         if isTouchInverted()
         {
             if self is HorizontalBarChartView
@@ -783,30 +783,30 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 translation.y = -translation.y
             }
         }
-        
+
         let originalMatrix = _viewPortHandler.touchMatrix
-        
+
         var matrix = CGAffineTransform(translationX: translation.x, y: translation.y)
         matrix = originalMatrix.concatenating(matrix)
-        
+
         matrix = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
-        
+
         if delegate !== nil
         {
             delegate?.chartTranslated?(self, dX: translation.x, dY: translation.y)
         }
-        
+
         // Did we managed to actually drag or did we reach the edge?
         return matrix.tx != originalMatrix.tx || matrix.ty != originalMatrix.ty
     }
-    
+
     fileprivate func isTouchInverted() -> Bool
     {
         return isAnyAxisInverted &&
             _closestDataSetToTouch !== nil &&
             getAxis(_closestDataSetToTouch.axisDependency).isInverted
     }
-    
+
     open func stopDeceleration()
     {
         if _decelerationDisplayLink !== nil
@@ -815,40 +815,40 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             _decelerationDisplayLink = nil
         }
     }
-    
+
     @objc fileprivate func decelerationLoop()
     {
         let currentTime = CACurrentMediaTime()
-        
+
         _decelerationVelocity.x *= self.dragDecelerationFrictionCoef
         _decelerationVelocity.y *= self.dragDecelerationFrictionCoef
-        
+
         let timeInterval = CGFloat(currentTime - _decelerationLastTime)
-        
+
         let distance = CGPoint(
             x: _decelerationVelocity.x * timeInterval,
             y: _decelerationVelocity.y * timeInterval
         )
-        
+
         if !performPanChange(translation: distance)
         {
             // We reached the edge, stop
             _decelerationVelocity.x = 0.0
             _decelerationVelocity.y = 0.0
         }
-        
+
         _decelerationLastTime = currentTime
-        
+
         if abs(_decelerationVelocity.x) < 0.001 && abs(_decelerationVelocity.y) < 0.001
         {
             stopDeceleration()
-            
+
             // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
             calculateOffsets()
             setNeedsDisplay()
         }
     }
-    
+
     fileprivate func nsuiGestureRecognizerShouldBegin(_ gestureRecognizer: NSUIGestureRecognizer) -> Bool
     {
         if gestureRecognizer == _panGestureRecognizer
@@ -871,10 +871,10 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 }
             #endif
         }
-        
+
         return true
     }
-    
+
     #if !os(OSX)
     open override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool
     {
@@ -882,18 +882,18 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         {
             return false
         }
-        
+
         return nsuiGestureRecognizerShouldBegin(gestureRecognizer)
     }
     #endif
-    
+
     #if os(OSX)
     public func gestureRecognizerShouldBegin(gestureRecognizer: NSGestureRecognizer) -> Bool
     {
         return nsuiGestureRecognizerShouldBegin(gestureRecognizer)
     }
     #endif
-    
+
     open func gestureRecognizer(_ gestureRecognizer: NSUIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSUIGestureRecognizer) -> Bool
     {
         #if !os(tvOS)
@@ -905,7 +905,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 return true
             }
         #endif
-        
+
         if (gestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) &&
             otherGestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) && (
                 gestureRecognizer == _panGestureRecognizer
@@ -916,7 +916,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             {
                 scrollView = scrollView?.superview
             }
-            
+
             // If there is two scrollview together, we pick the superview of the inner scrollview.
             // In the case of UITableViewWrepperView, the superview will be UITableView
             if let superViewOfScrollView = scrollView?.superview
@@ -926,14 +926,14 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
 
             var foundScrollView = scrollView as? NSUIScrollView
-            
+
             if foundScrollView !== nil && !foundScrollView!.nsuiIsScrollEnabled
             {
                 foundScrollView = nil
             }
-            
+
             var scrollViewPanGestureRecognizer: NSUIGestureRecognizer!
-            
+
             if foundScrollView !== nil
             {
                 for scrollRecognizer in foundScrollView!.nsuiGestureRecognizers!
@@ -945,38 +945,38 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                     }
                 }
             }
-            
+
             if otherGestureRecognizer === scrollViewPanGestureRecognizer
             {
                 _outerScrollView = foundScrollView
-                
+
                 return true
             }
         }
-        
+
         return false
     }
-    
-    /// MARK: Viewport modifiers
-    
-    /// Zooms in by 1.4, into the charts center.
+
+    // MARK: Viewport modifiers
+
+    // Zooms in by 1.4, into the charts center.
     open func zoomIn()
     {
         let center = _viewPortHandler.contentCenter
-        
+
         let matrix = _viewPortHandler.zoomIn(x: center.x, y: -center.y)
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
-        
+
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
         calculateOffsets()
         setNeedsDisplay()
     }
 
-    /// Zooms out by 0.7, from the charts center.
+    // Zooms out by 0.7, from the charts center.
     open func zoomOut()
     {
         let center = _viewPortHandler.contentCenter
-        
+
         let matrix = _viewPortHandler.zoomOut(x: center.x, y: -center.y)
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
 
@@ -984,25 +984,25 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         calculateOffsets()
         setNeedsDisplay()
     }
-    
-    /// Zooms out to original size.
+
+    // Zooms out to original size.
     open func resetZoom()
     {
         let matrix = _viewPortHandler.resetZoom()
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
-        
+
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
         calculateOffsets()
         setNeedsDisplay()
     }
 
-    /// Zooms in or out by the given scale factor. x and y are the coordinates
-    /// (in pixels) of the zoom center.
-    ///
-    /// - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
-    /// - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
-    /// - parameter x:
-    /// - parameter y:
+    // Zooms in or out by the given scale factor. x and y are the coordinates
+    // (in pixels) of the zoom center.
+    //
+    // - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
+    // - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
+    // - parameter x:
+    // - parameter y:
     open func zoom(
         scaleX: CGFloat,
                scaleY: CGFloat,
@@ -1011,20 +1011,20 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         let matrix = _viewPortHandler.zoom(scaleX: scaleX, scaleY: scaleY, x: x, y: -y)
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
-        
+
         // Range might have changed, which means that Y-axis labels could have changed in size, affecting Y-axis size. So we need to recalculate offsets.
         calculateOffsets()
         setNeedsDisplay()
     }
-    
-    /// Zooms in or out by the given scale factor.
-    /// x and y are the values (**not pixels**) of the zoom center.
-    ///
-    /// - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
-    /// - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis:
+
+    // Zooms in or out by the given scale factor.
+    // x and y are the values (**not pixels**) of the zoom center.
+    //
+    // - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
+    // - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis:
     open func zoom(
         scaleX: CGFloat,
                scaleY: CGFloat,
@@ -1043,14 +1043,14 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             view: self)
         addViewportJob(job)
     }
-    
-    /// Zooms to the center of the chart with the given scale factor.
-    ///
-    /// - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
-    /// - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis:
+
+    // Zooms to the center of the chart with the given scale factor.
+    //
+    // - parameter scaleX: if < 1 --> zoom out, if > 1 --> zoom in
+    // - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis:
     open func zoomToCenter(
         scaleX: CGFloat,
                scaleY: CGFloat)
@@ -1063,16 +1063,16 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             y: -center.y)
         let _ = viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
     }
-    
-    /// Zooms by the specified scale factor to the specified values on the specified axis.
-    ///
-    /// - parameter scaleX:
-    /// - parameter scaleY:
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // Zooms by the specified scale factor to the specified values on the specified axis.
+    //
+    // - parameter scaleX:
+    // - parameter scaleY:
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func zoomAndCenterViewAnimated(
         scaleX: CGFloat,
         scaleY: CGFloat,
@@ -1085,7 +1085,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         let origin = valueForTouchPoint(
             point: CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop),
             axis: axis)
-        
+
         let job = AnimatedZoomViewJob(
             viewPortHandler: viewPortHandler,
             transformer: getTransformer(forAxis: axis),
@@ -1102,19 +1102,19 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             zoomOriginY: origin.y,
             duration: duration,
             easing: easing)
-            
+
         addViewportJob(job)
     }
-    
-    /// Zooms by the specified scale factor to the specified values on the specified axis.
-    ///
-    /// - parameter scaleX:
-    /// - parameter scaleY:
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // Zooms by the specified scale factor to the specified values on the specified axis.
+    //
+    // - parameter scaleX:
+    // - parameter scaleY:
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func zoomAndCenterViewAnimated(
         scaleX: CGFloat,
         scaleY: CGFloat,
@@ -1126,16 +1126,16 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         zoomAndCenterViewAnimated(scaleX: scaleX, scaleY: scaleY, xValue: xValue, yValue: yValue, axis: axis, duration: duration, easing: easingFunctionFromOption(easingOption))
     }
-    
-    /// Zooms by the specified scale factor to the specified values on the specified axis.
-    ///
-    /// - parameter scaleX:
-    /// - parameter scaleY:
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // Zooms by the specified scale factor to the specified values on the specified axis.
+    //
+    // - parameter scaleX:
+    // - parameter scaleY:
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func zoomAndCenterViewAnimated(
         scaleX: CGFloat,
         scaleY: CGFloat,
@@ -1146,57 +1146,57 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         zoomAndCenterViewAnimated(scaleX: scaleX, scaleY: scaleY, xValue: xValue, yValue: yValue, axis: axis, duration: duration, easingOption: .easeInOutSine)
     }
-    
-    /// Resets all zooming and dragging and makes the chart fit exactly it's bounds.
+
+    // Resets all zooming and dragging and makes the chart fit exactly it's bounds.
     open func fitScreen()
     {
         let matrix = _viewPortHandler.fitScreen()
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
-        
+
         calculateOffsets()
         setNeedsDisplay()
     }
-    
-    /// Sets the minimum scale value to which can be zoomed out. 1 = fitScreen
+
+    // Sets the minimum scale value to which can be zoomed out. 1 = fitScreen
     open func setScaleMinima(_ scaleX: CGFloat, scaleY: CGFloat)
     {
         _viewPortHandler.setMinimumScaleX(scaleX)
         _viewPortHandler.setMinimumScaleY(scaleY)
     }
-    
+
     open var visibleXRange: Double
     {
         return abs(highestVisibleX - lowestVisibleX)
     }
-    
-    /// Sets the size of the area (range on the x-axis) that should be maximum visible at once (no further zooming out allowed).
-    ///
-    /// If this is e.g. set to 10, no more than a range of 10 values on the x-axis can be viewed at once without scrolling.
-    ///
-    /// If you call this method, chart must have data or it has no effect.
+
+    // Sets the size of the area (range on the x-axis) that should be maximum visible at once (no further zooming out allowed).
+    //
+    // If this is e.g. set to 10, no more than a range of 10 values on the x-axis can be viewed at once without scrolling.
+    //
+    // If you call this method, chart must have data or it has no effect.
     open func setVisibleXRangeMaximum(_ maxXRange: Double)
     {
         let xScale = _xAxis.axisRange / maxXRange
         _viewPortHandler.setMinimumScaleX(CGFloat(xScale))
     }
-    
-    /// Sets the size of the area (range on the x-axis) that should be minimum visible at once (no further zooming in allowed).
-    ///
-    /// If this is e.g. set to 10, no less than a range of 10 values on the x-axis can be viewed at once without scrolling.
-    ///
-    /// If you call this method, chart must have data or it has no effect.
+
+    // Sets the size of the area (range on the x-axis) that should be minimum visible at once (no further zooming in allowed).
+    //
+    // If this is e.g. set to 10, no less than a range of 10 values on the x-axis can be viewed at once without scrolling.
+    //
+    // If you call this method, chart must have data or it has no effect.
     open func setVisibleXRangeMinimum(_ minXRange: Double)
     {
         let xScale = _xAxis.axisRange / minXRange
         _viewPortHandler.setMaximumScaleX(CGFloat(xScale))
     }
 
-    /// Limits the maximum and minimum value count that can be visible by pinching and zooming.
-    ///
-    /// e.g. minRange=10, maxRange=100 no less than 10 values and no more that 100 values can be viewed
-    /// at once without scrolling.
-    ///
-    /// If you call this method, chart must have data or it has no effect.
+    // Limits the maximum and minimum value count that can be visible by pinching and zooming.
+    //
+    // e.g. minRange=10, maxRange=100 no less than 10 values and no more that 100 values can be viewed
+    // at once without scrolling.
+    //
+    // If you call this method, chart must have data or it has no effect.
     open func setVisibleXRange(minXRange: Double, maxXRange: Double)
     {
         let minScale = _xAxis.axisRange / maxXRange
@@ -1205,41 +1205,41 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             minScaleX: CGFloat(minScale),
             maxScaleX: CGFloat(maxScale))
     }
-    
-    /// Sets the size of the area (range on the y-axis) that should be maximum visible at once.
-    ///
-    /// - parameter yRange:
-    /// - parameter axis: - the axis for which this limit should apply
+
+    // Sets the size of the area (range on the y-axis) that should be maximum visible at once.
+    //
+    // - parameter yRange:
+    // - parameter axis: - the axis for which this limit should apply
     open func setVisibleYRangeMaximum(_ maxYRange: Double, axis: YAxis.AxisDependency)
     {
         let yScale = getAxisRange(axis: axis) / maxYRange
         _viewPortHandler.setMinimumScaleY(CGFloat(yScale))
     }
-    
-    /// Sets the size of the area (range on the y-axis) that should be minimum visible at once, no further zooming in possible.
-    ///
-    /// - parameter yRange:
-    /// - parameter axis: - the axis for which this limit should apply
+
+    // Sets the size of the area (range on the y-axis) that should be minimum visible at once, no further zooming in possible.
+    //
+    // - parameter yRange:
+    // - parameter axis: - the axis for which this limit should apply
     open func setVisibleYRangeMinimum(_ minYRange: Double, axis: YAxis.AxisDependency)
     {
         let yScale = getAxisRange(axis: axis) / minYRange
         _viewPortHandler.setMaximumScaleY(CGFloat(yScale))
     }
 
-    /// Limits the maximum and minimum y range that can be visible by pinching and zooming.
-    ///
-    /// - parameter minYRange:
-    /// - parameter maxYRange:
-    /// - parameter axis:
+    // Limits the maximum and minimum y range that can be visible by pinching and zooming.
+    //
+    // - parameter minYRange:
+    // - parameter maxYRange:
+    // - parameter axis:
     open func setVisibleYRange(minYRange: Double, maxYRange: Double, axis: YAxis.AxisDependency)
     {
         let minScale = getAxisRange(axis: axis) / minYRange
         let maxScale = getAxisRange(axis: axis) / maxYRange
         _viewPortHandler.setMinMaxScaleY(minScaleY: CGFloat(minScale), maxScaleY: CGFloat(maxScale))
     }
-    
-    /// Moves the left side of the current viewport to the specified x-value.
-    /// This also refreshes the chart by calling setNeedsDisplay().
+
+    // Moves the left side of the current viewport to the specified x-value.
+    // This also refreshes the chart by calling setNeedsDisplay().
     open func moveViewToX(_ xValue: Double)
     {
         let job = MoveViewJob(
@@ -1248,57 +1248,57 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             yValue: 0.0,
             transformer: getTransformer(forAxis: .left),
             view: self)
-        
+
         addViewportJob(job)
     }
 
-    /// Centers the viewport to the specified y-value on the y-axis.
-    /// This also refreshes the chart by calling setNeedsDisplay().
-    /// 
-    /// - parameter yValue:
-    /// - parameter axis: - which axis should be used as a reference for the y-axis
+    // Centers the viewport to the specified y-value on the y-axis.
+    // This also refreshes the chart by calling setNeedsDisplay().
+    //
+    // - parameter yValue:
+    // - parameter axis: - which axis should be used as a reference for the y-axis
     open func moveViewToY(_ yValue: Double, axis: YAxis.AxisDependency)
     {
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
-        
+
         let job = MoveViewJob(
             viewPortHandler: viewPortHandler,
             xValue: 0.0,
             yValue: yValue + yInView / 2.0,
             transformer: getTransformer(forAxis: axis),
             view: self)
-        
+
         addViewportJob(job)
     }
 
-    /// This will move the left side of the current viewport to the specified x-value on the x-axis, and center the viewport to the specified y-value on the y-axis.
-    /// This also refreshes the chart by calling setNeedsDisplay().
-    /// 
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: - which axis should be used as a reference for the y-axis
+    // This will move the left side of the current viewport to the specified x-value on the x-axis, and center the viewport to the specified y-value on the y-axis.
+    // This also refreshes the chart by calling setNeedsDisplay().
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: - which axis should be used as a reference for the y-axis
     open func moveViewTo(xValue: Double, yValue: Double, axis: YAxis.AxisDependency)
     {
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
-        
+
         let job = MoveViewJob(
             viewPortHandler: viewPortHandler,
             xValue: xValue,
             yValue: yValue + yInView / 2.0,
             transformer: getTransformer(forAxis: axis),
             view: self)
-        
+
         addViewportJob(job)
     }
-    
-    /// This will move the left side of the current viewport to the specified x-position and center the viewport to the specified y-position animated.
-    /// This also refreshes the chart by calling setNeedsDisplay().
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // This will move the left side of the current viewport to the specified x-position and center the viewport to the specified y-position animated.
+    // This also refreshes the chart by calling setNeedsDisplay().
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func moveViewToAnimated(
         xValue: Double,
         yValue: Double,
@@ -1309,9 +1309,9 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         let bounds = valueForTouchPoint(
             point: CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop),
             axis: axis)
-        
+
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
-        
+
         let job = AnimatedMoveViewJob(
             viewPortHandler: viewPortHandler,
             xValue: xValue,
@@ -1322,18 +1322,18 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             yOrigin: bounds.y,
             duration: duration,
             easing: easing)
-        
+
         addViewportJob(job)
     }
-    
-    /// This will move the left side of the current viewport to the specified x-position and center the viewport to the specified y-position animated.
-    /// This also refreshes the chart by calling setNeedsDisplay().
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // This will move the left side of the current viewport to the specified x-position and center the viewport to the specified y-position animated.
+    // This also refreshes the chart by calling setNeedsDisplay().
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func moveViewToAnimated(
         xValue: Double,
         yValue: Double,
@@ -1343,15 +1343,15 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         moveViewToAnimated(xValue: xValue, yValue: yValue, axis: axis, duration: duration, easing: easingFunctionFromOption(easingOption))
     }
-    
-    /// This will move the left side of the current viewport to the specified x-position and center the viewport to the specified y-position animated.
-    /// This also refreshes the chart by calling setNeedsDisplay().
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // This will move the left side of the current viewport to the specified x-position and center the viewport to the specified y-position animated.
+    // This also refreshes the chart by calling setNeedsDisplay().
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func moveViewToAnimated(
         xValue: Double,
         yValue: Double,
@@ -1360,13 +1360,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         moveViewToAnimated(xValue: xValue, yValue: yValue, axis: axis, duration: duration, easingOption: .easeInOutSine)
     }
-    
-    /// This will move the center of the current viewport to the specified x-value and y-value.
-    /// This also refreshes the chart by calling setNeedsDisplay().
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: - which axis should be used as a reference for the y-axis
+
+    // This will move the center of the current viewport to the specified x-value and y-value.
+    // This also refreshes the chart by calling setNeedsDisplay().
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: - which axis should be used as a reference for the y-axis
     open func centerViewTo(
         xValue: Double,
         yValue: Double,
@@ -1374,24 +1374,24 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
         let xInView = xAxis.axisRange / Double(_viewPortHandler.scaleX)
-        
+
         let job = MoveViewJob(
             viewPortHandler: viewPortHandler,
             xValue: xValue - xInView / 2.0,
             yValue: yValue + yInView / 2.0,
             transformer: getTransformer(forAxis: axis),
             view: self)
-        
+
         addViewportJob(job)
     }
-    
-    /// This will move the center of the current viewport to the specified x-value and y-value animated.
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // This will move the center of the current viewport to the specified x-value and y-value animated.
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func centerViewToAnimated(
         xValue: Double,
         yValue: Double,
@@ -1402,10 +1402,10 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         let bounds = valueForTouchPoint(
             point: CGPoint(x: viewPortHandler.contentLeft, y: viewPortHandler.contentTop),
             axis: axis)
-        
+
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
         let xInView = xAxis.axisRange / Double(_viewPortHandler.scaleX)
-        
+
         let job = AnimatedMoveViewJob(
             viewPortHandler: viewPortHandler,
             xValue: xValue - xInView / 2.0,
@@ -1416,17 +1416,17 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             yOrigin: bounds.y,
             duration: duration,
             easing: easing)
-        
+
         addViewportJob(job)
     }
-    
-    /// This will move the center of the current viewport to the specified x-value and y-value animated.
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // This will move the center of the current viewport to the specified x-value and y-value animated.
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func centerViewToAnimated(
         xValue: Double,
         yValue: Double,
@@ -1436,14 +1436,14 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         centerViewToAnimated(xValue: xValue, yValue: yValue, axis: axis, duration: duration, easing: easingFunctionFromOption(easingOption))
     }
-    
-    /// This will move the center of the current viewport to the specified x-value and y-value animated.
-    ///
-    /// - parameter xValue:
-    /// - parameter yValue:
-    /// - parameter axis: which axis should be used as a reference for the y-axis
-    /// - parameter duration: the duration of the animation in seconds
-    /// - parameter easing:
+
+    // This will move the center of the current viewport to the specified x-value and y-value animated.
+    //
+    // - parameter xValue:
+    // - parameter yValue:
+    // - parameter axis: which axis should be used as a reference for the y-axis
+    // - parameter duration: the duration of the animation in seconds
+    // - parameter easing:
     open func centerViewToAnimated(
         xValue: Double,
         yValue: Double,
@@ -1453,12 +1453,12 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         centerViewToAnimated(xValue: xValue, yValue: yValue, axis: axis, duration: duration, easingOption: .easeInOutSine)
     }
 
-    /// Sets custom offsets for the current `ChartViewPort` (the offsets on the sides of the actual chart window). Setting this will prevent the chart from automatically calculating it's offsets. Use `resetViewPortOffsets()` to undo this.
-    /// ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING, else use `setExtraOffsets(...)`.
+    // Sets custom offsets for the current `ChartViewPort` (the offsets on the sides of the actual chart window). Setting this will prevent the chart from automatically calculating it's offsets. Use `resetViewPortOffsets()` to undo this.
+    // ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING, else use `setExtraOffsets(...)`.
     open func setViewPortOffsets(left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         _customViewPortEnabled = true
-        
+
         if Thread.isMainThread
         {
             self._viewPortHandler.restrainViewPort(offsetLeft: left, offsetTop: top, offsetRight: right, offsetBottom: bottom)
@@ -1473,7 +1473,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
 
-    /// Resets all custom offsets set via `setViewPortOffsets(...)` method. Allows the chart to again calculate all offsets automatically.
+    // Resets all custom offsets set via `setViewPortOffsets(...)` method. Allows the chart to again calculate all offsets automatically.
     open func resetViewPortOffsets()
     {
         _customViewPortEnabled = false
@@ -1481,8 +1481,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     // MARK: - Accessors
-    
-    /// - returns: The range of the specified axis.
+
+    // - returns: The range of the specified axis.
     open func getAxisRange(axis: YAxis.AxisDependency) -> Double
     {
         if axis == .left
@@ -1495,7 +1495,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
 
-    /// - returns: The position (in pixels) the provided Entry has inside the chart view
+    // - returns: The position (in pixels) the provided Entry has inside the chart view
     open func getPosition(entry e: ChartDataEntry, axis: YAxis.AxisDependency) -> CGPoint
     {
         var vals = CGPoint(x: CGFloat(e.x), y: CGFloat(e.y))
@@ -1505,7 +1505,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         return vals
     }
 
-    /// is dragging enabled? (moving the chart with the finger) for the chart (this does not affect scaling).
+    // is dragging enabled? (moving the chart with the finger) for the chart (this does not affect scaling).
     open var dragEnabled: Bool
     {
         get
@@ -1520,14 +1520,14 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         }
     }
-    
-    /// is dragging enabled? (moving the chart with the finger) for the chart (this does not affect scaling).
+
+    // is dragging enabled? (moving the chart with the finger) for the chart (this does not affect scaling).
     open var isDragEnabled: Bool
     {
         return dragEnabled
     }
-    
-    /// is scaling enabled? (zooming in and out by gesture) for the chart (this does not affect dragging).
+
+    // is scaling enabled? (zooming in and out by gesture) for the chart (this does not affect dragging).
     open func setScaleEnabled(_ enabled: Bool)
     {
         if _scaleXEnabled != enabled || _scaleYEnabled != enabled
@@ -1539,7 +1539,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             #endif
         }
     }
-    
+
     open var scaleXEnabled: Bool
     {
         get
@@ -1557,7 +1557,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         }
     }
-    
+
     open var scaleYEnabled: Bool
     {
         get
@@ -1575,11 +1575,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         }
     }
-    
+
     open var isScaleXEnabled: Bool { return scaleXEnabled }
     open var isScaleYEnabled: Bool { return scaleYEnabled }
-    
-    /// flag that indicates if double tap zoom is enabled or not
+
+    // flag that indicates if double tap zoom is enabled or not
     open var doubleTapToZoomEnabled: Bool
     {
         get
@@ -1595,57 +1595,57 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         }
     }
-    
-    /// **default**: true
-    /// - returns: `true` if zooming via double-tap is enabled `false` ifnot.
+
+    // **default**: true
+    // - returns: `true` if zooming via double-tap is enabled `false` ifnot.
     open var isDoubleTapToZoomEnabled: Bool
     {
         return doubleTapToZoomEnabled
     }
-    
-    /// flag that indicates if highlighting per dragging over a fully zoomed out chart is enabled
+
+    // flag that indicates if highlighting per dragging over a fully zoomed out chart is enabled
     open var highlightPerDragEnabled = true
-    
-    /// If set to true, highlighting per dragging over a fully zoomed out chart is enabled
-    /// You might want to disable this when using inside a `NSUIScrollView`
-    /// 
-    /// **default**: true
+
+    // If set to true, highlighting per dragging over a fully zoomed out chart is enabled
+    // You might want to disable this when using inside a `NSUIScrollView`
+    //
+    // **default**: true
     open var isHighlightPerDragEnabled: Bool
     {
         return highlightPerDragEnabled
     }
-    
-    /// **default**: true
-    /// - returns: `true` if drawing the grid background is enabled, `false` ifnot.
+
+    // **default**: true
+    // - returns: `true` if drawing the grid background is enabled, `false` ifnot.
     open var isDrawGridBackgroundEnabled: Bool
     {
         return drawGridBackgroundEnabled
     }
-    
-    /// **default**: false
-    /// - returns: `true` if drawing the borders rectangle is enabled, `false` ifnot.
+
+    // **default**: false
+    // - returns: `true` if drawing the borders rectangle is enabled, `false` ifnot.
     open var isDrawBordersEnabled: Bool
     {
         return drawBordersEnabled
     }
 
-    /// - returns: The x and y values in the chart at the given touch point
-    /// (encapsulated in a `CGPoint`). This method transforms pixel coordinates to
-    /// coordinates / values in the chart. This is the opposite method to
-    /// `getPixelsForValues(...)`.
+    // - returns: The x and y values in the chart at the given touch point
+    // (encapsulated in a `CGPoint`). This method transforms pixel coordinates to
+    // coordinates / values in the chart. This is the opposite method to
+    // `getPixelsForValues(...)`.
     open func valueForTouchPoint(point pt: CGPoint, axis: YAxis.AxisDependency) -> CGPoint
     {
         return getTransformer(forAxis: axis).valueForTouchPoint(pt)
     }
 
-    /// Transforms the given chart values into pixels. This is the opposite
-    /// method to `valueForTouchPoint(...)`.
+    // Transforms the given chart values into pixels. This is the opposite
+    // method to `valueForTouchPoint(...)`.
     open func pixelForValues(x: Double, y: Double, axis: YAxis.AxisDependency) -> CGPoint
     {
         return getTransformer(forAxis: axis).pixelForValues(x: x, y: y)
     }
-    
-    /// - returns: The Entry object displayed at the touched position of the chart
+
+    // - returns: The Entry object displayed at the touched position of the chart
     open func getEntryByTouchPoint(point pt: CGPoint) -> ChartDataEntry!
     {
         if let h = getHighlightByTouchPoint(pt)
@@ -1654,8 +1654,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
         return nil
     }
-    
-    /// - returns: The DataSet object displayed at the touched position of the chart
+
+    // - returns: The DataSet object displayed at the touched position of the chart
     open func getDataSetByTouchPoint(point pt: CGPoint) -> IBarLineScatterCandleBubbleChartDataSet!
     {
         let h = getHighlightByTouchPoint(pt)
@@ -1666,7 +1666,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         return nil
     }
 
-    /// - returns: The current x-scale factor
+    // - returns: The current x-scale factor
     open var scaleX: CGFloat
     {
         if _viewPortHandler === nil
@@ -1676,7 +1676,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         return _viewPortHandler.scaleX
     }
 
-    /// - returns: The current y-scale factor
+    // - returns: The current y-scale factor
     open var scaleY: CGFloat
     {
         if _viewPortHandler === nil
@@ -1686,22 +1686,22 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         return _viewPortHandler.scaleY
     }
 
-    /// if the chart is fully zoomed out, return true
+    // if the chart is fully zoomed out, return true
     open var isFullyZoomedOut: Bool { return _viewPortHandler.isFullyZoomedOut }
 
-    /// - returns: The left y-axis object. In the horizontal bar-chart, this is the
-    /// top axis.
+    // - returns: The left y-axis object. In the horizontal bar-chart, this is the
+    // top axis.
     open var leftAxis: YAxis
     {
         return _leftAxis
     }
 
-    /// - returns: The right y-axis object. In the horizontal bar-chart, this is the
-    /// bottom axis.
+    // - returns: The right y-axis object. In the horizontal bar-chart, this is the
+    // bottom axis.
     open var rightAxis: YAxis { return _rightAxis }
 
-    /// - returns: The y-axis object to the corresponding AxisDependency. In the
-    /// horizontal bar-chart, LEFT == top, RIGHT == BOTTOM
+    // - returns: The y-axis object to the corresponding AxisDependency. In the
+    // horizontal bar-chart, LEFT == top, RIGHT == BOTTOM
     open func getAxis(_ axis: YAxis.AxisDependency) -> YAxis
     {
         if axis == .left
@@ -1713,8 +1713,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             return _rightAxis
         }
     }
-    
-    /// flag that indicates if pinch-zoom is enabled. if true, both x and y axis can be scaled simultaneously with 2 fingers, if false, x and y axis can be scaled separately
+
+    // flag that indicates if pinch-zoom is enabled. if true, both x and y axis can be scaled simultaneously with 2 fingers, if false, x and y axis can be scaled separately
     open var pinchZoomEnabled: Bool
     {
         get
@@ -1733,54 +1733,54 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
 
-    /// **default**: false
-    /// - returns: `true` if pinch-zoom is enabled, `false` ifnot
+    // **default**: false
+    // - returns: `true` if pinch-zoom is enabled, `false` ifnot
     open var isPinchZoomEnabled: Bool { return pinchZoomEnabled }
 
-    /// Set an offset in dp that allows the user to drag the chart over it's
-    /// bounds on the x-axis.
+    // Set an offset in dp that allows the user to drag the chart over it's
+    // bounds on the x-axis.
     open func setDragOffsetX(_ offset: CGFloat)
     {
         _viewPortHandler.setDragOffsetX(offset)
     }
 
-    /// Set an offset in dp that allows the user to drag the chart over it's
-    /// bounds on the y-axis.
+    // Set an offset in dp that allows the user to drag the chart over it's
+    // bounds on the y-axis.
     open func setDragOffsetY(_ offset: CGFloat)
     {
         _viewPortHandler.setDragOffsetY(offset)
     }
 
-    /// - returns: `true` if both drag offsets (x and y) are zero or smaller.
+    // - returns: `true` if both drag offsets (x and y) are zero or smaller.
     open var hasNoDragOffset: Bool { return _viewPortHandler.hasNoDragOffset }
 
-    /// The X axis renderer. This is a read-write property so you can set your own custom renderer here.
-    /// **default**: An instance of XAxisRenderer
-    /// - returns: The current set X axis renderer
+    // The X axis renderer. This is a read-write property so you can set your own custom renderer here.
+    // **default**: An instance of XAxisRenderer
+    // - returns: The current set X axis renderer
     open var xAxisRenderer: XAxisRenderer
     {
         get { return _xAxisRenderer }
         set { _xAxisRenderer = newValue }
     }
-    
-    /// The left Y axis renderer. This is a read-write property so you can set your own custom renderer here.
-    /// **default**: An instance of YAxisRenderer
-    /// - returns: The current set left Y axis renderer
+
+    // The left Y axis renderer. This is a read-write property so you can set your own custom renderer here.
+    // **default**: An instance of YAxisRenderer
+    // - returns: The current set left Y axis renderer
     open var leftYAxisRenderer: YAxisRenderer
     {
         get { return _leftYAxisRenderer }
         set { _leftYAxisRenderer = newValue }
     }
-    
-    /// The right Y axis renderer. This is a read-write property so you can set your own custom renderer here.
-    /// **default**: An instance of YAxisRenderer
-    /// - returns: The current set right Y axis renderer
+
+    // The right Y axis renderer. This is a read-write property so you can set your own custom renderer here.
+    // **default**: An instance of YAxisRenderer
+    // - returns: The current set right Y axis renderer
     open var rightYAxisRenderer: YAxisRenderer
     {
         get { return _rightYAxisRenderer }
         set { _rightYAxisRenderer = newValue }
     }
-    
+
     open override var chartYMax: Double
     {
         return max(leftAxis._axisMaximum, rightAxis._axisMaximum)
@@ -1790,26 +1790,26 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         return min(leftAxis._axisMinimum, rightAxis._axisMinimum)
     }
-    
-    /// - returns: `true` if either the left or the right or both axes are inverted.
+
+    // - returns: `true` if either the left or the right or both axes are inverted.
     open var isAnyAxisInverted: Bool
     {
         return _leftAxis.isInverted || _rightAxis.isInverted
     }
-    
-    /// flag that indicates if auto scaling on the y axis is enabled.
-    /// if yes, the y axis automatically adjusts to the min and max y values of the current x axis range whenever the viewport changes
+
+    // flag that indicates if auto scaling on the y axis is enabled.
+    // if yes, the y axis automatically adjusts to the min and max y values of the current x axis range whenever the viewport changes
     open var autoScaleMinMaxEnabled: Bool
     {
         get { return _autoScaleMinMaxEnabled }
         set { _autoScaleMinMaxEnabled = newValue }
     }
-    
-    /// **default**: false
-    /// - returns: `true` if auto scaling on the y axis is enabled.
+
+    // **default**: false
+    // - returns: `true` if auto scaling on the y axis is enabled.
     open var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled }
-    
-    /// Sets a minimum width to the specified y axis.
+
+    // Sets a minimum width to the specified y axis.
     open func setYAxisMinWidth(_ axis: YAxis.AxisDependency, width: CGFloat)
     {
         if axis == .left
@@ -1821,9 +1821,9 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             _rightAxis.minWidth = width
         }
     }
-    
-    /// **default**: 0.0
-    /// - returns: The (custom) minimum width of the specified Y axis.
+
+    // **default**: 0.0
+    // - returns: The (custom) minimum width of the specified Y axis.
     open func getYAxisMinWidth(_ axis: YAxis.AxisDependency) -> CGFloat
     {
         if axis == .left
@@ -1835,8 +1835,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             return _rightAxis.minWidth
         }
     }
-    /// Sets a maximum width to the specified y axis.
-    /// Zero (0.0) means there's no maximum width
+    // Sets a maximum width to the specified y axis.
+    // Zero (0.0) means there's no maximum width
     open func setYAxisMaxWidth(_ axis: YAxis.AxisDependency, width: CGFloat)
     {
         if axis == .left
@@ -1848,11 +1848,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             _rightAxis.maxWidth = width
         }
     }
-    
-    /// Zero (0.0) means there's no maximum width
-    ///
-    /// **default**: 0.0 (no maximum specified)
-    /// - returns: The (custom) maximum width of the specified Y axis.
+
+    // Zero (0.0) means there's no maximum width
+    //
+    // **default**: 0.0 (no maximum specified)
+    // - returns: The (custom) maximum width of the specified Y axis.
     open func getYAxisMaxWidth(_ axis: YAxis.AxisDependency) -> CGFloat
     {
         if axis == .left
@@ -1865,7 +1865,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
 
-    /// - returns the width of the specified y axis.
+    // - returns the width of the specified y axis.
     open func getYAxisWidth(_ axis: YAxis.AxisDependency) -> CGFloat
     {
         if axis == .left
@@ -1877,12 +1877,12 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             return _rightAxis.requiredSize().width
         }
     }
-    
+
     // MARK: - BarLineScatterCandleBubbleChartDataProvider
-    
-    /// - returns: The Transformer class that contains all matrices and is
-    /// responsible for transforming values into pixels on the screen and
-    /// backwards.
+
+    // - returns: The Transformer class that contains all matrices and is
+    // responsible for transforming values into pixels on the screen and
+    // backwards.
     open func getTransformer(forAxis axis: YAxis.AxisDependency) -> Transformer
     {
         if axis == .left
@@ -1894,8 +1894,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             return _rightAxisTransformer
         }
     }
-    
-    /// the number of maximum visible drawn values on the chart only active when `drawValuesEnabled` is enabled
+
+    // the number of maximum visible drawn values on the chart only active when `drawValuesEnabled` is enabled
     open override var maxVisibleCount: Int
     {
         get
@@ -1907,31 +1907,31 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             _maxVisibleCount = newValue
         }
     }
-    
+
     open func isInverted(axis: YAxis.AxisDependency) -> Bool
     {
         return getAxis(axis).isInverted
     }
-    
-    /// - returns: The lowest x-index (value on the x-axis) that is still visible on he chart.
+
+    // - returns: The lowest x-index (value on the x-axis) that is still visible on he chart.
     open var lowestVisibleX: Double
     {
         var pt = CGPoint(
             x: viewPortHandler.contentLeft,
             y: viewPortHandler.contentBottom)
-        
+
         getTransformer(forAxis: .left).pixelToValues(&pt)
-        
+
         return max(xAxis._axisMinimum, Double(pt.x))
     }
-    
-    /// - returns: The highest x-index (value on the x-axis) that is still visible on the chart.
+
+    // - returns: The highest x-index (value on the x-axis) that is still visible on the chart.
     open var highestVisibleX: Double
     {
         var pt = CGPoint(
             x: viewPortHandler.contentRight,
             y: viewPortHandler.contentBottom)
-        
+
         getTransformer(forAxis: .left).pixelToValues(&pt)
 
         return min(xAxis._axisMaximum, Double(pt.x))

--- a/Source/Charts/Charts/CandleStickChartView.swift
+++ b/Source/Charts/Charts/CandleStickChartView.swift
@@ -12,21 +12,21 @@
 import Foundation
 import CoreGraphics
 
-/// Financial chart type that draws candle-sticks.
+// Financial chart type that draws candle-sticks.
 open class CandleStickChartView: BarLineChartViewBase, CandleChartDataProvider
 {
     internal override func initialize()
     {
         super.initialize()
-        
+
         renderer = CandleStickChartRenderer(dataProvider: self, animator: _animator, viewPortHandler: _viewPortHandler)
-        
+
         self.xAxis.spaceMin = 0.5
         self.xAxis.spaceMax = 0.5
     }
-    
+
     // MARK: - CandleChartDataProvider
-    
+
     open var candleData: CandleChartData?
     {
         return _data as? CandleChartData

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -20,17 +20,17 @@ import CoreGraphics
 @objc
 public protocol ChartViewDelegate
 {
-    /// Called when a value has been selected inside the chart.
-    /// - parameter entry: The selected Entry.
-    /// - parameter highlight: The corresponding highlight object that contains information about the highlighted position such as dataSetIndex etc.
+    // Called when a value has been selected inside the chart.
+    // - parameter entry: The selected Entry.
+    // - parameter highlight: The corresponding highlight object that contains information about the highlighted position such as dataSetIndex etc.
     @objc optional func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight)
-    
+
     // Called when nothing has been selected or an "un-select" has been made.
     @objc optional func chartValueNothingSelected(_ chartView: ChartViewBase)
-    
+
     // Callbacks when the chart is scaled / zoomed via pinch zoom gesture.
     @objc optional func chartScaled(_ chartView: ChartViewBase, scaleX: CGFloat, scaleY: CGFloat)
-    
+
     // Callbacks when the chart is moved / translated via drag gesture.
     @objc optional func chartTranslated(_ chartView: ChartViewBase, dX: CGFloat, dY: CGFloat)
 }
@@ -38,50 +38,50 @@ public protocol ChartViewDelegate
 open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
 {
     // MARK: - Properties
-    
-    /// - returns: The object representing all x-labels, this method can be used to
-    /// acquire the XAxis object and modify it (e.g. change the position of the
-    /// labels)
+
+    // - returns: The object representing all x-labels, this method can be used to
+    // acquire the XAxis object and modify it (e.g. change the position of the
+    // labels)
     open var xAxis: XAxis
     {
         return _xAxis
     }
-    
-    /// The default IValueFormatter that has been determined by the chart considering the provided minimum and maximum values.
+
+    // The default IValueFormatter that has been determined by the chart considering the provided minimum and maximum values.
     internal var _defaultValueFormatter: IValueFormatter? = DefaultValueFormatter(decimals: 0)
-    
-    /// object that holds all data that was originally set for the chart, before it was modified or any filtering algorithms had been applied
+
+    // object that holds all data that was originally set for the chart, before it was modified or any filtering algorithms had been applied
     internal var _data: ChartData?
-    
-    /// Flag that indicates if highlighting per tap (touch) is enabled
+
+    // Flag that indicates if highlighting per tap (touch) is enabled
     fileprivate var _highlightPerTapEnabled = true
-    
-    /// If set to true, chart continues to scroll after touch up
+
+    // If set to true, chart continues to scroll after touch up
     open var dragDecelerationEnabled = true
-    
-    /// Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
-    /// 1 is an invalid value, and will be converted to 0.999 automatically.
+
+    // Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
+    // 1 is an invalid value, and will be converted to 0.999 automatically.
     fileprivate var _dragDecelerationFrictionCoef: CGFloat = 0.9
-    
-    /// if true, units are drawn next to the values in the chart
+
+    // if true, units are drawn next to the values in the chart
     internal var _drawUnitInChart = false
-    
-    /// The object representing the labels on the x-axis
+
+    // The object representing the labels on the x-axis
     internal var _xAxis: XAxis!
-    
-    /// The `Description` object of the chart.
-    /// This should have been called just "description", but
+
+    // The `Description` object of the chart.
+    // This should have been called just "description", but
     open var chartDescription: Description?
-    
-    /// This property is deprecated - Use `chartDescription.text` instead.
+
+    // This property is deprecated - Use `chartDescription.text` instead.
     @available(*, deprecated: 1.0, message: "Use `chartDescription.text` instead.")
     open var descriptionText: String
     {
         get { return chartDescription?.text ?? "" }
         set { chartDescription?.text = newValue }
     }
-    
-    /// This property is deprecated - Use `chartDescription.font` instead.
+
+    // This property is deprecated - Use `chartDescription.font` instead.
     @available(*, deprecated: 1.0, message: "Use `chartDescription.font` instead.")
     open var descriptionFont: NSUIFont?
     {
@@ -94,8 +94,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             }
         }
     }
-    
-    /// This property is deprecated - Use `chartDescription.textColor` instead.
+
+    // This property is deprecated - Use `chartDescription.textColor` instead.
     @available(*, deprecated: 1.0, message: "Use `chartDescription.textColor` instead.")
     open var descriptionTextColor: NSUIColor?
     {
@@ -108,82 +108,82 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             }
         }
     }
-    
-    /// This property is deprecated - Use `chartDescription.textAlign` instead.
+
+    // This property is deprecated - Use `chartDescription.textAlign` instead.
     @available(*, deprecated: 1.0, message: "Use `chartDescription.textAlign` instead.")
     open var descriptionTextAlign: NSTextAlignment
     {
         get { return chartDescription?.textAlign ?? NSTextAlignment.right }
         set { chartDescription?.textAlign = newValue }
     }
-    
-    /// This property is deprecated - Use `chartDescription.position` instead.
+
+    // This property is deprecated - Use `chartDescription.position` instead.
     @available(*, deprecated: 1.0, message: "Use `chartDescription.position` instead.")
     open var descriptionTextPosition: CGPoint?
     {
         get { return chartDescription?.position }
         set { chartDescription?.position = newValue }
     }
-    
-    /// The legend object containing all data associated with the legend
+
+    // The legend object containing all data associated with the legend
     internal var _legend: Legend!
-    
-    /// delegate to receive chart events
+
+    // delegate to receive chart events
     open weak var delegate: ChartViewDelegate?
-    
-    /// text that is displayed when the chart is empty
+
+    // text that is displayed when the chart is empty
     open var noDataText = "No chart data available."
-    
-    /// Font to be used for the no data text.
+
+    // Font to be used for the no data text.
     open var noDataFont: NSUIFont! = NSUIFont(name: "HelveticaNeue", size: 12.0)
-    
-    /// color of the no data text
+
+    // color of the no data text
     open var noDataTextColor: NSUIColor = NSUIColor.black
-    
+
     internal var _legendRenderer: LegendRenderer!
-    
-    /// object responsible for rendering the data
+
+    // object responsible for rendering the data
     open var renderer: DataRenderer?
-    
+
     open var highlighter: IHighlighter?
-    
-    /// object that manages the bounds and drawing constraints of the chart
+
+    // object that manages the bounds and drawing constraints of the chart
     internal var _viewPortHandler: ViewPortHandler!
-    
-    /// object responsible for animations
+
+    // object responsible for animations
     internal var _animator: Animator!
-    
-    /// flag that indicates if offsets calculation has already been done or not
+
+    // flag that indicates if offsets calculation has already been done or not
     fileprivate var _offsetsCalculated = false
-	
-    /// array of Highlight objects that reference the highlighted slices in the chart
+
+    // array of Highlight objects that reference the highlighted slices in the chart
     internal var _indicesToHighlight = [Highlight]()
-    
-    /// `true` if drawing the marker is enabled when tapping on values
-    /// (use the `marker` property to specify a marker)
+
+    // `true` if drawing the marker is enabled when tapping on values
+    // (use the `marker` property to specify a marker)
     open var drawMarkers = true
-    
-    /// - returns: `true` if drawing the marker is enabled when tapping on values
-    /// (use the `marker` property to specify a marker)
+
+    // - returns: `true` if drawing the marker is enabled when tapping on values
+    // (use the `marker` property to specify a marker)
     open var isDrawMarkersEnabled: Bool { return drawMarkers }
-    
-    /// The marker that is displayed when a value is clicked on the chart
+
+    // The marker that is displayed when a value is clicked on the chart
     open var marker: IMarker?
-    
+
     fileprivate var _interceptTouchEvents = false
-    
-    /// An extra offset to be appended to the viewport's top
+
+    // An extra offset to be appended to the viewport's top
     open var extraTopOffset: CGFloat = 0.0
-    
-    /// An extra offset to be appended to the viewport's right
+
+    // An extra offset to be appended to the viewport's right
     open var extraRightOffset: CGFloat = 0.0
-    
-    /// An extra offset to be appended to the viewport's bottom
+
+    // An extra offset to be appended to the viewport's bottom
     open var extraBottomOffset: CGFloat = 0.0
-    
-    /// An extra offset to be appended to the viewport's left
+
+    // An extra offset to be appended to the viewport's left
     open var extraLeftOffset: CGFloat = 0.0
-    
+
     open func setExtraOffsets(left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         extraLeftOffset = left
@@ -191,27 +191,27 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         extraRightOffset = right
         extraBottomOffset = bottom
     }
-    
+
     // MARK: - Initializers
-    
+
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
         initialize()
     }
-    
+
     public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
         initialize()
     }
-    
+
     deinit
     {
         self.removeObserver(self, forKeyPath: "bounds")
         self.removeObserver(self, forKeyPath: "frame")
     }
-    
+
     internal func initialize()
     {
         #if os(iOS)
@@ -223,21 +223,21 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
 
         _viewPortHandler = ViewPortHandler()
         _viewPortHandler.setChartDimens(width: bounds.size.width, height: bounds.size.height)
-        
+
         chartDescription = Description()
-        
+
         _legend = Legend()
         _legendRenderer = LegendRenderer(viewPortHandler: _viewPortHandler, legend: _legend)
-        
+
         _xAxis = XAxis()
-        
+
         self.addObserver(self, forKeyPath: "bounds", options: .new, context: nil)
         self.addObserver(self, forKeyPath: "frame", options: .new, context: nil)
     }
-    
+
     // MARK: - ChartViewBase
-    
-    /// The data for the chart
+
+    // The data for the chart
     open var data: ChartData?
     {
         get
@@ -248,15 +248,15 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         {
             _data = newValue
             _offsetsCalculated = false
-            
+
             if _data == nil
             {
                 return
             }
-            
+
             // calculate how many digits are needed
             setupDefaultFormatter(min: _data!.getYMin(), max: _data!.getYMax())
-            
+
             for set in _data!.dataSets
             {
                 if set.needsFormatter || set.valueFormatter === _defaultValueFormatter
@@ -264,31 +264,31 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                     set.valueFormatter = _defaultValueFormatter
                 }
             }
-            
+
             // let the chart know there is new data
             notifyDataSetChanged()
         }
     }
-    
-    /// Clears the chart from all data (sets it to null) and refreshes it (by calling setNeedsDisplay()).
+
+    // Clears the chart from all data (sets it to null) and refreshes it (by calling setNeedsDisplay()).
     open func clear()
     {
         _data = nil
         _offsetsCalculated = false
         _indicesToHighlight.removeAll()
 	    lastHighlighted = nil
-	
+
         setNeedsDisplay()
     }
-    
-    /// Removes all DataSets (and thereby Entries) from the chart. Does not set the data object to nil. Also refreshes the chart by calling setNeedsDisplay().
+
+    // Removes all DataSets (and thereby Entries) from the chart. Does not set the data object to nil. Also refreshes the chart by calling setNeedsDisplay().
     open func clearValues()
     {
         _data?.clearValues()
         setNeedsDisplay()
     }
 
-    /// - returns: `true` if the chart is empty (meaning it's data object is either null or contains no entries).
+    // - returns: `true` if the chart is empty (meaning it's data object is either null or contains no entries).
     open func isEmpty() -> Bool
     {
         guard let data = _data else { return true }
@@ -302,32 +302,32 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             return false
         }
     }
-    
-    /// Lets the chart know its underlying data has changed and should perform all necessary recalculations.
-    /// It is crucial that this method is called everytime data is changed dynamically. Not calling this method can lead to crashes or unexpected behaviour.
+
+    // Lets the chart know its underlying data has changed and should perform all necessary recalculations.
+    // It is crucial that this method is called everytime data is changed dynamically. Not calling this method can lead to crashes or unexpected behaviour.
     open func notifyDataSetChanged()
     {
         fatalError("notifyDataSetChanged() cannot be called on ChartViewBase")
     }
-    
-    /// Calculates the offsets of the chart to the border depending on the position of an eventual legend or depending on the length of the y-axis and x-axis labels and their position
+
+    // Calculates the offsets of the chart to the border depending on the position of an eventual legend or depending on the length of the y-axis and x-axis labels and their position
     internal func calculateOffsets()
     {
         fatalError("calculateOffsets() cannot be called on ChartViewBase")
     }
-    
-    /// calcualtes the y-min and y-max value and the y-delta and x-delta value
+
+    // calcualtes the y-min and y-max value and the y-delta and x-delta value
     internal func calcMinMax()
     {
         fatalError("calcMinMax() cannot be called on ChartViewBase")
     }
-    
-    /// calculates the required number of digits for the values that might be drawn in the chart (if enabled), and creates the default value formatter
+
+    // calculates the required number of digits for the values that might be drawn in the chart (if enabled), and creates the default value formatter
     internal func setupDefaultFormatter(min: Double, max: Double)
     {
         // check if a custom formatter is set or not
         var reference = Double(0.0)
-        
+
         if let data = _data , data.entryCount >= 2
         {
             reference = fabs(max - min)
@@ -338,30 +338,30 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             let absMax = fabs(max)
             reference = absMin > absMax ? absMin : absMax
         }
-        
-    
+
+
         if _defaultValueFormatter is DefaultValueFormatter
         {
             // setup the formatter with a new number of digits
             let digits = ChartUtils.decimals(reference)
-            
+
             (_defaultValueFormatter as? DefaultValueFormatter)?.decimals
              = digits
         }
     }
-    
+
     open override func draw(_ rect: CGRect)
     {
         let optionalContext = NSUIGraphicsGetCurrentContext()
         guard let context = optionalContext else { return }
-        
+
         let frame = self.bounds
 
         if _data === nil && noDataText.characters.count > 0
         {
             context.saveGState()
             defer { context.restoreGState() }
-            
+
             ChartUtils.drawMultilineText(
                 context: context,
                 text: noDataText,
@@ -372,18 +372,18 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 constrainedToSize: self.bounds.size,
                 anchor: CGPoint(x: 0.5, y: 0.5),
                 angleRadians: 0.0)
-            
+
             return
         }
-        
+
         if !_offsetsCalculated
         {
             calculateOffsets()
             _offsetsCalculated = true
         }
     }
-    
-    /// Draws the description text in the bottom right corner of the chart (per default)
+
+    // Draws the description text in the bottom right corner of the chart (per default)
     internal func drawDescription(context: CGContext)
     {
         // check if description should be drawn
@@ -393,7 +393,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             let descriptionText = description.text,
             descriptionText.characters.count > 0
             else { return }
-        
+
         var position = description.position
 
         // if no position specified, draw on default position
@@ -404,9 +404,9 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 x: frame.width - _viewPortHandler.offsetRight - description.xOffset,
                 y: frame.height - _viewPortHandler.offsetBottom - description.yOffset - description.font.lineHeight)
         }
-        
+
         var attrs = [String : AnyObject]()
-        
+
         attrs[NSFontAttributeName] = description.font
         attrs[NSForegroundColorAttributeName] = description.textColor
 
@@ -417,46 +417,46 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             align: description.textAlign,
             attributes: attrs)
     }
-    
+
     // MARK: - Highlighting
-    
-    /// - returns: The array of currently highlighted values. This might an empty if nothing is highlighted.
+
+    // - returns: The array of currently highlighted values. This might an empty if nothing is highlighted.
     open var highlighted: [Highlight]
     {
         return _indicesToHighlight
     }
-    
-    /// Set this to false to prevent values from being highlighted by tap gesture.
-    /// Values can still be highlighted via drag or programmatically.
-    /// **default**: true
+
+    // Set this to false to prevent values from being highlighted by tap gesture.
+    // Values can still be highlighted via drag or programmatically.
+    // **default**: true
     open var highlightPerTapEnabled: Bool
     {
         get { return _highlightPerTapEnabled }
         set { _highlightPerTapEnabled = newValue }
     }
-    
-    /// - returns: `true` if values can be highlighted via tap gesture, `false` ifnot.
+
+    // - returns: `true` if values can be highlighted via tap gesture, `false` ifnot.
     open var isHighLightPerTapEnabled: Bool
     {
         return highlightPerTapEnabled
     }
-    
-    /// Checks if the highlight array is null, has a length of zero or if the first object is null.
-    /// - returns: `true` if there are values to highlight, `false` ifthere are no values to highlight.
+
+    // Checks if the highlight array is null, has a length of zero or if the first object is null.
+    // - returns: `true` if there are values to highlight, `false` ifthere are no values to highlight.
     open func valuesToHighlight() -> Bool
     {
         return _indicesToHighlight.count > 0
     }
 
-    /// Highlights the values at the given indices in the given DataSets. Provide
-    /// null or an empty array to undo all highlighting. 
-    /// This should be used to programmatically highlight values.
-    /// This method *will not* call the delegate.
+    // Highlights the values at the given indices in the given DataSets. Provide
+    // null or an empty array to undo all highlighting.
+    // This should be used to programmatically highlight values.
+    // This method *will not* call the delegate.
     open func highlightValues(_ highs: [Highlight]?)
     {
         // set the indices to highlight
         _indicesToHighlight = highs ?? [Highlight]()
-        
+
         if _indicesToHighlight.isEmpty
         {
             self.lastHighlighted = nil
@@ -469,44 +469,44 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         // redraw the chart
         setNeedsDisplay()
     }
-    
-    /// Highlights any y-value at the given x-value in the given DataSet.
-    /// Provide -1 as the dataSetIndex to undo all highlighting.
-    /// This method will call the delegate.
-    /// - parameter x: The x-value to highlight
-    /// - parameter dataSetIndex: The dataset index to search in
+
+    // Highlights any y-value at the given x-value in the given DataSet.
+    // Provide -1 as the dataSetIndex to undo all highlighting.
+    // This method will call the delegate.
+    // - parameter x: The x-value to highlight
+    // - parameter dataSetIndex: The dataset index to search in
     open func highlightValue(x: Double, dataSetIndex: Int)
     {
         highlightValue(x: x, dataSetIndex: dataSetIndex, callDelegate: true)
     }
-    
-    /// Highlights the value at the given x-value and y-value in the given DataSet.
-    /// Provide -1 as the dataSetIndex to undo all highlighting.
-    /// This method will call the delegate.
-    /// - parameter x: The x-value to highlight
-    /// - parameter y: The y-value to highlight. Supply `NaN` for "any"
-    /// - parameter dataSetIndex: The dataset index to search in
+
+    // Highlights the value at the given x-value and y-value in the given DataSet.
+    // Provide -1 as the dataSetIndex to undo all highlighting.
+    // This method will call the delegate.
+    // - parameter x: The x-value to highlight
+    // - parameter y: The y-value to highlight. Supply `NaN` for "any"
+    // - parameter dataSetIndex: The dataset index to search in
     open func highlightValue(x: Double, y: Double, dataSetIndex: Int)
     {
         highlightValue(x: x, y: y, dataSetIndex: dataSetIndex, callDelegate: true)
     }
-    
-    /// Highlights any y-value at the given x-value in the given DataSet.
-    /// Provide -1 as the dataSetIndex to undo all highlighting.
-    /// - parameter x: The x-value to highlight
-    /// - parameter dataSetIndex: The dataset index to search in
-    /// - parameter callDelegate: Should the delegate be called for this change
+
+    // Highlights any y-value at the given x-value in the given DataSet.
+    // Provide -1 as the dataSetIndex to undo all highlighting.
+    // - parameter x: The x-value to highlight
+    // - parameter dataSetIndex: The dataset index to search in
+    // - parameter callDelegate: Should the delegate be called for this change
     open func highlightValue(x: Double, dataSetIndex: Int, callDelegate: Bool)
     {
         highlightValue(x: x, y: Double.nan, dataSetIndex: dataSetIndex, callDelegate: callDelegate)
     }
-    
-    /// Highlights the value at the given x-value and y-value in the given DataSet.
-    /// Provide -1 as the dataSetIndex to undo all highlighting.
-    /// - parameter x: The x-value to highlight
-    /// - parameter y: The y-value to highlight. Supply `NaN` for "any"
-    /// - parameter dataSetIndex: The dataset index to search in
-    /// - parameter callDelegate: Should the delegate be called for this change
+
+    // Highlights the value at the given x-value and y-value in the given DataSet.
+    // Provide -1 as the dataSetIndex to undo all highlighting.
+    // - parameter x: The x-value to highlight
+    // - parameter y: The y-value to highlight. Supply `NaN` for "any"
+    // - parameter dataSetIndex: The dataset index to search in
+    // - parameter callDelegate: Should the delegate be called for this change
     open func highlightValue(x: Double, y: Double, dataSetIndex: Int, callDelegate: Bool)
     {
         guard let data = _data else
@@ -514,7 +514,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             Swift.print("Value not highlighted because data is nil")
             return
         }
-        
+
         if dataSetIndex < 0 || dataSetIndex >= data.dataSetCount
         {
             highlightValue(nil, callDelegate: callDelegate)
@@ -524,21 +524,21 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             highlightValue(Highlight(x: x, y: y, dataSetIndex: dataSetIndex), callDelegate: callDelegate)
         }
     }
-    
-    /// Highlights the values represented by the provided Highlight object
-    /// This method *will not* call the delegate.
-    /// - parameter highlight: contains information about which entry should be highlighted
+
+    // Highlights the values represented by the provided Highlight object
+    // This method *will not* call the delegate.
+    // - parameter highlight: contains information about which entry should be highlighted
     open func highlightValue(_ highlight: Highlight?)
     {
         highlightValue(highlight, callDelegate: false)
     }
 
-    /// Highlights the value selected by touch gesture.
+    // Highlights the value selected by touch gesture.
     open func highlightValue(_ highlight: Highlight?, callDelegate: Bool)
     {
         var entry: ChartDataEntry?
         var h = highlight
-        
+
         if h == nil
         {
             _indicesToHighlight.removeAll(keepingCapacity: false)
@@ -557,7 +557,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 _indicesToHighlight = [h!]
             }
         }
-        
+
         if callDelegate && delegate != nil
         {
             if h == nil
@@ -570,14 +570,14 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 delegate!.chartValueSelected?(self, entry: entry!, highlight: h!)
             }
         }
-        
+
         // redraw the chart
         setNeedsDisplay()
     }
-    
-    /// - returns: The Highlight object (contains x-index and DataSet index) of the
-    /// selected value at the given touch point inside the Line-, Scatter-, or
-    /// CandleStick-Chart.
+
+    // - returns: The Highlight object (contains x-index and DataSet index) of the
+    // selected value at the given touch point inside the Line-, Scatter-, or
+    // CandleStick-Chart.
     open func getHighlightByTouchPoint(_ pt: CGPoint) -> Highlight?
     {
         if _data === nil
@@ -585,16 +585,16 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             Swift.print("Can't select by touch. No data set.")
             return nil
         }
-        
+
         return self.highlighter?.getHighlight(x: pt.x, y: pt.y)
     }
 
-    /// The last value that was highlighted via touch.
+    // The last value that was highlighted via touch.
     open var lastHighlighted: Highlight?
-  
+
     // MARK: - Markers
 
-    /// draws all MarkerViews on the highlighted positions
+    // draws all MarkerViews on the highlighted positions
     internal func drawMarkers(context: CGContext)
     {
         // if there is no marker view or drawing marker is disabled
@@ -603,16 +603,16 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             , isDrawMarkersEnabled &&
                 valuesToHighlight()
             else { return }
-        
+
         for i in 0 ..< _indicesToHighlight.count
         {
             let highlight = _indicesToHighlight[i]
-            
+
             guard let
                 set = data?.getDataSetByIndex(highlight.dataSetIndex),
                 let e = _data?.entryForHighlight(highlight)
                 else { continue }
-            
+
             let entryIndex = set.entryIndex(entry: e)
             if entryIndex > Int(Double(set.entryCount) * _animator.phaseX)
             {
@@ -629,263 +629,263 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
 
             // callbacks to update the content
             marker.refreshContent(entry: e, highlight: highlight)
-            
+
             // draw the marker
             marker.draw(context: context, point: pos)
         }
     }
-    
-    /// - returns: The actual position in pixels of the MarkerView for the given Entry in the given DataSet.
+
+    // - returns: The actual position in pixels of the MarkerView for the given Entry in the given DataSet.
     open func getMarkerPosition(highlight: Highlight) -> CGPoint
     {
         return CGPoint(x: highlight.drawX, y: highlight.drawY)
     }
-    
+
     // MARK: - Animation
-    
-    /// - returns: The animator responsible for animating chart values.
+
+    // - returns: The animator responsible for animating chart values.
     open var chartAnimator: Animator!
     {
         return _animator
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingX: an easing function for the animation on the x axis
-    /// - parameter easingY: an easing function for the animation on the y axis
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingX: an easing function for the animation on the x axis
+    // - parameter easingY: an easing function for the animation on the y axis
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easingX, easingY: easingY)
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingOptionX: the easing function for the animation on the x axis
-    /// - parameter easingOptionY: the easing function for the animation on the y axis
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingOptionX: the easing function for the animation on the x axis
+    // - parameter easingOptionY: the easing function for the animation on the y axis
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOptionX: easingOptionX, easingOptionY: easingOptionY)
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easing: an easing function for the animation
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easing: an easing function for the animation
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easing: easing)
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingOption: the easing function for the animation
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingOption: the easing function for the animation
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOption: easingOption)
     }
-    
-    /// Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter yAxisDuration: duration for animating the y axis
+
+    // Animates the drawing / rendering of the chart on both x- and y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter yAxisDuration: duration for animating the y axis
     open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration)
     }
-    
-    /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter easing: an easing function for the animation
+
+    // Animates the drawing / rendering of the chart the x-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter easing: an easing function for the animation
     open func animate(xAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, easing: easing)
     }
-    
-    /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
-    /// - parameter easingOption: the easing function for the animation
+
+    // Animates the drawing / rendering of the chart the x-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
+    // - parameter easingOption: the easing function for the animation
     open func animate(xAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, easingOption: easingOption)
     }
-    
-    /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter xAxisDuration: duration for animating the x axis
+
+    // Animates the drawing / rendering of the chart the x-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter xAxisDuration: duration for animating the x axis
     open func animate(xAxisDuration: TimeInterval)
     {
         _animator.animate(xAxisDuration: xAxisDuration)
     }
-    
-    /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easing: an easing function for the animation
+
+    // Animates the drawing / rendering of the chart the y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easing: an easing function for the animation
     open func animate(yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(yAxisDuration: yAxisDuration, easing: easing)
     }
-    
-    /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter yAxisDuration: duration for animating the y axis
-    /// - parameter easingOption: the easing function for the animation
+
+    // Animates the drawing / rendering of the chart the y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter yAxisDuration: duration for animating the y axis
+    // - parameter easingOption: the easing function for the animation
     open func animate(yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(yAxisDuration: yAxisDuration, easingOption: easingOption)
     }
-    
-    /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
-    /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
-    /// - parameter yAxisDuration: duration for animating the y axis
+
+    // Animates the drawing / rendering of the chart the y-axis with the specified animation time.
+    // If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
+    // - parameter yAxisDuration: duration for animating the y axis
     open func animate(yAxisDuration: TimeInterval)
     {
         _animator.animate(yAxisDuration: yAxisDuration)
     }
-    
+
     // MARK: - Accessors
 
-    /// - returns: The current y-max value across all DataSets
+    // - returns: The current y-max value across all DataSets
     open var chartYMax: Double
     {
         return _data?.yMax ?? 0.0
     }
 
-    /// - returns: The current y-min value across all DataSets
+    // - returns: The current y-min value across all DataSets
     open var chartYMin: Double
     {
         return _data?.yMin ?? 0.0
     }
-    
+
     open var chartXMax: Double
     {
         return _xAxis._axisMaximum
     }
-    
+
     open var chartXMin: Double
     {
         return _xAxis._axisMinimum
     }
-    
+
     open var xRange: Double
     {
         return _xAxis.axisRange
     }
-    
-    /// *
-    /// - note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)*
-    /// - returns: The center point of the chart (the whole View) in pixels.
+
+    // *
+    // - note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)*
+    // - returns: The center point of the chart (the whole View) in pixels.
     open var midPoint: CGPoint
     {
         let bounds = self.bounds
         return CGPoint(x: bounds.origin.x + bounds.size.width / 2.0, y: bounds.origin.y + bounds.size.height / 2.0)
     }
-    
-    /// - returns: The center of the chart taking offsets under consideration. (returns the center of the content rectangle)
+
+    // - returns: The center of the chart taking offsets under consideration. (returns the center of the content rectangle)
     open var centerOffsets: CGPoint
     {
         return _viewPortHandler.contentCenter
     }
-    
-    /// - returns: The Legend object of the chart. This method can be used to get an instance of the legend in order to customize the automatically generated Legend.
+
+    // - returns: The Legend object of the chart. This method can be used to get an instance of the legend in order to customize the automatically generated Legend.
     open var legend: Legend
     {
         return _legend
     }
-    
-    /// - returns: The renderer object responsible for rendering / drawing the Legend.
+
+    // - returns: The renderer object responsible for rendering / drawing the Legend.
     open var legendRenderer: LegendRenderer!
     {
         return _legendRenderer
     }
-    
-    /// - returns: The rectangle that defines the borders of the chart-value surface (into which the actual values are drawn).
+
+    // - returns: The rectangle that defines the borders of the chart-value surface (into which the actual values are drawn).
     open var contentRect: CGRect
     {
         return _viewPortHandler.contentRect
     }
-    
-    /// - returns: The ViewPortHandler of the chart that is responsible for the
-    /// content area of the chart and its offsets and dimensions.
+
+    // - returns: The ViewPortHandler of the chart that is responsible for the
+    // content area of the chart and its offsets and dimensions.
     open var viewPortHandler: ViewPortHandler!
     {
         return _viewPortHandler
     }
-    
-    /// - returns: The bitmap that represents the chart.
+
+    // - returns: The bitmap that represents the chart.
     open func getChartImage(transparent: Bool) -> NSUIImage?
     {
         NSUIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque || !transparent, NSUIMainScreen()?.nsuiScale ?? 1.0)
-        
+
         guard let context = NSUIGraphicsGetCurrentContext()
             else { return nil }
-        
+
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: bounds.size)
-        
+
         if isOpaque || !transparent
         {
             // Background color may be partially transparent, we must fill with white if we want to output an opaque image
             context.setFillColor(NSUIColor.white.cgColor)
             context.fill(rect)
-            
+
             if let backgroundColor = self.backgroundColor
             {
                 context.setFillColor(backgroundColor.cgColor)
                 context.fill(rect)
             }
         }
-        
+
         nsuiLayer?.render(in: context)
-        
+
         let image = NSUIGraphicsGetImageFromCurrentImageContext()
-        
+
         NSUIGraphicsEndImageContext()
-        
+
         return image
     }
-    
+
     public enum ImageFormat
     {
         case jpeg
         case png
     }
-    
-    /// Saves the current chart state with the given name to the given path on
-    /// the sdcard leaving the path empty "" will put the saved file directly on
-    /// the SD card chart is saved as a PNG image, example:
-    /// saveToPath("myfilename", "foldername1/foldername2")
-    ///
-    /// - parameter to: path to the image to save
-    /// - parameter format: the format to save
-    /// - parameter compressionQuality: compression quality for lossless formats (JPEG)
-    ///
-    /// - returns: `true` if the image was saved successfully
+
+    // Saves the current chart state with the given name to the given path on
+    // the sdcard leaving the path empty "" will put the saved file directly on
+    // the SD card chart is saved as a PNG image, example:
+    // saveToPath("myfilename", "foldername1/foldername2")
+    //
+    // - parameter to: path to the image to save
+    // - parameter format: the format to save
+    // - parameter compressionQuality: compression quality for lossless formats (JPEG)
+    //
+    // - returns: `true` if the image was saved successfully
     open func save(to path: String, format: ImageFormat, compressionQuality: Double) -> Bool
     {
 		guard let image = getChartImage(transparent: format != .jpeg)
             else { return false }
-        
+
         var imageData: Data!
         switch (format)
         {
         case .png:
             imageData = NSUIImagePNGRepresentation(image)
             break
-            
+
         case .jpeg:
             imageData = NSUIImageJPEGRepresentation(image, CGFloat(compressionQuality))
             break
         }
-        
+
         do
         {
             try imageData.write(to: URL(fileURLWithPath: path), options: .atomic)
@@ -894,36 +894,36 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         {
             return false
         }
-        
+
 		return true
     }
-    
+
     internal var _viewportJobs = [ViewPortJob]()
-    
+
     open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?)
     {
         if keyPath == "bounds" || keyPath == "frame"
         {
             let bounds = self.bounds
-            
+
             if (_viewPortHandler !== nil &&
                 (bounds.size.width != _viewPortHandler.chartWidth ||
                 bounds.size.height != _viewPortHandler.chartHeight))
             {
                 _viewPortHandler.setChartDimens(width: bounds.size.width, height: bounds.size.height)
-                
+
                 // Finish any pending viewport changes
                 while (!_viewportJobs.isEmpty)
                 {
                     let job = _viewportJobs.remove(at: 0)
                     job.doJob()
                 }
-                
+
                 notifyDataSetChanged()
             }
         }
     }
-    
+
     open func removeViewportJob(_ job: ViewPortJob)
     {
         if let index = _viewportJobs.index(where: { $0 === job })
@@ -931,12 +931,12 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             _viewportJobs.remove(at: index)
         }
     }
-    
+
     open func clearAllViewportJobs()
     {
         _viewportJobs.removeAll(keepingCapacity: false)
     }
-    
+
     open func addViewportJob(_ job: ViewPortJob)
     {
         if _viewPortHandler.hasChartDimens
@@ -948,18 +948,18 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             _viewportJobs.append(job)
         }
     }
-    
-    /// **default**: true
-    /// - returns: `true` if chart continues to scroll after touch up, `false` ifnot.
+
+    // **default**: true
+    // - returns: `true` if chart continues to scroll after touch up, `false` ifnot.
     open var isDragDecelerationEnabled: Bool
         {
             return dragDecelerationEnabled
     }
-    
-    /// Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
-    /// 1 is an invalid value, and will be converted to 0.999 automatically.
-    /// 
-    /// **default**: true
+
+    // Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
+    // 1 is an invalid value, and will be converted to 0.999 automatically.
+    //
+    // **default**: true
     open var dragDecelerationFrictionCoef: CGFloat
     {
         get
@@ -977,35 +977,35 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             {
                 val = 0.999
             }
-            
+
             _dragDecelerationFrictionCoef = val
         }
     }
-    
-    /// The maximum distance in screen pixels away from an entry causing it to highlight.
-    /// **default**: 500.0
+
+    // The maximum distance in screen pixels away from an entry causing it to highlight.
+    // **default**: 500.0
     open var maxHighlightDistance: CGFloat = 500.0
-    
-    /// the number of maximum visible drawn values on the chart only active when `drawValuesEnabled` is enabled
+
+    // the number of maximum visible drawn values on the chart only active when `drawValuesEnabled` is enabled
     open var maxVisibleCount: Int
     {
         return Int(INT_MAX)
     }
-    
+
     // MARK: - AnimatorDelegate
-    
+
     open func animatorUpdated(_ chartAnimator: Animator)
     {
         setNeedsDisplay()
     }
-    
+
     open func animatorStopped(_ chartAnimator: Animator)
     {
-        
+
     }
-    
+
     // MARK: - Touches
-    
+
     open override func nsuiTouchesBegan(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         if !_interceptTouchEvents
@@ -1013,7 +1013,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             super.nsuiTouchesBegan(touches, withEvent: event)
         }
     }
-    
+
     open override func nsuiTouchesMoved(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         if !_interceptTouchEvents
@@ -1021,7 +1021,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             super.nsuiTouchesMoved(touches, withEvent: event)
         }
     }
-    
+
     open override func nsuiTouchesEnded(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         if !_interceptTouchEvents
@@ -1029,7 +1029,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             super.nsuiTouchesEnded(touches, withEvent: event)
         }
     }
-    
+
     open override func nsuiTouchesCancelled(_ touches: Set<NSUITouch>?, withEvent event: NSUIEvent?)
     {
         if !_interceptTouchEvents

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -12,13 +12,13 @@
 import Foundation
 import CoreGraphics
 
-/// This chart class allows the combination of lines, bars, scatter and candle data all displayed in one chart area.
+// This chart class allows the combination of lines, bars, scatter and candle data all displayed in one chart area.
 open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
 {
-    /// the fill-formatter used for determining the position of the fill-line
+    // the fill-formatter used for determining the position of the fill-line
     internal var _fillFormatter: IFillFormatter!
-    
-    /// enum that allows to specify the order in which the different data objects for the combined-chart are drawn
+
+    // enum that allows to specify the order in which the different data objects for the combined-chart are drawn
     @objc(CombinedChartDrawOrder)
     public enum DrawOrder: Int
     {
@@ -28,21 +28,21 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
         case candle
         case scatter
     }
-    
+
     open override func initialize()
     {
         super.initialize()
-        
+
         self.highlighter = CombinedHighlighter(chart: self, barDataProvider: self)
-        
+
         // Old default behaviour
         self.highlightFullBarEnabled = true
-        
+
         _fillFormatter = DefaultFillFormatter()
-        
+
         renderer = CombinedChartRenderer(chart: self, animator: _animator, viewPortHandler: _viewPortHandler)
     }
-    
+
     open override var data: ChartData?
     {
         get
@@ -52,14 +52,14 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
         set
         {
             super.data = newValue
-            
+
             self.highlighter = CombinedHighlighter(chart: self, barDataProvider: self)
-            
+
             (renderer as! CombinedChartRenderer?)!.createRenderers()
             renderer?.initBuffers()
         }
     }
-    
+
     open var fillFormatter: IFillFormatter
     {
         get
@@ -75,8 +75,8 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             }
         }
     }
-    
-    /// - returns: The Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the CombinedChart.
+
+    // - returns: The Highlight object (contains x-index and DataSet index) of the selected value at the given touch point inside the CombinedChart.
     open override func getHighlightByTouchPoint(_ pt: CGPoint) -> Highlight?
     {
         if _data === nil
@@ -84,12 +84,12 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             Swift.print("Can't select by touch. No data set.")
             return nil
         }
-        
+
         guard let h = self.highlighter?.getHighlight(x: pt.x, y: pt.y)
             else { return nil }
-        
+
         if !isHighlightFullBarEnabled { return h }
-        
+
         // For isHighlightFullBarEnabled, remove stackIndex
         return Highlight(
             x: h.x, y: h.y,
@@ -99,9 +99,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             stackIndex: -1,
             axis: h.axis)
     }
-    
+
     // MARK: - CombinedChartDataProvider
-    
+
     open var combinedData: CombinedChartData?
     {
         get
@@ -109,9 +109,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             return _data as? CombinedChartData
         }
     }
-    
+
     // MARK: - LineChartDataProvider
-    
+
     open var lineData: LineChartData?
     {
         get
@@ -123,9 +123,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             return (_data as! CombinedChartData!).lineData
         }
     }
-    
+
     // MARK: - BarChartDataProvider
-    
+
     open var barData: BarChartData?
     {
         get
@@ -137,9 +137,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             return (_data as! CombinedChartData!).barData
         }
     }
-    
+
     // MARK: - ScatterChartDataProvider
-    
+
     open var scatterData: ScatterChartData?
     {
         get
@@ -151,9 +151,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             return (_data as! CombinedChartData!).scatterData
         }
     }
-    
+
     // MARK: - CandleChartDataProvider
-    
+
     open var candleData: CandleChartData?
     {
         get
@@ -165,9 +165,9 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             return (_data as! CombinedChartData!).candleData
         }
     }
-    
+
     // MARK: - BubbleChartDataProvider
-    
+
     open var bubbleData: BubbleChartData?
     {
         get
@@ -179,32 +179,32 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             return (_data as! CombinedChartData!).bubbleData
         }
     }
-    
+
     // MARK: - Accessors
-    
-    /// if set to true, all values are drawn above their bars, instead of below their top
+
+    // if set to true, all values are drawn above their bars, instead of below their top
     open var drawValueAboveBarEnabled: Bool
         {
         get { return (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled }
         set { (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled = newValue }
     }
-    
-    /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
+
+    // if set to true, a grey area is drawn behind each bar that indicates the maximum value
     open var drawBarShadowEnabled: Bool
     {
         get { return (renderer as! CombinedChartRenderer!).drawBarShadowEnabled }
         set { (renderer as! CombinedChartRenderer!).drawBarShadowEnabled = newValue }
     }
-    
-    /// - returns: `true` if drawing values above bars is enabled, `false` ifnot
+
+    // - returns: `true` if drawing values above bars is enabled, `false` ifnot
     open var isDrawValueAboveBarEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled }
-    
-    /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
+
+    // - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
     open var isDrawBarShadowEnabled: Bool { return (renderer as! CombinedChartRenderer!).drawBarShadowEnabled }
-    
-    /// the order in which the provided data objects should be drawn.
-    /// The earlier you place them in the provided array, the further they will be in the background. 
-    /// e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
+
+    // the order in which the provided data objects should be drawn.
+    // The earlier you place them in the provided array, the further they will be in the background.
+    // e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
     open var drawOrder: [Int]
     {
         get
@@ -216,10 +216,10 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             (renderer as! CombinedChartRenderer!).drawOrder = newValue.map { DrawOrder(rawValue: $0)! }
         }
     }
-    
-    /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values
+
+    // Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values
     open var highlightFullBarEnabled: Bool = false
-    
-    /// - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
+
+    // - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
     open var isHighlightFullBarEnabled: Bool { return highlightFullBarEnabled }
 }

--- a/Source/Charts/Charts/HorizontalBarChartView.swift
+++ b/Source/Charts/Charts/HorizontalBarChartView.swift
@@ -16,49 +16,49 @@ import CoreGraphics
     import UIKit
 #endif
 
-/// BarChart with horizontal bar orientation. In this implementation, x- and y-axis are switched.
+// BarChart with horizontal bar orientation. In this implementation, x- and y-axis are switched.
 open class HorizontalBarChartView: BarChartView
 {
     internal override func initialize()
     {
         super.initialize()
-        
+
         _leftAxisTransformer = TransformerHorizontalBarChart(viewPortHandler: _viewPortHandler)
         _rightAxisTransformer = TransformerHorizontalBarChart(viewPortHandler: _viewPortHandler)
-        
+
         renderer = HorizontalBarChartRenderer(dataProvider: self, animator: _animator, viewPortHandler: _viewPortHandler)
         _leftYAxisRenderer = YAxisRendererHorizontalBarChart(viewPortHandler: _viewPortHandler, yAxis: _leftAxis, transformer: _leftAxisTransformer)
         _rightYAxisRenderer = YAxisRendererHorizontalBarChart(viewPortHandler: _viewPortHandler, yAxis: _rightAxis, transformer: _rightAxisTransformer)
         _xAxisRenderer = XAxisRendererHorizontalBarChart(viewPortHandler: _viewPortHandler, xAxis: _xAxis, transformer: _leftAxisTransformer, chart: self)
-        
+
         self.highlighter = HorizontalBarHighlighter(chart: self)
     }
-    
+
     internal override func calculateOffsets()
     {
         var offsetLeft: CGFloat = 0.0,
         offsetRight: CGFloat = 0.0,
         offsetTop: CGFloat = 0.0,
         offsetBottom: CGFloat = 0.0
-        
+
         calculateLegendOffsets(offsetLeft: &offsetLeft,
                                offsetTop: &offsetTop,
                                offsetRight: &offsetRight,
                                offsetBottom: &offsetBottom)
-        
+
         // offsets for y-labels
         if _leftAxis.needsOffset
         {
             offsetTop += _leftAxis.getRequiredHeightSpace()
         }
-        
+
         if _rightAxis.needsOffset
         {
             offsetBottom += _rightAxis.getRequiredHeightSpace()
         }
-        
+
         let xlabelwidth = _xAxis.labelRotatedWidth
-        
+
         if _xAxis.isEnabled
         {
             // offsets for x-labels
@@ -76,63 +76,63 @@ open class HorizontalBarChartView: BarChartView
                 offsetRight += xlabelwidth
             }
         }
-        
+
         offsetTop += self.extraTopOffset
         offsetRight += self.extraRightOffset
         offsetBottom += self.extraBottomOffset
         offsetLeft += self.extraLeftOffset
-        
+
         _viewPortHandler.restrainViewPort(
             offsetLeft: max(self.minOffset, offsetLeft),
             offsetTop: max(self.minOffset, offsetTop),
             offsetRight: max(self.minOffset, offsetRight),
             offsetBottom: max(self.minOffset, offsetBottom))
-        
+
         prepareOffsetMatrix()
         prepareValuePxMatrix()
     }
-    
+
     internal override func prepareValuePxMatrix()
     {
         _rightAxisTransformer.prepareMatrixValuePx(chartXMin: _rightAxis._axisMinimum, deltaX: CGFloat(_rightAxis.axisRange), deltaY: CGFloat(_xAxis.axisRange), chartYMin: _xAxis._axisMinimum)
         _leftAxisTransformer.prepareMatrixValuePx(chartXMin: _leftAxis._axisMinimum, deltaX: CGFloat(_leftAxis.axisRange), deltaY: CGFloat(_xAxis.axisRange), chartYMin: _xAxis._axisMinimum)
     }
-    
+
     open override func getMarkerPosition(highlight: Highlight) -> CGPoint
     {
         return CGPoint(x: highlight.drawY, y: highlight.drawX)
     }
-    
+
     open override func getBarBounds(entry e: BarChartDataEntry) -> CGRect
     {
         guard
             let data = _data as? BarChartData,
             let set = data.getDataSetForEntry(e) as? IBarChartDataSet
             else { return CGRect.null }
-        
+
         let y = e.y
         let x = e.x
-        
+
         let barWidth = data.barWidth
-        
+
         let top = x - 0.5 + barWidth / 2.0
         let bottom = x + 0.5 - barWidth / 2.0
         let left = y >= 0.0 ? y : 0.0
         let right = y <= 0.0 ? y : 0.0
-        
+
         var bounds = CGRect(x: left, y: top, width: right - left, height: bottom - top)
-        
+
         getTransformer(forAxis: set.axisDependency).rectValueToPixel(&bounds)
-        
+
         return bounds
     }
-    
+
     open override func getPosition(entry e: ChartDataEntry, axis: YAxis.AxisDependency) -> CGPoint
     {
         var vals = CGPoint(x: CGFloat(e.y), y: CGFloat(e.x))
-        
+
         getTransformer(forAxis: axis).pointValueToPixel(&vals)
-        
+
         return vals
     }
 
@@ -143,67 +143,67 @@ open class HorizontalBarChartView: BarChartView
             Swift.print("Can't select by touch. No data set.", terminator: "\n")
             return nil
         }
-        
+
         return self.highlighter?.getHighlight(x: pt.y, y: pt.x)
     }
-    
-    /// - returns: The lowest x-index (value on the x-axis) that is still visible on he chart.
+
+    // - returns: The lowest x-index (value on the x-axis) that is still visible on he chart.
     open override var lowestVisibleX: Double
     {
         var pt = CGPoint(
             x: viewPortHandler.contentLeft,
             y: viewPortHandler.contentBottom)
-        
+
         getTransformer(forAxis: .left).pixelToValues(&pt)
-        
+
         return max(xAxis._axisMinimum, Double(pt.y))
     }
-    
-    /// - returns: The highest x-index (value on the x-axis) that is still visible on the chart.
+
+    // - returns: The highest x-index (value on the x-axis) that is still visible on the chart.
     open override var highestVisibleX: Double
     {
         var pt = CGPoint(
             x: viewPortHandler.contentLeft,
             y: viewPortHandler.contentTop)
-        
+
         getTransformer(forAxis: .left).pixelToValues(&pt)
-        
+
         return min(xAxis._axisMaximum, Double(pt.y))
     }
-    
+
     // MARK: - Viewport
-    
+
     open override func setVisibleXRangeMaximum(_ maxXRange: Double)
     {
         let xScale = xAxis.axisRange / maxXRange
         viewPortHandler.setMinimumScaleY(CGFloat(xScale))
     }
-    
+
     open override func setVisibleXRangeMinimum(_ minXRange: Double)
     {
         let xScale = xAxis.axisRange / minXRange
         viewPortHandler.setMaximumScaleY(CGFloat(xScale))
     }
-    
+
     open override func setVisibleXRange(minXRange: Double, maxXRange: Double)
     {
         let minScale = xAxis.axisRange / minXRange
         let maxScale = xAxis.axisRange / maxXRange
         viewPortHandler.setMinMaxScaleY(minScaleY: CGFloat(minScale), maxScaleY: CGFloat(maxScale))
     }
-    
+
     open override func setVisibleYRangeMaximum(_ maxYRange: Double, axis: YAxis.AxisDependency)
     {
         let yScale = getAxisRange(axis: axis) / maxYRange
         viewPortHandler.setMinimumScaleX(CGFloat(yScale))
     }
-    
+
     open override func setVisibleYRangeMinimum(_ minYRange: Double, axis: YAxis.AxisDependency)
     {
         let yScale = getAxisRange(axis: axis) / minYRange
         viewPortHandler.setMaximumScaleX(CGFloat(yScale))
     }
-    
+
     open override func setVisibleYRange(minYRange: Double, maxYRange: Double, axis: YAxis.AxisDependency)
     {
         let minScale = getAxisRange(axis: axis) / minYRange

--- a/Source/Charts/Charts/LineChartView.swift
+++ b/Source/Charts/Charts/LineChartView.swift
@@ -12,17 +12,17 @@
 import Foundation
 import CoreGraphics
 
-/// Chart that draws lines, surfaces, circles, ...
+// Chart that draws lines, surfaces, circles, ...
 open class LineChartView: BarLineChartViewBase, LineChartDataProvider
 {
     internal override func initialize()
     {
         super.initialize()
-        
+
         renderer = LineChartRenderer(dataProvider: self, animator: _animator, viewPortHandler: _viewPortHandler)
     }
-    
+
     // MARK: - LineChartDataProvider
-    
+
     open var lineData: LineChartData? { return _data as? LineChartData }
 }

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -16,183 +16,183 @@ import CoreGraphics
     import UIKit
 #endif
 
-/// View that represents a pie chart. Draws cake like slices.
+// View that represents a pie chart. Draws cake like slices.
 open class PieChartView: PieRadarChartViewBase
 {
-    /// rect object that represents the bounds of the piechart, needed for drawing the circle
+    // rect object that represents the bounds of the piechart, needed for drawing the circle
     fileprivate var _circleBox = CGRect()
-    
-    /// flag indicating if entry labels should be drawn or not
+
+    // flag indicating if entry labels should be drawn or not
     fileprivate var _drawEntryLabelsEnabled = true
-    
-    /// array that holds the width of each pie-slice in degrees
+
+    // array that holds the width of each pie-slice in degrees
     fileprivate var _drawAngles = [CGFloat]()
-    
-    /// array that holds the absolute angle in degrees of each slice
+
+    // array that holds the absolute angle in degrees of each slice
     fileprivate var _absoluteAngles = [CGFloat]()
-    
-    /// if true, the hole inside the chart will be drawn
+
+    // if true, the hole inside the chart will be drawn
     fileprivate var _drawHoleEnabled = true
-    
+
     fileprivate var _holeColor: NSUIColor? = NSUIColor.white
-    
-    /// Sets the color the entry labels are drawn with.
+
+    // Sets the color the entry labels are drawn with.
     fileprivate var _entryLabelColor: NSUIColor? = NSUIColor.white
-    
-    /// Sets the font the entry labels are drawn with.
+
+    // Sets the font the entry labels are drawn with.
     fileprivate var _entryLabelFont: NSUIFont? = NSUIFont(name: "HelveticaNeue", size: 13.0)
-    
-    /// if true, the hole will see-through to the inner tips of the slices
+
+    // if true, the hole will see-through to the inner tips of the slices
     fileprivate var _drawSlicesUnderHoleEnabled = false
-    
-    /// if true, the values inside the piechart are drawn as percent values
+
+    // if true, the values inside the piechart are drawn as percent values
     fileprivate var _usePercentValuesEnabled = false
-    
-    /// variable for the text that is drawn in the center of the pie-chart
+
+    // variable for the text that is drawn in the center of the pie-chart
     fileprivate var _centerAttributedText: NSAttributedString?
-    
-    /// the offset on the x- and y-axis the center text has in dp.
+
+    // the offset on the x- and y-axis the center text has in dp.
     fileprivate var _centerTextOffset: CGPoint = CGPoint()
-    
-    /// indicates the size of the hole in the center of the piechart
-    ///
-    /// **default**: `0.5`
+
+    // indicates the size of the hole in the center of the piechart
+    //
+    // **default**: `0.5`
     fileprivate var _holeRadiusPercent = CGFloat(0.5)
-    
+
     fileprivate var _transparentCircleColor: NSUIColor? = NSUIColor(white: 1.0, alpha: 105.0/255.0)
-    
-    /// the radius of the transparent circle next to the chart-hole in the center
+
+    // the radius of the transparent circle next to the chart-hole in the center
     fileprivate var _transparentCircleRadiusPercent = CGFloat(0.55)
-    
-    /// if enabled, centertext is drawn
+
+    // if enabled, centertext is drawn
     fileprivate var _drawCenterTextEnabled = true
-    
+
     fileprivate var _centerTextRadiusPercent: CGFloat = 1.0
-    
-    /// maximum angle for this pie
+
+    // maximum angle for this pie
     fileprivate var _maxAngle: CGFloat = 360.0
 
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
     }
-    
+
     public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }
-    
+
     internal override func initialize()
     {
         super.initialize()
-        
+
         renderer = PieChartRenderer(chart: self, animator: _animator, viewPortHandler: _viewPortHandler)
         _xAxis = nil
-        
+
         self.highlighter = PieHighlighter(chart: self)
     }
-    
+
     open override func draw(_ rect: CGRect)
     {
         super.draw(rect)
-        
+
         if _data === nil
         {
             return
         }
-        
+
         let optionalContext = NSUIGraphicsGetCurrentContext()
         guard let context = optionalContext else { return }
-        
+
         renderer!.drawData(context: context)
-        
+
         if (valuesToHighlight())
         {
             renderer!.drawHighlighted(context: context, indices: _indicesToHighlight)
         }
-        
+
         renderer!.drawExtras(context: context)
-        
+
         renderer!.drawValues(context: context)
-        
+
         _legendRenderer.renderLegend(context: context)
-        
+
         drawDescription(context: context)
-        
+
         drawMarkers(context: context)
     }
-    
+
     internal override func calculateOffsets()
     {
         super.calculateOffsets()
-        
+
         // prevent nullpointer when no data set
         if _data === nil
         {
             return
         }
-        
+
         let radius = diameter / 2.0
-        
+
         let c = self.centerOffsets
-        
+
         let shift = (data as? PieChartData)?.dataSet?.selectionShift ?? 0.0
-        
+
         // create the circle box that will contain the pie-chart (the bounds of the pie-chart)
         _circleBox.origin.x = (c.x - radius) + shift
         _circleBox.origin.y = (c.y - radius) + shift
         _circleBox.size.width = diameter - shift * 2.0
         _circleBox.size.height = diameter - shift * 2.0
     }
-    
+
     internal override func calcMinMax()
     {
         calcAngles()
     }
-    
+
     open override func getMarkerPosition(highlight: Highlight) -> CGPoint
     {
         let center = self.centerCircleBox
         var r = self.radius
-        
+
         var off = r / 10.0 * 3.6
-        
+
         if self.isDrawHoleEnabled
         {
             off = (r - (r * self.holeRadiusPercent)) / 2.0
         }
-        
+
         r -= off // offset to keep things inside the chart
-        
+
         let rotationAngle = self.rotationAngle
-        
+
         let entryIndex = Int(highlight.x)
-        
+
         // offset needed to center the drawn text in the slice
         let offset = drawAngles[entryIndex] / 2.0
-        
+
         // calculate the text position
         let x: CGFloat = (r * cos(((rotationAngle + absoluteAngles[entryIndex] - offset) * CGFloat(_animator.phaseY)) * ChartUtils.Math.FDEG2RAD) + center.x)
         let y: CGFloat = (r * sin(((rotationAngle + absoluteAngles[entryIndex] - offset) * CGFloat(_animator.phaseY)) * ChartUtils.Math.FDEG2RAD) + center.y)
-        
+
         return CGPoint(x: x, y: y)
     }
-    
-    /// calculates the needed angles for the chart slices
+
+    // calculates the needed angles for the chart slices
     fileprivate func calcAngles()
     {
         _drawAngles = [CGFloat]()
         _absoluteAngles = [CGFloat]()
-        
+
         guard let data = _data else { return }
 
         let entryCount = data.entryCount
-        
+
         _drawAngles.reserveCapacity(entryCount)
         _absoluteAngles.reserveCapacity(entryCount)
-        
+
         let yValueSum = (_data as! PieChartData).yValueSum
-        
+
         var dataSets = data.dataSets
 
         var cnt = 0
@@ -205,7 +205,7 @@ open class PieChartView: PieRadarChartViewBase
             for j in 0 ..< entryCount
             {
                 guard let e = set.entryForIndex(j) else { continue }
-                
+
                 _drawAngles.append(calcAngle(value: abs(e.y), yValueSum: yValueSum))
 
                 if cnt == 0
@@ -221,8 +221,8 @@ open class PieChartView: PieRadarChartViewBase
             }
         }
     }
-    
-    /// Checks if the given index is set to be highlighted.
+
+    // Checks if the given index is set to be highlighted.
     open func needsHighlight(index: Int) -> Bool
     {
         // no highlight
@@ -230,7 +230,7 @@ open class PieChartView: PieRadarChartViewBase
         {
             return false
         }
-        
+
         for i in 0 ..< _indicesToHighlight.count
         {
             // check if the xvalue for the given dataset needs highlight
@@ -239,28 +239,28 @@ open class PieChartView: PieRadarChartViewBase
                 return true
             }
         }
-        
+
         return false
     }
-    
-    /// calculates the needed angle for a given value
+
+    // calculates the needed angle for a given value
     fileprivate func calcAngle(_ value: Double) -> CGFloat
     {
         return calcAngle(value: value, yValueSum: (_data as! PieChartData).yValueSum)
     }
-    
-    /// calculates the needed angle for a given value
+
+    // calculates the needed angle for a given value
     fileprivate func calcAngle(value: Double, yValueSum: Double) -> CGFloat
     {
         return CGFloat(value) / CGFloat(yValueSum) * _maxAngle
     }
-    
-    /// This will throw an exception, PieChart has no XAxis object.
+
+    // This will throw an exception, PieChart has no XAxis object.
     open override var xAxis: XAxis
     {
         fatalError("PieChart has no XAxis")
     }
-    
+
     open override func indexForAngle(_ angle: CGFloat) -> Int
     {
         // take the current angle of the chart into consideration
@@ -272,15 +272,15 @@ open class PieChartView: PieRadarChartViewBase
                 return i
             }
         }
-        
+
         return -1 // return -1 if no index found
     }
-    
-    /// - returns: The index of the DataSet this x-index belongs to.
+
+    // - returns: The index of the DataSet this x-index belongs to.
     open func dataSetIndexForIndex(_ xValue: Double) -> Int
     {
         var dataSets = _data?.dataSets ?? []
-        
+
         for i in 0 ..< dataSets.count
         {
             if (dataSets[i].entryForXValue(xValue, closestToY: Double.nan) !== nil)
@@ -288,28 +288,28 @@ open class PieChartView: PieRadarChartViewBase
                 return i
             }
         }
-        
+
         return -1
     }
-    
-    /// - returns: An integer array of all the different angles the chart slices
-    /// have the angles in the returned array determine how much space (of 360°)
-    /// each slice takes
+
+    // - returns: An integer array of all the different angles the chart slices
+    // have the angles in the returned array determine how much space (of 360°)
+    // each slice takes
     open var drawAngles: [CGFloat]
     {
         return _drawAngles
     }
 
-    /// - returns: The absolute angles of the different chart slices (where the
-    /// slices end)
+    // - returns: The absolute angles of the different chart slices (where the
+    // slices end)
     open var absoluteAngles: [CGFloat]
     {
         return _absoluteAngles
     }
-    
-    /// The color for the hole that is drawn in the center of the PieChart (if enabled).
-    /// 
-    /// - note: Use holeTransparent with holeColor = nil to make the hole transparent.*
+
+    // The color for the hole that is drawn in the center of the PieChart (if enabled).
+    //
+    // - note: Use holeTransparent with holeColor = nil to make the hole transparent.*
     open var holeColor: NSUIColor?
     {
         get
@@ -322,10 +322,10 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// if true, the hole will see-through to the inner tips of the slices
-    ///
-    /// **default**: `false`
+
+    // if true, the hole will see-through to the inner tips of the slices
+    //
+    // **default**: `false`
     open var drawSlicesUnderHoleEnabled: Bool
     {
         get
@@ -338,14 +338,14 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// - returns: `true` if the inner tips of the slices are visible behind the hole, `false` if not.
+
+    // - returns: `true` if the inner tips of the slices are visible behind the hole, `false` if not.
     open var isDrawSlicesUnderHoleEnabled: Bool
     {
         return drawSlicesUnderHoleEnabled
     }
-    
-    /// `true` if the hole in the center of the pie-chart is set to be visible, `false` ifnot
+
+    // `true` if the hole in the center of the pie-chart is set to be visible, `false` ifnot
     open var drawHoleEnabled: Bool
     {
         get
@@ -358,8 +358,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// - returns: `true` if the hole in the center of the pie-chart is set to be visible, `false` ifnot
+
+    // - returns: `true` if the hole in the center of the pie-chart is set to be visible, `false` ifnot
     open var isDrawHoleEnabled: Bool
     {
         get
@@ -367,8 +367,8 @@ open class PieChartView: PieRadarChartViewBase
             return drawHoleEnabled
         }
     }
-    
-    /// the text that is displayed in the center of the pie-chart
+
+    // the text that is displayed in the center of the pie-chart
     open var centerText: String?
     {
         get
@@ -391,7 +391,7 @@ open class PieChartView: PieRadarChartViewBase
                 #endif
                 paragraphStyle.lineBreakMode = NSLineBreakMode.byTruncatingTail
                 paragraphStyle.alignment = .center
-                
+
                 attrString = NSMutableAttributedString(string: newValue!)
                 attrString?.setAttributes([
                     NSForegroundColorAttributeName: NSUIColor.black,
@@ -402,8 +402,8 @@ open class PieChartView: PieRadarChartViewBase
             self.centerAttributedText = attrString
         }
     }
-    
-    /// the text that is displayed in the center of the pie-chart
+
+    // the text that is displayed in the center of the pie-chart
     open var centerAttributedText: NSAttributedString?
     {
         get
@@ -416,8 +416,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// Sets the offset the center text should have from it's original position in dp. Default x = 0, y = 0
+
+    // Sets the offset the center text should have from it's original position in dp. Default x = 0, y = 0
     open var centerTextOffset: CGPoint
     {
         get
@@ -430,8 +430,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// `true` if drawing the center text is enabled
+
+    // `true` if drawing the center text is enabled
     open var drawCenterTextEnabled: Bool
     {
         get
@@ -444,8 +444,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// - returns: `true` if drawing the center text is enabled
+
+    // - returns: `true` if drawing the center text is enabled
     open var isDrawCenterTextEnabled: Bool
     {
         get
@@ -453,37 +453,37 @@ open class PieChartView: PieRadarChartViewBase
             return drawCenterTextEnabled
         }
     }
-    
+
     internal override var requiredLegendOffset: CGFloat
     {
         return _legend.font.pointSize * 2.0
     }
-    
+
     internal override var requiredBaseOffset: CGFloat
     {
         return 0.0
     }
-    
+
     open override var radius: CGFloat
     {
         return _circleBox.width / 2.0
     }
-    
-    /// - returns: The circlebox, the boundingbox of the pie-chart slices
+
+    // - returns: The circlebox, the boundingbox of the pie-chart slices
     open var circleBox: CGRect
     {
         return _circleBox
     }
-    
-    /// - returns: The center of the circlebox
+
+    // - returns: The center of the circlebox
     open var centerCircleBox: CGPoint
     {
         return CGPoint(x: _circleBox.midX, y: _circleBox.midY)
     }
-    
-    /// the radius of the hole in the center of the piechart in percent of the maximum radius (max = the radius of the whole chart)
-    /// 
-    /// **default**: 0.5 (50%) (half the pie)
+
+    // the radius of the hole in the center of the piechart in percent of the maximum radius (max = the radius of the whole chart)
+    //
+    // **default**: 0.5 (50%) (half the pie)
     open var holeRadiusPercent: CGFloat
     {
         get
@@ -496,10 +496,10 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// The color that the transparent-circle should have.
-    ///
-    /// **default**: `nil`
+
+    // The color that the transparent-circle should have.
+    //
+    // **default**: `nil`
     open var transparentCircleColor: NSUIColor?
     {
         get
@@ -512,10 +512,10 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// the radius of the transparent circle that is drawn next to the hole in the piechart in percent of the maximum radius (max = the radius of the whole chart)
-    /// 
-    /// **default**: 0.55 (55%) -> means 5% larger than the center-hole by default
+
+    // the radius of the transparent circle that is drawn next to the hole in the piechart in percent of the maximum radius (max = the radius of the whole chart)
+    //
+    // **default**: 0.55 (55%) -> means 5% larger than the center-hole by default
     open var transparentCircleRadiusPercent: CGFloat
     {
         get
@@ -528,8 +528,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// set this to true to draw the enrty labels into the pie slices
+
+    // set this to true to draw the enrty labels into the pie slices
     @available(*, deprecated: 1.0, message: "Use `drawEntryLabelsEnabled` instead.")
     open var drawSliceTextEnabled: Bool
     {
@@ -542,8 +542,8 @@ open class PieChartView: PieRadarChartViewBase
             drawEntryLabelsEnabled = newValue
         }
     }
-    
-    /// - returns: `true` if drawing entry labels is enabled, `false` ifnot
+
+    // - returns: `true` if drawing entry labels is enabled, `false` ifnot
     @available(*, deprecated: 1.0, message: "Use `isDrawEntryLabelsEnabled` instead.")
     open var isDrawSliceTextEnabled: Bool
     {
@@ -552,8 +552,8 @@ open class PieChartView: PieRadarChartViewBase
             return isDrawEntryLabelsEnabled
         }
     }
-    
-    /// The color the entry labels are drawn with.
+
+    // The color the entry labels are drawn with.
     open var entryLabelColor: NSUIColor?
     {
         get { return _entryLabelColor }
@@ -563,8 +563,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// The font the entry labels are drawn with.
+
+    // The font the entry labels are drawn with.
     open var entryLabelFont: NSUIFont?
     {
         get { return _entryLabelFont }
@@ -574,8 +574,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// Set this to true to draw the enrty labels into the pie slices
+
+    // Set this to true to draw the enrty labels into the pie slices
     open var drawEntryLabelsEnabled: Bool
     {
         get
@@ -588,8 +588,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// - returns: `true` if drawing entry labels is enabled, `false` ifnot
+
+    // - returns: `true` if drawing entry labels is enabled, `false` ifnot
     open var isDrawEntryLabelsEnabled: Bool
     {
         get
@@ -597,8 +597,8 @@ open class PieChartView: PieRadarChartViewBase
             return drawEntryLabelsEnabled
         }
     }
-    
-    /// If this is enabled, values inside the PieChart are drawn in percent and not with their original value. Values provided for the ValueFormatter to format are then provided in percent.
+
+    // If this is enabled, values inside the PieChart are drawn in percent and not with their original value. Values provided for the ValueFormatter to format are then provided in percent.
     open var usePercentValuesEnabled: Bool
     {
         get
@@ -611,8 +611,8 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// - returns: `true` if drawing x-values is enabled, `false` ifnot
+
+    // - returns: `true` if drawing x-values is enabled, `false` ifnot
     open var isUsePercentValuesEnabled: Bool
     {
         get
@@ -620,8 +620,8 @@ open class PieChartView: PieRadarChartViewBase
             return usePercentValuesEnabled
         }
     }
-    
-    /// the rectangular radius of the bounding box for the center text, as a percentage of the pie hole
+
+    // the rectangular radius of the bounding box for the center text, as a percentage of the pie hole
     open var centerTextRadiusPercent: CGFloat
     {
         get
@@ -634,10 +634,10 @@ open class PieChartView: PieRadarChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// The max angle that is used for calculating the pie-circle.
-    /// 360 means it's a full pie-chart, 180 results in a half-pie-chart.
-    /// **default**: 360.0
+
+    // The max angle that is used for calculating the pie-circle.
+    // 360 means it's a full pie-chart, 180 results in a half-pie-chart.
+    // **default**: 360.0
     open var maxAngle: CGFloat
     {
         get
@@ -647,12 +647,12 @@ open class PieChartView: PieRadarChartViewBase
         set
         {
             _maxAngle = newValue
-            
+
             if _maxAngle > 360.0
             {
                 _maxAngle = 360.0
             }
-            
+
             if _maxAngle < 90.0
             {
                 _maxAngle = 90.0

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -16,50 +16,50 @@ import CoreGraphics
     import UIKit
 #endif
 
-/// Base class of PieChartView and RadarChartView.
+// Base class of PieChartView and RadarChartView.
 open class PieRadarChartViewBase: ChartViewBase
 {
-    /// holds the normalized version of the current rotation angle of the chart
+    // holds the normalized version of the current rotation angle of the chart
     fileprivate var _rotationAngle = CGFloat(270.0)
-    
-    /// holds the raw version of the current rotation angle of the chart
+
+    // holds the raw version of the current rotation angle of the chart
     fileprivate var _rawRotationAngle = CGFloat(270.0)
-    
-    /// flag that indicates if rotation is enabled or not
+
+    // flag that indicates if rotation is enabled or not
     open var rotationEnabled = true
-    
-    /// Sets the minimum offset (padding) around the chart, defaults to 0.0
+
+    // Sets the minimum offset (padding) around the chart, defaults to 0.0
     open var minOffset = CGFloat(0.0)
 
-    /// iOS && OSX only: Enabled multi-touch rotation using two fingers.
+    // iOS && OSX only: Enabled multi-touch rotation using two fingers.
     fileprivate var _rotationWithTwoFingers = false
-    
+
     fileprivate var _tapGestureRecognizer: NSUITapGestureRecognizer!
     #if !os(tvOS)
     fileprivate var _rotationGestureRecognizer: NSUIRotationGestureRecognizer!
     #endif
-    
+
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
     }
-    
+
     public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }
-    
+
     deinit
     {
         stopDeceleration()
     }
-    
+
     internal override func initialize()
     {
         super.initialize()
-        
+
         _tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(tapGestureRecognized(_:)))
-        
+
         self.addGestureRecognizer(_tapGestureRecognizer)
 
         #if !os(tvOS)
@@ -68,12 +68,12 @@ open class PieRadarChartViewBase: ChartViewBase
             _rotationGestureRecognizer.isEnabled = rotationWithTwoFingers
         #endif
     }
-    
+
     internal override func calcMinMax()
     {
         /*_xAxis.axisRange = Double((_data?.xVals.count ?? 0) - 1)*/
     }
-    
+
     open override var maxVisibleCount: Int
     {
         get
@@ -81,21 +81,21 @@ open class PieRadarChartViewBase: ChartViewBase
             return data?.entryCount ?? 0
         }
     }
-    
+
     open override func notifyDataSetChanged()
     {
         calcMinMax()
-        
+
         if let data = _data , _legend !== nil
         {
             _legendRenderer.computeLegend(data: data)
         }
-        
+
         calculateOffsets()
-        
+
         setNeedsDisplay()
     }
-  
+
     internal override func calculateOffsets()
     {
         var legendLeft = CGFloat(0.0)
@@ -106,13 +106,13 @@ open class PieRadarChartViewBase: ChartViewBase
         if _legend != nil && _legend.enabled && !_legend.drawInside
         {
             let fullLegendWidth = min(_legend.neededWidth, _viewPortHandler.chartWidth * _legend.maxSizePercent)
-            
+
             switch _legend.orientation
             {
             case .vertical:
-                
+
                 var xLegendOffset: CGFloat = 0.0
-                
+
                 if _legend.horizontalAlignment == .left
                     || _legend.horizontalAlignment == .right
                 {
@@ -120,31 +120,31 @@ open class PieRadarChartViewBase: ChartViewBase
                     {
                         // this is the space between the legend and the chart
                         let spacing = CGFloat(13.0)
-                        
+
                         xLegendOffset = fullLegendWidth + spacing
                     }
                     else
                     {
                         // this is the space between the legend and the chart
                         let spacing = CGFloat(8.0)
-                        
+
                         let legendWidth = fullLegendWidth + spacing
                         let legendHeight = _legend.neededHeight + _legend.textHeightMax
-                        
+
                         let c = self.midPoint
-                        
+
                         let bottomX = _legend.horizontalAlignment == .right
                             ? self.bounds.width - legendWidth + 15.0
                             : legendWidth - 15.0
                         let bottomY = legendHeight + 15
                         let distLegend = distanceToCenter(x: bottomX, y: bottomY)
-                        
+
                         let reference = getPosition(center: c, dist: self.radius,
                                                     angle: angleForPoint(x: bottomX, y: bottomY))
-                        
+
                         let distReference = distanceToCenter(x: reference.x, y: reference.y)
                         let minOffset = CGFloat(5.0)
-                        
+
                         if bottomY >= c.y
                             && self.bounds.height - legendWidth > self.bounds.width
                         {
@@ -157,34 +157,34 @@ open class PieRadarChartViewBase: ChartViewBase
                         }
                     }
                 }
-                
+
                 switch _legend.horizontalAlignment
                 {
                 case .left:
                     legendLeft = xLegendOffset
-                    
+
                 case .right:
                     legendRight = xLegendOffset
-                    
+
                 case .center:
-                    
+
                     switch _legend.verticalAlignment
                     {
                     case .top:
                         legendTop = min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent)
-                        
+
                     case .bottom:
                         legendBottom = min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent)
-                        
+
                     default:
                         break
                     }
                 }
-            
+
             case .horizontal:
-                
+
                 var yLegendOffset: CGFloat = 0.0
-                
+
                 if _legend.verticalAlignment == .top
                     || _legend.verticalAlignment == .bottom
                 {
@@ -192,22 +192,22 @@ open class PieRadarChartViewBase: ChartViewBase
                     //   is available through the extraOffsets, but changing it can mean
                     //   changing default visibility for existing apps.
                     let yOffset = self.requiredLegendOffset
-                    
+
                     yLegendOffset = min(
                         _legend.neededHeight + yOffset,
                         _viewPortHandler.chartHeight * _legend.maxSizePercent)
                 }
-                
+
                 switch _legend.verticalAlignment
                 {
                 case .top:
-                    
+
                     legendTop = yLegendOffset
-                    
+
                 case .bottom:
-                    
+
                     legendBottom = yLegendOffset
-                    
+
                 default:
                     break
                 }
@@ -218,18 +218,18 @@ open class PieRadarChartViewBase: ChartViewBase
             legendTop += self.requiredBaseOffset
             legendBottom += self.requiredBaseOffset
         }
-        
+
         legendTop += self.extraTopOffset
         legendRight += self.extraRightOffset
         legendBottom += self.extraBottomOffset
         legendLeft += self.extraLeftOffset
-        
+
         var minOffset = self.minOffset
-        
+
         if (self.isKind(of: RadarChartView.self))
         {
             let x = self.xAxis
-            
+
             if x.isEnabled && x.drawLabelsEnabled
             {
                 minOffset = max(minOffset, x.labelRotatedWidth)
@@ -244,12 +244,12 @@ open class PieRadarChartViewBase: ChartViewBase
         _viewPortHandler.restrainViewPort(offsetLeft: offsetLeft, offsetTop: offsetTop, offsetRight: offsetRight, offsetBottom: offsetBottom)
     }
 
-    /// - returns: The angle relative to the chart center for the given point on the chart in degrees.
-    /// The angle is always between 0 and 360°, 0° is NORTH, 90° is EAST, ...
+    // - returns: The angle relative to the chart center for the given point on the chart in degrees.
+    // The angle is always between 0 and 360°, 0° is NORTH, 90° is EAST, ...
     open func angleForPoint(x: CGFloat, y: CGFloat) -> CGFloat
     {
         let c = centerOffsets
-        
+
         let tx = Double(x - c.x)
         let ty = Double(y - c.y)
         let length = sqrt(tx * tx + ty * ty)
@@ -273,16 +273,16 @@ open class PieRadarChartViewBase: ChartViewBase
 
         return CGFloat(angle)
     }
-    
-    /// Calculates the position around a center point, depending on the distance
-    /// from the center, and the angle of the position around the center.
+
+    // Calculates the position around a center point, depending on the distance
+    // from the center, and the angle of the position around the center.
     open func getPosition(center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
     {
         return CGPoint(x: center.x + dist * cos(angle * ChartUtils.Math.FDEG2RAD),
                 y: center.y + dist * sin(angle * ChartUtils.Math.FDEG2RAD))
     }
 
-    /// - returns: The distance of a certain point on the chart to the center of the chart.
+    // - returns: The distance of a certain point on the chart to the center of the chart.
     open func distanceToCenter(x: CGFloat, y: CGFloat) -> CGFloat
     {
         let c = self.centerOffsets
@@ -316,17 +316,17 @@ open class PieRadarChartViewBase: ChartViewBase
         return dist
     }
 
-    /// - returns: The xIndex for the given angle around the center of the chart.
-    /// -1 if not found / outofbounds.
+    // - returns: The xIndex for the given angle around the center of the chart.
+    // -1 if not found / outofbounds.
     open func indexForAngle(_ angle: CGFloat) -> Int
     {
         fatalError("indexForAngle() cannot be called on PieRadarChartViewBase")
     }
 
-    /// current rotation angle of the pie chart
-    ///
-    /// **default**: 270 --> top (NORTH)
-    /// - returns: Will always return a normalized value, which will be between 0.0 < 360.0
+    // current rotation angle of the pie chart
+    //
+    // **default**: 270 --> top (NORTH)
+    // - returns: Will always return a normalized value, which will be between 0.0 < 360.0
     open var rotationAngle: CGFloat
     {
         get
@@ -340,15 +340,15 @@ open class PieRadarChartViewBase: ChartViewBase
             setNeedsDisplay()
         }
     }
-    
-    /// gets the raw version of the current rotation angle of the pie chart the returned value could be any value, negative or positive, outside of the 360 degrees. 
-    /// this is used when working with rotation direction, mainly by gestures and animations.
+
+    // gets the raw version of the current rotation angle of the pie chart the returned value could be any value, negative or positive, outside of the 360 degrees.
+    // this is used when working with rotation direction, mainly by gestures and animations.
     open var rawRotationAngle: CGFloat
     {
         return _rawRotationAngle
     }
 
-    /// - returns: The diameter of the pie- or radar-chart
+    // - returns: The diameter of the pie- or radar-chart
     open var diameter: CGFloat
     {
         var content = _viewPortHandler.contentRect
@@ -359,44 +359,44 @@ open class PieRadarChartViewBase: ChartViewBase
         return min(content.width, content.height)
     }
 
-    /// - returns: The radius of the chart in pixels.
+    // - returns: The radius of the chart in pixels.
     open var radius: CGFloat
     {
         fatalError("radius cannot be called on PieRadarChartViewBase")
     }
 
-    /// - returns: The required offset for the chart legend.
+    // - returns: The required offset for the chart legend.
     internal var requiredLegendOffset: CGFloat
     {
         fatalError("requiredLegendOffset cannot be called on PieRadarChartViewBase")
     }
 
-    /// - returns: The base offset needed for the chart without calculating the
-    /// legend size.
+    // - returns: The base offset needed for the chart without calculating the
+    // legend size.
     internal var requiredBaseOffset: CGFloat
     {
         fatalError("requiredBaseOffset cannot be called on PieRadarChartViewBase")
     }
-    
+
     open override var chartYMax: Double
     {
         return 0.0
     }
-    
+
     open override var chartYMin: Double
     {
         return 0.0
     }
-    
+
     open var isRotationEnabled: Bool { return rotationEnabled }
-    
-    /// flag that indicates if rotation is done with two fingers or one.
-    /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
-    ///
-    /// On iOS this will disable one-finger rotation.
-    /// On OSX this will keep two-finger multitouch rotation, and one-pointer mouse rotation.
-    /// 
-    /// **default**: false
+
+    // flag that indicates if rotation is done with two fingers or one.
+    // when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
+    //
+    // On iOS this will disable one-finger rotation.
+    // On OSX this will keep two-finger multitouch rotation, and one-pointer mouse rotation.
+    //
+    // **default**: false
     open var rotationWithTwoFingers: Bool
     {
         get
@@ -411,50 +411,50 @@ open class PieRadarChartViewBase: ChartViewBase
             #endif
         }
     }
-    
-    /// flag that indicates if rotation is done with two fingers or one.
-    /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
-    ///
-    /// On iOS this will disable one-finger rotation.
-    /// On OSX this will keep two-finger multitouch rotation, and one-pointer mouse rotation.
-    ///
-    /// **default**: false
+
+    // flag that indicates if rotation is done with two fingers or one.
+    // when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
+    //
+    // On iOS this will disable one-finger rotation.
+    // On OSX this will keep two-finger multitouch rotation, and one-pointer mouse rotation.
+    //
+    // **default**: false
     open var isRotationWithTwoFingers: Bool
     {
         return _rotationWithTwoFingers
     }
-    
+
     // MARK: - Animation
-    
+
     fileprivate var _spinAnimator: Animator!
-    
-    /// Applys a spin animation to the Chart.
+
+    // Applys a spin animation to the Chart.
     open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easing: ChartEasingFunctionBlock?)
     {
         if _spinAnimator != nil
         {
             _spinAnimator.stop()
         }
-        
+
         _spinAnimator = Animator()
         _spinAnimator.updateBlock = {
             self.rotationAngle = (toAngle - fromAngle) * CGFloat(self._spinAnimator.phaseX) + fromAngle
         }
         _spinAnimator.stopBlock = { self._spinAnimator = nil }
-        
+
         _spinAnimator.animate(xAxisDuration: duration, easing: easing)
     }
-    
+
     open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easingOption: ChartEasingOption)
     {
         spin(duration: duration, fromAngle: fromAngle, toAngle: toAngle, easing: easingFunctionFromOption(easingOption))
     }
-    
+
     open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat)
     {
         spin(duration: duration, fromAngle: fromAngle, toAngle: toAngle, easing: nil)
     }
-    
+
     open func stopSpinAnimation()
     {
         if _spinAnimator != nil
@@ -462,46 +462,46 @@ open class PieRadarChartViewBase: ChartViewBase
             _spinAnimator.stop()
         }
     }
-    
+
     // MARK: - Gestures
-    
+
     fileprivate var _rotationGestureStartPoint: CGPoint!
     fileprivate var _isRotating = false
     fileprivate var _startAngle = CGFloat(0.0)
-    
+
     fileprivate struct AngularVelocitySample
     {
         var time: TimeInterval
         var angle: CGFloat
     }
-    
+
     fileprivate var _velocitySamples = [AngularVelocitySample]()
-    
+
     fileprivate var _decelerationLastTime: TimeInterval = 0.0
     fileprivate var _decelerationDisplayLink: NSUIDisplayLink!
     fileprivate var _decelerationAngularVelocity: CGFloat = 0.0
-    
+
     internal final func processRotationGestureBegan(location: CGPoint)
     {
         self.resetVelocity()
-        
+
         if rotationEnabled
         {
             self.sampleVelocity(touchLocation: location)
         }
-        
+
         self.setGestureStartAngle(x: location.x, y: location.y)
-        
+
         _rotationGestureStartPoint = location
     }
-    
+
     internal final func processRotationGestureMoved(location: CGPoint)
     {
         if isDragDecelerationEnabled
         {
             sampleVelocity(touchLocation: location)
         }
-        
+
         if !_isRotating &&
             distance(
                 eventX: location.x,
@@ -517,17 +517,17 @@ open class PieRadarChartViewBase: ChartViewBase
             setNeedsDisplay()
         }
     }
-    
+
     internal final func processRotationGestureEnded(location: CGPoint)
     {
         if isDragDecelerationEnabled
         {
             stopDeceleration()
-            
+
             sampleVelocity(touchLocation: location)
-            
+
             _decelerationAngularVelocity = calculateVelocity()
-            
+
             if _decelerationAngularVelocity != 0.0
             {
                 _decelerationLastTime = CACurrentMediaTime()
@@ -536,7 +536,7 @@ open class PieRadarChartViewBase: ChartViewBase
             }
         }
     }
-    
+
     internal final func processRotationGestureCancelled()
     {
         if _isRotating
@@ -544,7 +544,7 @@ open class PieRadarChartViewBase: ChartViewBase
             _isRotating = false
         }
     }
-    
+
     #if !os(OSX)
     open override func nsuiTouchesBegan(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
@@ -552,70 +552,70 @@ open class PieRadarChartViewBase: ChartViewBase
         if rotationEnabled
         {
             stopDeceleration()
-            
+
             if !rotationWithTwoFingers
             {
                 let touch = touches.first as NSUITouch!
-                
+
                 let touchLocation = touch?.location(in: self)
-                
+
                 processRotationGestureBegan(location: touchLocation!)
             }
         }
-        
+
         if !_isRotating
         {
             super.nsuiTouchesBegan(touches, withEvent: event)
         }
     }
-    
+
     open override func nsuiTouchesMoved(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         if rotationEnabled && !rotationWithTwoFingers
         {
             let touch = touches.first as NSUITouch!
-            
+
             let touchLocation = touch?.location(in: self)
-            
+
             processRotationGestureMoved(location: touchLocation!)
         }
-        
+
         if !_isRotating
         {
             super.nsuiTouchesMoved(touches, withEvent: event)
         }
     }
-    
+
     open override func nsuiTouchesEnded(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         if !_isRotating
         {
             super.nsuiTouchesEnded(touches, withEvent: event)
         }
-        
+
         if rotationEnabled && !rotationWithTwoFingers
         {
             let touch = touches.first as NSUITouch!
-            
+
             let touchLocation = touch?.location(in: self)
-            
+
             processRotationGestureEnded(location: touchLocation!)
         }
-        
+
         if _isRotating
         {
             _isRotating = false
         }
     }
-    
+
     open override func nsuiTouchesCancelled(_ touches: Set<NSUITouch>?, withEvent event: NSUIEvent?)
     {
         super.nsuiTouchesCancelled(touches, withEvent: event)
-        
+
         processRotationGestureCancelled()
     }
     #endif
-    
+
     #if os(OSX)
     open override func mouseDown(with theEvent: NSEvent)
     {
@@ -623,65 +623,65 @@ open class PieRadarChartViewBase: ChartViewBase
         if rotationEnabled
         {
             stopDeceleration()
-        
+
             let location = self.convert(theEvent.locationInWindow, from: nil)
-            
+
             processRotationGestureBegan(location: location)
         }
-        
+
         if !_isRotating
         {
             super.mouseDown(with: theEvent)
         }
     }
-    
+
     open override func mouseDragged(with theEvent: NSEvent)
     {
         if rotationEnabled
         {
             let location = self.convert(theEvent.locationInWindow, from: nil)
-            
+
             processRotationGestureMoved(location: location)
         }
-        
+
         if !_isRotating
         {
             super.mouseDragged(with: theEvent)
         }
     }
-    
+
     open override func mouseUp(with theEvent: NSEvent)
     {
         if !_isRotating
         {
             super.mouseUp(with: theEvent)
         }
-        
+
         if rotationEnabled
         {
             let location = self.convert(theEvent.locationInWindow, from: nil)
-            
+
             processRotationGestureEnded(location: location)
         }
-        
+
         if _isRotating
         {
             _isRotating = false
         }
     }
     #endif
-    
+
     fileprivate func resetVelocity()
     {
         _velocitySamples.removeAll(keepingCapacity: false)
     }
-    
+
     fileprivate func sampleVelocity(touchLocation: CGPoint)
     {
         let currentTime = CACurrentMediaTime()
-        
+
         _velocitySamples.append(AngularVelocitySample(time: currentTime, angle: angleForPoint(x: touchLocation.x, y: touchLocation.y)))
-        
+
         // Remove samples older than our sample time - 1 seconds
         var i = 0, count = _velocitySamples.count
         while (i < count - 2)
@@ -696,21 +696,21 @@ open class PieRadarChartViewBase: ChartViewBase
             {
                 break
             }
-            
+
             i += 1
         }
     }
-    
+
     fileprivate func calculateVelocity() -> CGFloat
     {
         if _velocitySamples.isEmpty
         {
             return 0.0
         }
-        
+
         var firstSample = _velocitySamples[0]
         var lastSample = _velocitySamples[_velocitySamples.count - 1]
-        
+
         // Look for a sample that's closest to the latest sample, but not the same, so we can deduce the direction
         var beforeLastSample = firstSample
         for i in stride(from: (_velocitySamples.count - 1), through: 0, by: -1)
@@ -721,14 +721,14 @@ open class PieRadarChartViewBase: ChartViewBase
                 break
             }
         }
-        
+
         // Calculate the sampling time
         var timeDelta = lastSample.time - firstSample.time
         if timeDelta == 0.0
         {
             timeDelta = 0.1
         }
-        
+
         // Calculate clockwise/ccw by choosing two values that should be closest to each other,
         // so if the angles are two far from each other we know they are inverted "for sure"
         var clockwise = lastSample.angle >= beforeLastSample.angle
@@ -736,7 +736,7 @@ open class PieRadarChartViewBase: ChartViewBase
         {
             clockwise = !clockwise
         }
-        
+
         // Now if the "gesture" is over a too big of an angle - then we know the angles are inverted, and we need to move them closer to each other from both sides of the 360.0 wrapping point
         if lastSample.angle - firstSample.angle > 180.0
         {
@@ -746,34 +746,34 @@ open class PieRadarChartViewBase: ChartViewBase
         {
             lastSample.angle += 360.0
         }
-        
+
         // The velocity
         var velocity = abs((lastSample.angle - firstSample.angle) / CGFloat(timeDelta))
-        
+
         // Direction?
         if !clockwise
         {
             velocity = -velocity
         }
-        
+
         return velocity
     }
-    
-    /// sets the starting angle of the rotation, this is only used by the touch listener, x and y is the touch position
+
+    // sets the starting angle of the rotation, this is only used by the touch listener, x and y is the touch position
     fileprivate func setGestureStartAngle(x: CGFloat, y: CGFloat)
     {
         _startAngle = angleForPoint(x: x, y: y)
-        
+
         // take the current angle into consideration when starting a new drag
         _startAngle -= _rotationAngle
     }
-    
-    /// updates the view rotation depending on the given touch position, also takes the starting angle into consideration
+
+    // updates the view rotation depending on the given touch position, also takes the starting angle into consideration
     fileprivate func updateGestureRotation(x: CGFloat, y: CGFloat)
     {
         self.rotationAngle = angleForPoint(x: x, y: y) - _startAngle
     }
-    
+
     open func stopDeceleration()
     {
         if _decelerationDisplayLink !== nil
@@ -782,87 +782,87 @@ open class PieRadarChartViewBase: ChartViewBase
             _decelerationDisplayLink = nil
         }
     }
-    
+
     @objc fileprivate func decelerationLoop()
     {
         let currentTime = CACurrentMediaTime()
-        
+
         _decelerationAngularVelocity *= self.dragDecelerationFrictionCoef
-        
+
         let timeInterval = CGFloat(currentTime - _decelerationLastTime)
-        
+
         self.rotationAngle += _decelerationAngularVelocity * timeInterval
-        
+
         _decelerationLastTime = currentTime
-        
+
         if(abs(_decelerationAngularVelocity) < 0.001)
         {
             stopDeceleration()
         }
     }
-    
-    /// - returns: The distance between two points
+
+    // - returns: The distance between two points
     fileprivate func distance(eventX: CGFloat, startX: CGFloat, eventY: CGFloat, startY: CGFloat) -> CGFloat
     {
         let dx = eventX - startX
         let dy = eventY - startY
         return sqrt(dx * dx + dy * dy)
     }
-    
-    /// - returns: The distance between two points
+
+    // - returns: The distance between two points
     fileprivate func distance(from: CGPoint, to: CGPoint) -> CGFloat
     {
         let dx = from.x - to.x
         let dy = from.y - to.y
         return sqrt(dx * dx + dy * dy)
     }
-    
-    /// reference to the last highlighted object
+
+    // reference to the last highlighted object
     fileprivate var _lastHighlight: Highlight!
-    
+
     @objc fileprivate func tapGestureRecognized(_ recognizer: NSUITapGestureRecognizer)
     {
         if recognizer.state == NSUIGestureRecognizerState.ended
         {
             if !self.isHighLightPerTapEnabled { return }
-            
+
             let location = recognizer.location(in: self)
-            
+
             let high = self.getHighlightByTouchPoint(location)
             self.highlightValue(high, callDelegate: true)
         }
     }
-    
+
     #if !os(tvOS)
     @objc fileprivate func rotationGestureRecognized(_ recognizer: NSUIRotationGestureRecognizer)
     {
         if recognizer.state == NSUIGestureRecognizerState.began
         {
             stopDeceleration()
-            
+
             _startAngle = self.rawRotationAngle
         }
-        
+
         if recognizer.state == NSUIGestureRecognizerState.began || recognizer.state == NSUIGestureRecognizerState.changed
         {
             let angle = ChartUtils.Math.FRAD2DEG * recognizer.nsuiRotation
-            
+
             self.rotationAngle = _startAngle + angle
             setNeedsDisplay()
         }
         else if recognizer.state == NSUIGestureRecognizerState.ended
         {
             let angle = ChartUtils.Math.FRAD2DEG * recognizer.nsuiRotation
-            
+
             self.rotationAngle = _startAngle + angle
             setNeedsDisplay()
-            
+
             if isDragDecelerationEnabled
             {
                 stopDeceleration()
-                
+
                 _decelerationAngularVelocity = ChartUtils.Math.FRAD2DEG * recognizer.velocity
-                
+
                 if _decelerationAngularVelocity != 0.0
                 {
                     _decelerationLastTime = CACurrentMediaTime()

--- a/Source/Charts/Charts/RadarChartView.swift
+++ b/Source/Charts/Charts/RadarChartView.swift
@@ -13,90 +13,90 @@ import Foundation
 import CoreGraphics
 
 
-/// Implementation of the RadarChart, a "spidernet"-like chart. It works best
-/// when displaying 5-10 entries per DataSet.
+// Implementation of the RadarChart, a "spidernet"-like chart. It works best
+// when displaying 5-10 entries per DataSet.
 open class RadarChartView: PieRadarChartViewBase
 {
-    /// width of the web lines that come from the center.
+    // width of the web lines that come from the center.
     open var webLineWidth = CGFloat(1.5)
-    
-    /// width of the web lines that are in between the lines coming from the center
+
+    // width of the web lines that are in between the lines coming from the center
     open var innerWebLineWidth = CGFloat(0.75)
-    
-    /// color for the web lines that come from the center
+
+    // color for the web lines that come from the center
     open var webColor = NSUIColor(red: 122/255.0, green: 122/255.0, blue: 122.0/255.0, alpha: 1.0)
-    
-    /// color for the web lines in between the lines that come from the center.
+
+    // color for the web lines in between the lines that come from the center.
     open var innerWebColor = NSUIColor(red: 122/255.0, green: 122/255.0, blue: 122.0/255.0, alpha: 1.0)
-    
-    /// transparency the grid is drawn with (0.0 - 1.0)
+
+    // transparency the grid is drawn with (0.0 - 1.0)
     open var webAlpha: CGFloat = 150.0 / 255.0
-    
-    /// flag indicating if the web lines should be drawn or not
+
+    // flag indicating if the web lines should be drawn or not
     open var drawWeb = true
-    
-    /// modulus that determines how many labels and web-lines are skipped before the next is drawn
+
+    // modulus that determines how many labels and web-lines are skipped before the next is drawn
     fileprivate var _skipWebLineCount = 0
-    
-    /// the object reprsenting the y-axis labels
+
+    // the object reprsenting the y-axis labels
     fileprivate var _yAxis: YAxis!
-    
+
     internal var _yAxisRenderer: YAxisRendererRadarChart!
     internal var _xAxisRenderer: XAxisRendererRadarChart!
-    
+
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
     }
-    
+
     public required init?(coder aDecoder: NSCoder)
     {
         super.init(coder: aDecoder)
     }
-    
+
     internal override func initialize()
     {
         super.initialize()
-        
+
         _yAxis = YAxis(position: .left)
-        
+
         renderer = RadarChartRenderer(chart: self, animator: _animator, viewPortHandler: _viewPortHandler)
-        
+
         _yAxisRenderer = YAxisRendererRadarChart(viewPortHandler: _viewPortHandler, yAxis: _yAxis, chart: self)
         _xAxisRenderer = XAxisRendererRadarChart(viewPortHandler: _viewPortHandler, xAxis: _xAxis, chart: self)
-        
+
         self.highlighter = RadarHighlighter(chart: self)
     }
 
     internal override func calcMinMax()
     {
         super.calcMinMax()
-        
+
         guard let data = _data else { return }
-        
+
         _yAxis.calculate(min: data.getYMin(axis: .left), max: data.getYMax(axis: .left))
         _xAxis.calculate(min: 0.0, max: Double(data.maxEntryCountSet?.entryCount ?? 0))
     }
-    
+
     open override func notifyDataSetChanged()
     {
         calcMinMax()
-        
+
         _yAxisRenderer?.computeAxis(min: _yAxis._axisMinimum, max: _yAxis._axisMaximum, inverted: _yAxis.isInverted)
         _xAxisRenderer?.computeAxis(min: _xAxis._axisMinimum, max: _xAxis._axisMaximum, inverted: false)
-        
+
         if let data = _data,
             let legend = _legend,
             !legend.isLegendCustom
         {
             _legendRenderer?.computeLegend(data: data)
         }
-        
+
         calculateOffsets()
-        
+
         setNeedsDisplay()
     }
-    
+
     open override func draw(_ rect: CGRect)
     {
         super.draw(rect)
@@ -105,22 +105,22 @@ open class RadarChartView: PieRadarChartViewBase
         {
             return
         }
-        
+
         let optionalContext = NSUIGraphicsGetCurrentContext()
         guard let context = optionalContext else { return }
-        
+
         if _xAxis.isEnabled
         {
             _xAxisRenderer.computeAxis(min: _xAxis._axisMinimum, max: _xAxis._axisMaximum, inverted: false)
         }
-        
+
         _xAxisRenderer?.renderAxisLabels(context: context)
-        
+
         if drawWeb
         {
             renderer!.drawExtras(context: context)
         }
-        
+
         if _yAxis.isEnabled && _yAxis.isDrawLimitLinesBehindDataEnabled
         {
             _yAxisRenderer.renderLimitLines(context: context)
@@ -132,12 +132,12 @@ open class RadarChartView: PieRadarChartViewBase
         {
             renderer!.drawHighlighted(context: context, indices: _indicesToHighlight)
         }
-        
+
         if _yAxis.isEnabled && !_yAxis.isDrawLimitLinesBehindDataEnabled
         {
             _yAxisRenderer.renderLimitLines(context: context)
         }
-        
+
         _yAxisRenderer.renderAxisLabels(context: context)
 
         renderer!.drawValues(context: context)
@@ -149,7 +149,7 @@ open class RadarChartView: PieRadarChartViewBase
         drawMarkers(context: context)
     }
 
-    /// - returns: The factor that is needed to transform values into pixels.
+    // - returns: The factor that is needed to transform values into pixels.
     open var factor: CGFloat
     {
         let content = _viewPortHandler.contentRect
@@ -157,7 +157,7 @@ open class RadarChartView: PieRadarChartViewBase
                 / CGFloat(_yAxis.axisRange)
     }
 
-    /// - returns: The angle that each slice in the radar chart occupies.
+    // - returns: The angle that each slice in the radar chart occupies.
     open var sliceAngle: CGFloat
     {
         return 360.0 / CGFloat(_data?.maxEntryCountSet?.entryCount ?? 0)
@@ -167,35 +167,35 @@ open class RadarChartView: PieRadarChartViewBase
     {
         // take the current angle of the chart into consideration
         let a = ChartUtils.normalizedAngleFromAngle(angle - self.rotationAngle)
-        
+
         let sliceAngle = self.sliceAngle
-        
+
         let max = _data?.maxEntryCountSet?.entryCount ?? 0
-        
+
         var index = 0
-        
+
         for i in 0..<max
         {
             let referenceAngle = sliceAngle * CGFloat(i + 1) - sliceAngle / 2.0
-            
+
             if referenceAngle > a
             {
                 index = i
                 break
             }
         }
-        
+
         return index
     }
 
-    /// - returns: The object that represents all y-labels of the RadarChart.
+    // - returns: The object that represents all y-labels of the RadarChart.
     open var yAxis: YAxis
     {
         return _yAxis
     }
 
-    /// Sets the number of web-lines that should be skipped on chart web before the next one is drawn. This targets the lines that come from the center of the RadarChart.
-    /// if count = 1 -> 1 line is skipped in between
+    // Sets the number of web-lines that should be skipped on chart web before the next one is drawn. This targets the lines that come from the center of the RadarChart.
+    // if count = 1 -> 1 line is skipped in between
     open var skipWebLineCount: Int
     {
         get
@@ -207,7 +207,7 @@ open class RadarChartView: PieRadarChartViewBase
             _skipWebLineCount = max(0, newValue)
         }
     }
-    
+
     internal override var requiredLegendOffset: CGFloat
     {
         return _legend.font.pointSize * 4.0
@@ -224,12 +224,12 @@ open class RadarChartView: PieRadarChartViewBase
         return min(content.width / 2.0, content.height / 2.0)
     }
 
-    /// - returns: The maximum value this chart can display on it's y-axis.
+    // - returns: The maximum value this chart can display on it's y-axis.
     open override var chartYMax: Double { return _yAxis._axisMaximum }
-    
-    /// - returns: The minimum value this chart can display on it's y-axis.
+
+    // - returns: The minimum value this chart can display on it's y-axis.
     open override var chartYMin: Double { return _yAxis._axisMinimum }
-    
-    /// - returns: The range of y-values this chart can display.
+
+    // - returns: The range of y-values this chart can display.
     open var yRange: Double { return _yAxis.axisRange }
 }

--- a/Source/Charts/Charts/ScatterChartView.swift
+++ b/Source/Charts/Charts/ScatterChartView.swift
@@ -12,17 +12,17 @@
 import Foundation
 import CoreGraphics
 
-/// The ScatterChart. Draws dots, triangles, squares and custom shapes into the chartview.
+// The ScatterChart. Draws dots, triangles, squares and custom shapes into the chartview.
 open class ScatterChartView: BarLineChartViewBase, ScatterChartDataProvider
 {
     open override func initialize()
     {
         super.initialize()
-        
+
         renderer = ScatterChartRenderer(dataProvider: self, animator: _animator, viewPortHandler: _viewPortHandler)
     }
-    
+
     // MARK: - ScatterChartDataProbider
-    
+
     open var scatterData: ScatterChartData? { return _data as? ScatterChartData }
 }

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -12,7 +12,7 @@
 import Foundation
 import CoreGraphics
 
-/// Base class for all axes
+// Base class for all axes
 @objc(ChartAxisBase)
 open class AxisBase: ComponentBase
 {
@@ -21,7 +21,7 @@ open class AxisBase: ComponentBase
         super.init()
     }
     
-    /// Custom formatter that is used instead of the auto-formatter if set
+    // Custom formatter that is used instead of the auto-formatter if set
     fileprivate var _axisValueFormatter: IAxisValueFormatter?
     
     open var labelFont = NSUIFont.systemFont(ofSize: 10.0)
@@ -41,13 +41,13 @@ open class AxisBase: ComponentBase
     open var drawGridLinesEnabled = true
     open var drawAxisLineEnabled = true
     
-    /// flag that indicates of the labels of this axis should be drawn or not
+    // flag that indicates of the labels of this axis should be drawn or not
     open var drawLabelsEnabled = true
     
     fileprivate var _centerAxisLabelsEnabled = false
 
-    /// Centers the axis labels instead of drawing them at their original position.
-    /// This is useful especially for grouped BarChart.
+    // Centers the axis labels instead of drawing them at their original position.
+    // This is useful especially for grouped BarChart.
     open var centerAxisLabelsEnabled: Bool
     {
         get { return _centerAxisLabelsEnabled && entryCount > 0 }
@@ -59,46 +59,46 @@ open class AxisBase: ComponentBase
         get { return centerAxisLabelsEnabled }
     }
 
-    /// array of limitlines that can be set for the axis
+    // array of limitlines that can be set for the axis
     fileprivate var _limitLines = [ChartLimitLine]()
     
-    /// Are the LimitLines drawn behind the data or in front of the data?
-    /// 
-    /// **default**: false
+    // Are the LimitLines drawn behind the data or in front of the data?
+    // 
+    // **default**: false
     open var drawLimitLinesBehindDataEnabled = false
 
-    /// the flag can be used to turn off the antialias for grid lines
+    // the flag can be used to turn off the antialias for grid lines
     open var gridAntialiasEnabled = true
     
-    /// the actual array of entries
+    // the actual array of entries
     open var entries = [Double]()
     
-    /// axis label entries only used for centered labels
+    // axis label entries only used for centered labels
     open var centeredEntries = [Double]()
     
-    /// the number of entries the legend contains
+    // the number of entries the legend contains
     open var entryCount: Int { return entries.count }
     
-    /// the number of label entries the axis should have
-    ///
-    /// **default**: 6
+    // the number of label entries the axis should have
+    //
+    // **default**: 6
     fileprivate var _labelCount = Int(6)
     
-    /// the number of decimal digits to use (for the default formatter
+    // the number of decimal digits to use (for the default formatter
     open var decimals: Int = 0
     
-    /// When true, axis labels are controlled by the `granularity` property.
-    /// When false, axis values could possibly be repeated.
-    /// This could happen if two adjacent axis values are rounded to same value.
-    /// If using granularity this could be avoided by having fewer axis values visible.
+    // When true, axis labels are controlled by the `granularity` property.
+    // When false, axis values could possibly be repeated.
+    // This could happen if two adjacent axis values are rounded to same value.
+    // If using granularity this could be avoided by having fewer axis values visible.
     open var granularityEnabled = false
     
     fileprivate var _granularity = Double(1.0)
     
-    /// The minimum interval between axis values.
-    /// This can be used to avoid label duplicating when zooming in.
-    ///
-    /// **default**: 1.0
+    // The minimum interval between axis values.
+    // This can be used to avoid label duplicating when zooming in.
+    //
+    // **default**: 1.0
     open var granularity: Double
     {
         get
@@ -114,7 +114,7 @@ open class AxisBase: ComponentBase
         }
     }
     
-    /// The minimum interval between axis values.
+    // The minimum interval between axis values.
     open var isGranularityEnabled: Bool
     {
         get
@@ -123,7 +123,7 @@ open class AxisBase: ComponentBase
         }
     }
     
-    /// if true, the set number of y-labels will be forced
+    // if true, the set number of y-labels will be forced
     open var forceLabelsEnabled = false
     
     open func getLongestLabel() -> String
@@ -143,7 +143,7 @@ open class AxisBase: ComponentBase
         return longest
     }
     
-    /// - returns: The formatted label at the specified index. This will either use the auto-formatter or the custom formatter (if one is set).
+    // - returns: The formatted label at the specified index. This will either use the auto-formatter or the custom formatter (if one is set).
     open func getFormattedLabel(_ index: Int) -> String
     {
         if index < 0 || index >= entries.count
@@ -154,9 +154,9 @@ open class AxisBase: ComponentBase
         return valueFormatter?.stringForValue(entries[index], axis: self) ?? ""
     }
     
-    /// Sets the formatter to be used for formatting the axis labels.
-    /// If no formatter is set, the chart will automatically determine a reasonable formatting (concerning decimals) for all the values that are drawn inside the chart.
-    /// Use `nil` to use the formatter calculated by the chart.
+    // Sets the formatter to be used for formatting the axis labels.
+    // If no formatter is set, the chart will automatically determine a reasonable formatting (concerning decimals) for all the values that are drawn inside the chart.
+    // Use `nil` to use the formatter calculated by the chart.
     open var valueFormatter: IAxisValueFormatter?
     {
         get
@@ -183,41 +183,41 @@ open class AxisBase: ComponentBase
     
     open var isDrawLabelsEnabled: Bool { return drawLabelsEnabled }
     
-    /// Are the LimitLines drawn behind the data or in front of the data?
-    /// 
-    /// **default**: false
+    // Are the LimitLines drawn behind the data or in front of the data?
+    // 
+    // **default**: false
     open var isDrawLimitLinesBehindDataEnabled: Bool { return drawLimitLinesBehindDataEnabled }
     
-    /// Extra spacing for `axisMinimum` to be added to automatically calculated `axisMinimum`
+    // Extra spacing for `axisMinimum` to be added to automatically calculated `axisMinimum`
     open var spaceMin: Double = 0.0
     
-    /// Extra spacing for `axisMaximum` to be added to automatically calculated `axisMaximum`
+    // Extra spacing for `axisMaximum` to be added to automatically calculated `axisMaximum`
     open var spaceMax: Double = 0.0
     
-    /// Flag indicating that the axis-min value has been customized
+    // Flag indicating that the axis-min value has been customized
     internal var _customAxisMin: Bool = false
     
-    /// Flag indicating that the axis-max value has been customized
+    // Flag indicating that the axis-max value has been customized
     internal var _customAxisMax: Bool = false
     
-    /// Do not touch this directly, instead, use axisMinimum.
-    /// This is automatically calculated to represent the real min value,
-    /// and is used when calculating the effective minimum.
+    // Do not touch this directly, instead, use axisMinimum.
+    // This is automatically calculated to represent the real min value,
+    // and is used when calculating the effective minimum.
     internal var _axisMinimum = Double(0)
     
-    /// Do not touch this directly, instead, use axisMaximum.
-    /// This is automatically calculated to represent the real max value,
-    /// and is used when calculating the effective maximum.
+    // Do not touch this directly, instead, use axisMaximum.
+    // This is automatically calculated to represent the real max value,
+    // and is used when calculating the effective maximum.
     internal var _axisMaximum = Double(0)
     
-    /// the total range of values this axis covers
+    // the total range of values this axis covers
     open var axisRange = Double(0)
     
-    /// the number of label entries the axis should have
-    /// max = 25,
-    /// min = 2,
-    /// default = 6,
-    /// be aware that this number is not fixed and can only be approximated
+    // the number of label entries the axis should have
+    // max = 25,
+    // min = 2,
+    // default = 6,
+    // be aware that this number is not fixed and can only be approximated
     open var labelCount: Int
     {
         get
@@ -247,16 +247,16 @@ open class AxisBase: ComponentBase
         forceLabelsEnabled = force
     }
     
-    /// - returns: `true` if focing the y-label count is enabled. Default: false
+    // - returns: `true` if focing the y-label count is enabled. Default: false
     open var isForceLabelsEnabled: Bool { return forceLabelsEnabled }
     
-    /// Adds a new ChartLimitLine to this axis.
+    // Adds a new ChartLimitLine to this axis.
     open func addLimitLine(_ line: ChartLimitLine)
     {
         _limitLines.append(line)
     }
     
-    /// Removes the specified ChartLimitLine from the axis.
+    // Removes the specified ChartLimitLine from the axis.
     open func removeLimitLine(_ line: ChartLimitLine)
     {
         for i in 0 ..< _limitLines.count
@@ -269,13 +269,13 @@ open class AxisBase: ComponentBase
         }
     }
     
-    /// Removes all LimitLines from the axis.
+    // Removes all LimitLines from the axis.
     open func removeAllLimitLines()
     {
         _limitLines.removeAll(keepingCapacity: false)
     }
     
-    /// - returns: The LimitLines of this axis.
+    // - returns: The LimitLines of this axis.
     open var limitLines : [ChartLimitLine]
     {
         return _limitLines
@@ -283,7 +283,7 @@ open class AxisBase: ComponentBase
     
     // MARK: Custom axis ranges
     
-    /// By calling this method, any custom minimum value that has been previously set is reseted, and the calculation is done automatically.
+    // By calling this method, any custom minimum value that has been previously set is reseted, and the calculation is done automatically.
     open func resetCustomAxisMin()
     {
         _customAxisMin = false
@@ -291,7 +291,7 @@ open class AxisBase: ComponentBase
     
     open var isAxisMinCustom: Bool { return _customAxisMin }
     
-    /// By calling this method, any custom maximum value that has been previously set is reseted, and the calculation is done automatically.
+    // By calling this method, any custom maximum value that has been previously set is reseted, and the calculation is done automatically.
     open func resetCustomAxisMax()
     {
         _customAxisMax = false
@@ -299,7 +299,7 @@ open class AxisBase: ComponentBase
     
     open var isAxisMaxCustom: Bool { return _customAxisMax }
     
-    /// This property is deprecated - Use `axisMinimum` instead.
+    // This property is deprecated - Use `axisMinimum` instead.
     @available(*, deprecated: 1.0, message: "Use axisMinimum instead.")
     open var axisMinValue: Double
     {
@@ -307,7 +307,7 @@ open class AxisBase: ComponentBase
         set { axisMinimum = newValue }
     }
     
-    /// This property is deprecated - Use `axisMaximum` instead.
+    // This property is deprecated - Use `axisMaximum` instead.
     @available(*, deprecated: 1.0, message: "Use axisMaximum instead.")
     open var axisMaxValue: Double
     {
@@ -315,9 +315,9 @@ open class AxisBase: ComponentBase
         set { axisMaximum = newValue }
     }
     
-    /// The minimum value for this axis.
-    /// If set, this value will not be calculated automatically depending on the provided data.
-    /// Use `resetCustomAxisMin()` to undo this.
+    // The minimum value for this axis.
+    // If set, this value will not be calculated automatically depending on the provided data.
+    // Use `resetCustomAxisMin()` to undo this.
     open var axisMinimum: Double
     {
         get
@@ -332,9 +332,9 @@ open class AxisBase: ComponentBase
         }
     }
     
-    /// The maximum value for this axis.
-    /// If set, this value will not be calculated automatically depending on the provided data.
-    /// Use `resetCustomAxisMax()` to undo this.
+    // The maximum value for this axis.
+    // If set, this value will not be calculated automatically depending on the provided data.
+    // Use `resetCustomAxisMax()` to undo this.
     open var axisMaximum: Double
     {
         get
@@ -349,9 +349,9 @@ open class AxisBase: ComponentBase
         }
     }
     
-    /// Calculates the minimum, maximum and range values of the YAxis with the given minimum and maximum values from the chart data.
-    /// - parameter dataMin: the y-min value according to chart data
-    /// - parameter dataMax: the y-max value according to chart
+    // Calculates the minimum, maximum and range values of the YAxis with the given minimum and maximum values from the chart data.
+    // - parameter dataMin: the y-min value according to chart data
+    // - parameter dataMax: the y-max value according to chart
     open func calculate(min dataMin: Double, max dataMax: Double)
     {
         // if custom, use value as is, else use data value

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -13,8 +13,8 @@ import Foundation
 import CoreGraphics
 
 
-/// The limit line is an additional feature for all Line, Bar and ScatterCharts.
-/// It allows the displaying of an additional line in the chart that marks a certain maximum / limit on the specified axis (x- or y-axis).
+// The limit line is an additional feature for all Line, Bar and ScatterCharts.
+// It allows the displaying of an additional line in the chart that marks a certain maximum / limit on the specified axis (x- or y-axis).
 open class ChartLimitLine: ComponentBase
 {
     @objc(ChartLimitLabelPosition)
@@ -25,41 +25,41 @@ open class ChartLimitLine: ComponentBase
         case rightTop
         case rightBottom
     }
-    
-    /// limit / maximum (the y-value or xIndex)
+
+    // limit / maximum (the y-value or xIndex)
     open var limit = Double(0.0)
-    
+
     fileprivate var _lineWidth = CGFloat(2.0)
     open var lineColor = NSUIColor(red: 237.0/255.0, green: 91.0/255.0, blue: 91.0/255.0, alpha: 1.0)
     open var lineDashPhase = CGFloat(0.0)
     open var lineDashLengths: [CGFloat]?
-    
+
     open var valueTextColor = NSUIColor.black
     open var valueFont = NSUIFont.systemFont(ofSize: 13.0)
-    
+
     open var drawLabelEnabled = true
     open var label = ""
     open var labelPosition = LabelPosition.rightTop
-    
+
     public override init()
     {
         super.init()
     }
-    
+
     public init(limit: Double)
     {
         super.init()
         self.limit = limit
     }
-    
+
     public init(limit: Double, label: String)
     {
         super.init()
         self.limit = limit
         self.label = label
     }
-    
-    /// set the line width of the chart (min = 0.2, max = 12); default 2
+
+    // set the line width of the chart (min = 0.2, max = 12); default 2
     open var lineWidth: CGFloat
     {
         get

--- a/Source/Charts/Components/ComponentBase.swift
+++ b/Source/Charts/Components/ComponentBase.swift
@@ -13,21 +13,21 @@ import Foundation
 import CoreGraphics
 
 
-/// This class encapsulates everything both Axis, Legend and LimitLines have in common
+// This class encapsulates everything both Axis, Legend and LimitLines have in common
 @objc(ChartComponentBase)
 open class ComponentBase: NSObject
 {
-    /// flag that indicates if this component is enabled or not
+    // flag that indicates if this component is enabled or not
     open var enabled = true
-    
-    /// The offset this component has on the x-axis
-    /// **default**: 5.0
+
+    // The offset this component has on the x-axis
+    // **default**: 5.0
     open var xOffset = CGFloat(5.0)
-    
-    /// The offset this component has on the x-axis
-    /// **default**: 5.0 (or 0.0 on ChartYAxis)
+
+    // The offset this component has on the x-axis
+    // **default**: 5.0 (or 0.0 on ChartYAxis)
     open var yOffset = CGFloat(5.0)
-    
+
     public override init()
     {
         super.init()

--- a/Source/Charts/Components/Description.swift
+++ b/Source/Charts/Components/Description.swift
@@ -25,22 +25,22 @@ open class Description: ComponentBase
         #else
             font = NSUIFont.systemFont(ofSize: 8.0)
         #endif
-        
+
         super.init()
     }
-    
-    /// The text to be shown as the description.
+
+    // The text to be shown as the description.
     open var text: String? = "Description Label"
-    
-    /// Custom position for the description text in pixels on the screen.
+
+    // Custom position for the description text in pixels on the screen.
     open var position: CGPoint? = nil
-    
-    /// The text alignment of the description text. Default RIGHT.
+
+    // The text alignment of the description text. Default RIGHT.
     open var textAlign: NSTextAlignment = NSTextAlignment.right
-    
-    /// Font object used for drawing the description text.
+
+    // Font object used for drawing the description text.
     open var font: NSUIFont
-    
-    /// Text color used for drawing the description text
+
+    // Text color used for drawing the description text
     open var textColor = NSUIColor.black
 }

--- a/Source/Charts/Components/IMarker.swift
+++ b/Source/Charts/Components/IMarker.swift
@@ -15,26 +15,26 @@ import CoreGraphics
 @objc(IChartMarker)
 public protocol IMarker: NSObjectProtocol
 {
-    /// - returns: The desired (general) offset you wish the IMarker to have on the x-axis.
-    ///
-    /// By returning x: -(width / 2) you will center the IMarker horizontally.
-    ///
-    /// By returning y: -(height / 2) you will center the IMarker vertically.
+    // - returns: The desired (general) offset you wish the IMarker to have on the x-axis.
+    //
+    // By returning x: -(width / 2) you will center the IMarker horizontally.
+    //
+    // By returning y: -(height / 2) you will center the IMarker vertically.
     var offset: CGPoint { get }
-    
-    /// - returns: The offset for drawing at the specific `point`.
-    ///            This allows conditional adjusting of the Marker position.
-    ///            If you have no adjustments to make, return self.offset().
-    ///
-    /// - parameter point: This is the point at which the marker wants to be drawn. You can adjust the offset conditionally based on this argument.
+
+    // - returns: The offset for drawing at the specific `point`.
+    //            This allows conditional adjusting of the Marker position.
+    //            If you have no adjustments to make, return self.offset().
+    //
+    // - parameter point: This is the point at which the marker wants to be drawn. You can adjust the offset conditionally based on this argument.
     func offsetForDrawing(atPoint: CGPoint) -> CGPoint
-    
-    /// This method enables a custom IMarker to update it's content every time the IMarker is redrawn according to the data entry it points to.
-    ///
-    /// - parameter entry: The Entry the IMarker belongs to. This can also be any subclass of Entry, like BarEntry or CandleEntry, simply cast it at runtime.
-    /// - parameter highlight: The highlight object contains information about the highlighted value such as it's dataset-index, the selected range or stack-index (only stacked bar entries).
+
+    // This method enables a custom IMarker to update it's content every time the IMarker is redrawn according to the data entry it points to.
+    //
+    // - parameter entry: The Entry the IMarker belongs to. This can also be any subclass of Entry, like BarEntry or CandleEntry, simply cast it at runtime.
+    // - parameter highlight: The highlight object contains information about the highlighted value such as it's dataset-index, the selected range or stack-index (only stacked bar entries).
     func refreshContent(entry: ChartDataEntry, highlight: Highlight)
-    
-    /// Draws the IMarker on the given position on the given context
+
+    // Draws the IMarker on the given position on the given context
     func draw(context: CGContext, point: CGPoint)
 }

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 @objc(ChartLegend)
 open class Legend: ComponentBase
 {
-    /// This property is deprecated - Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.
+    // This property is deprecated - Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.
     @available(*, deprecated: 1.0, message: "Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.")
     @objc(ChartLegendPosition)
     public enum Position: Int
@@ -38,29 +38,29 @@ open class Legend: ComponentBase
         case aboveChartCenter
         case piechartCenter
     }
-    
+
     @objc(ChartLegendForm)
     public enum Form: Int
     {
-        /// Avoid drawing a form
+        // Avoid drawing a form
         case none
-        
-        /// Do not draw the a form, but leave space for it
+
+        // Do not draw the a form, but leave space for it
         case empty
-        
-        /// Use default (default dataset's form to the legend's form)
+
+        // Use default (default dataset's form to the legend's form)
         case `default`
-        
-        /// Draw a square
+
+        // Draw a square
         case square
-        
-        /// Draw a circle
+
+        // Draw a circle
         case circle
-        
-        /// Draw a horizontal line
+
+        // Draw a horizontal line
         case line
     }
-    
+
     @objc(ChartLegendHorizontalAlignment)
     public enum HorizontalAlignment: Int
     {
@@ -68,7 +68,7 @@ open class Legend: ComponentBase
         case center
         case right
     }
-    
+
     @objc(ChartLegendVerticalAlignment)
     public enum VerticalAlignment: Int
     {
@@ -76,34 +76,34 @@ open class Legend: ComponentBase
         case center
         case bottom
     }
-    
+
     @objc(ChartLegendOrientation)
     public enum Orientation: Int
     {
         case horizontal
         case vertical
     }
-    
+
     @objc(ChartLegendDirection)
     public enum Direction: Int
     {
         case leftToRight
         case rightToLeft
     }
-    
-    /// The legend entries array
+
+    // The legend entries array
     open var entries = [LegendEntry]()
-    
-    /// Entries that will be appended to the end of the auto calculated entries after calculating the legend.
-    /// (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
+
+    // Entries that will be appended to the end of the auto calculated entries after calculating the legend.
+    // (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
     open var extraEntries = [LegendEntry]()
-    
-    /// Are the legend labels/colors a custom value or auto calculated? If false, then it's auto, if true, then custom.
-    /// 
-    /// **default**: false (automatic legend)
+
+    // Are the legend labels/colors a custom value or auto calculated? If false, then it's auto, if true, then custom.
+    //
+    // **default**: false (automatic legend)
     fileprivate var _isLegendCustom = false
-    
-    /// This property is deprecated - Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.
+
+    // This property is deprecated - Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.
     @available(*, deprecated: 1.0, message: "Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.")
     open var position: Position
     {
@@ -146,109 +146,109 @@ open class Legend: ComponentBase
                 horizontalAlignment = .left
                 verticalAlignment = newValue == .leftOfChartCenter ? .center : .top
                 orientation = .vertical
-                
+
             case .rightOfChart: fallthrough
             case .rightOfChartInside: fallthrough
             case .rightOfChartCenter:
                 horizontalAlignment = .right
                 verticalAlignment = newValue == .rightOfChartCenter ? .center : .top
                 orientation = .vertical
-                
+
             case .aboveChartLeft: fallthrough
             case .aboveChartCenter: fallthrough
             case .aboveChartRight:
                 horizontalAlignment = newValue == .aboveChartLeft ? .left : (newValue == .aboveChartRight ? .right : .center)
                 verticalAlignment = .top
                 orientation = .horizontal
-                
+
             case .belowChartLeft: fallthrough
             case .belowChartCenter: fallthrough
             case .belowChartRight:
                 horizontalAlignment = newValue == .belowChartLeft ? .left : (newValue == .belowChartRight ? .right : .center)
                 verticalAlignment = .bottom
                 orientation = .horizontal
-                
+
             case .piechartCenter:
                 horizontalAlignment = .center
                 verticalAlignment = .center
                 orientation = .vertical
             }
-            
+
             drawInside = newValue == .leftOfChartInside || newValue == .rightOfChartInside
         }
     }
-    
-    /// The horizontal alignment of the legend
+
+    // The horizontal alignment of the legend
     open var horizontalAlignment: HorizontalAlignment = HorizontalAlignment.left
-    
-    /// The vertical alignment of the legend
+
+    // The vertical alignment of the legend
     open var verticalAlignment: VerticalAlignment = VerticalAlignment.bottom
-    
-    /// The orientation of the legend
+
+    // The orientation of the legend
     open var orientation: Orientation = Orientation.horizontal
-    
-    /// Flag indicating whether the legend will draw inside the chart or outside
+
+    // Flag indicating whether the legend will draw inside the chart or outside
     open var drawInside: Bool = false
-    
-    /// Flag indicating whether the legend will draw inside the chart or outside
+
+    // Flag indicating whether the legend will draw inside the chart or outside
     open var isDrawInsideEnabled: Bool { return drawInside }
-    
-    /// The text direction of the legend
+
+    // The text direction of the legend
     open var direction: Direction = Direction.leftToRight
 
     open var font: NSUIFont = NSUIFont.systemFont(ofSize: 10.0)
     open var textColor = NSUIColor.black
 
-    /// The form/shape of the legend forms
+    // The form/shape of the legend forms
     open var form = Form.square
-    
-    /// The size of the legend forms
+
+    // The size of the legend forms
     open var formSize = CGFloat(8.0)
-    
-    /// The line width for forms that consist of lines
+
+    // The line width for forms that consist of lines
     open var formLineWidth = CGFloat(3.0)
-    
-    /// Line dash configuration for shapes that consist of lines.
-    ///
-    /// This is how much (in pixels) into the dash pattern are we starting from.
+
+    // Line dash configuration for shapes that consist of lines.
+    //
+    // This is how much (in pixels) into the dash pattern are we starting from.
     open var formLineDashPhase: CGFloat = 0.0
-    
-    /// Line dash configuration for shapes that consist of lines.
-    ///
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+
+    // Line dash configuration for shapes that consist of lines.
+    //
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     open var formLineDashLengths: [CGFloat]?
-    
+
     open var xEntrySpace = CGFloat(6.0)
     open var yEntrySpace = CGFloat(0.0)
     open var formToTextSpace = CGFloat(5.0)
     open var stackSpace = CGFloat(3.0)
-    
+
     open var calculatedLabelSizes = [CGSize]()
     open var calculatedLabelBreakPoints = [Bool]()
     open var calculatedLineSizes = [CGSize]()
-    
+
     public override init()
     {
         super.init()
-        
+
         self.xOffset = 5.0
         self.yOffset = 3.0
     }
-    
+
     public init(entries: [LegendEntry])
     {
         super.init()
-        
+
         self.entries = entries
     }
-    
+
     open func getMaximumEntrySize(withFont font: NSUIFont) -> CGSize
     {
         var maxW = CGFloat(0.0)
         var maxH = CGFloat(0.0)
-        
+
         var maxFormSize: CGFloat = 0.0
 
         for entry in entries
@@ -258,12 +258,12 @@ open class Legend: ComponentBase
             {
                 maxFormSize = formSize
             }
-            
+
             guard let label = entry.label
                 else { continue }
-            
+
             let size = (label as NSString!).size(attributes: [NSFontAttributeName: font])
-            
+
             if size.width > maxW
             {
                 maxW = size.width
@@ -273,7 +273,7 @@ open class Legend: ComponentBase
                 maxH = size.height
             }
         }
-        
+
         return CGSize(
             width: maxW + maxFormSize + formToTextSpace,
             height: maxH
@@ -284,24 +284,24 @@ open class Legend: ComponentBase
     open var neededHeight = CGFloat(0.0)
     open var textWidthMax = CGFloat(0.0)
     open var textHeightMax = CGFloat(0.0)
-    
-    /// flag that indicates if word wrapping is enabled
-    /// this is currently supported only for `orientation == Horizontal`.
-    /// you may want to set maxSizePercent when word wrapping, to set the point where the text wraps.
-    /// 
-    /// **default**: true
+
+    // flag that indicates if word wrapping is enabled
+    // this is currently supported only for `orientation == Horizontal`.
+    // you may want to set maxSizePercent when word wrapping, to set the point where the text wraps.
+    //
+    // **default**: true
     open var wordWrapEnabled = true
-    
-    /// if this is set, then word wrapping the legend is enabled.
+
+    // if this is set, then word wrapping the legend is enabled.
     open var isWordWrapEnabled: Bool { return wordWrapEnabled }
 
-    /// The maximum relative size out of the whole chart view in percent.
-    /// If the legend is to the right/left of the chart, then this affects the width of the legend.
-    /// If the legend is to the top/bottom of the chart, then this affects the height of the legend.
-    /// 
-    /// **default**: 0.95 (95%)
+    // The maximum relative size out of the whole chart view in percent.
+    // If the legend is to the right/left of the chart, then this affects the width of the legend.
+    // If the legend is to the top/bottom of the chart, then this affects the height of the legend.
+    //
+    // **default**: 0.95 (95%)
     open var maxSizePercent: CGFloat = 0.95
-    
+
     open func calculateDimensions(labelFont: NSUIFont, viewPortHandler: ViewPortHandler)
     {
         let maxEntrySize = getMaximumEntrySize(withFont: labelFont)
@@ -313,33 +313,33 @@ open class Legend: ComponentBase
         let wordWrapEnabled = self.wordWrapEnabled
         let entries = self.entries
         let entryCount = entries.count
-        
+
         textWidthMax = maxEntrySize.width
         textHeightMax = maxEntrySize.height
-        
+
         switch orientation
         {
         case .vertical:
-            
+
             var maxWidth = CGFloat(0.0)
             var width = CGFloat(0.0)
             var maxHeight = CGFloat(0.0)
             let labelLineHeight = labelFont.lineHeight
-            
+
             var wasStacked = false
-            
+
             for i in 0 ..< entryCount
             {
                 let e = entries[i]
                 let drawingForm = e.form != .none
                 let formSize = e.formSize.isNaN ? defaultFormSize : e.formSize
                 let label = e.label
-                
+
                 if !wasStacked
                 {
                     width = 0.0
                 }
-                
+
                 if drawingForm
                 {
                     if wasStacked
@@ -348,11 +348,11 @@ open class Legend: ComponentBase
                     }
                     width += formSize
                 }
-                
+
                 if label != nil
                 {
                     let size = (label as NSString!).size(attributes: [NSFontAttributeName: labelFont])
-                    
+
                     if drawingForm && !wasStacked
                     {
                         width += formToTextSpace
@@ -364,9 +364,9 @@ open class Legend: ComponentBase
                         width = 0.0
                         wasStacked = false
                     }
-                    
+
                     width += size.width
-                    
+
                     if i < entryCount - 1
                     {
                         maxHeight += labelLineHeight + yEntrySpace
@@ -376,54 +376,54 @@ open class Legend: ComponentBase
                 {
                     wasStacked = true
                     width += formSize
-                    
+
                     if i < entryCount - 1
                     {
                         width += stackSpace
                     }
                 }
-                
+
                 maxWidth = max(maxWidth, width)
             }
-            
+
             neededWidth = maxWidth
             neededHeight = maxHeight
-            
+
         case .horizontal:
-            
+
             let labelLineHeight = labelFont.lineHeight
-            
+
             let contentWidth: CGFloat = viewPortHandler.contentWidth * maxSizePercent
-            
+
             // Prepare arrays for calculated layout
             if calculatedLabelSizes.count != entryCount
             {
                 calculatedLabelSizes = [CGSize](repeating: CGSize(), count: entryCount)
             }
-            
+
             if calculatedLabelBreakPoints.count != entryCount
             {
                 calculatedLabelBreakPoints = [Bool](repeating: false, count: entryCount)
             }
-            
+
             calculatedLineSizes.removeAll(keepingCapacity: true)
-            
+
             // Start calculating layout
-            
+
             let labelAttrs = [NSFontAttributeName: labelFont]
             var maxLineWidth: CGFloat = 0.0
             var currentLineWidth: CGFloat = 0.0
             var requiredWidth: CGFloat = 0.0
             var stackedStartIndex: Int = -1
-            
+
             for i in 0 ..< entryCount
             {
                 let e = entries[i]
                 let drawingForm = e.form != .none
                 let label = e.label
-                
+
                 calculatedLabelBreakPoints[i] = false
-                
+
                 if stackedStartIndex == -1
                 {
                     // we are not stacking, so required width is for this label only
@@ -434,7 +434,7 @@ open class Legend: ComponentBase
                     // add the spacing appropriate for stacked labels/forms
                     requiredWidth += stackSpace
                 }
-                
+
                 // grouped forms have null labels
                 if label != nil
                 {
@@ -446,18 +446,18 @@ open class Legend: ComponentBase
                 {
                     calculatedLabelSizes[i] = CGSize()
                     requiredWidth += drawingForm ? formSize : 0.0
-                    
+
                     if stackedStartIndex == -1
                     {
                         // mark this index as we might want to break here later
                         stackedStartIndex = i
                     }
                 }
-                
+
                 if label != nil || i == entryCount - 1
                 {
                     let requiredSpacing = currentLineWidth == 0.0 ? 0.0 : xEntrySpace
-                    
+
                     if (!wordWrapEnabled || // No word wrapping, it must fit.
                         currentLineWidth == 0.0 || // The line is empty, it must fit.
                         (contentWidth - currentLineWidth >= requiredSpacing + requiredWidth)) // It simply fits
@@ -467,63 +467,63 @@ open class Legend: ComponentBase
                     }
                     else
                     { // It doesn't fit, we need to wrap a line
-                        
+
                         // Add current line size to array
                         calculatedLineSizes.append(CGSize(width: currentLineWidth, height: labelLineHeight))
                         maxLineWidth = max(maxLineWidth, currentLineWidth)
-                        
+
                         // Start a new line
                         calculatedLabelBreakPoints[stackedStartIndex > -1 ? stackedStartIndex : i] = true
                         currentLineWidth = requiredWidth
                     }
-                    
+
                     if i == entryCount - 1
                     { // Add last line size to array
                         calculatedLineSizes.append(CGSize(width: currentLineWidth, height: labelLineHeight))
                         maxLineWidth = max(maxLineWidth, currentLineWidth)
                     }
                 }
-                
+
                 stackedStartIndex = label != nil ? -1 : stackedStartIndex
             }
-            
+
             neededWidth = maxLineWidth
             neededHeight = labelLineHeight * CGFloat(calculatedLineSizes.count) +
                 yEntrySpace * CGFloat(calculatedLineSizes.count == 0 ? 0 : (calculatedLineSizes.count - 1))
         }
-        
+
         neededWidth += xOffset
         neededHeight += yOffset
     }
-    
-    /// MARK: - Custom legend
-    
-    /// Sets a custom legend's entries array.
-    /// * A nil label will start a group.
-    /// This will disable the feature that automatically calculates the legend entries from the datasets.
-    /// Call `resetCustom(...)` to re-enable automatic calculation (and then `notifyDataSetChanged()` is needed).
+
+    // MARK: - Custom legend
+
+    // Sets a custom legend's entries array.
+    // * A nil label will start a group.
+    // This will disable the feature that automatically calculates the legend entries from the datasets.
+    // Call `resetCustom(...)` to re-enable automatic calculation (and then `notifyDataSetChanged()` is needed).
     open func setCustom(entries: [LegendEntry])
     {
         self.entries = entries
         _isLegendCustom = true
     }
-    
-    /// Calling this will disable the custom legend entries (set by `setLegend(...)`). Instead, the entries will again be calculated automatically (after `notifyDataSetChanged()` is called).
+
+    // Calling this will disable the custom legend entries (set by `setLegend(...)`). Instead, the entries will again be calculated automatically (after `notifyDataSetChanged()` is called).
     open func resetCustom()
     {
         _isLegendCustom = false
     }
-    
-    /// **default**: false (automatic legend)
-    /// - returns: `true` if a custom legend entries has been set
+
+    // **default**: false (automatic legend)
+    // - returns: `true` if a custom legend entries has been set
     open var isLegendCustom: Bool
     {
         return _isLegendCustom
     }
-    
+
     // MARK: - Deprecated stuff
-    
-    /// This property is deprecated - Use `entries`.
+
+    // This property is deprecated - Use `entries`.
     @available(*, deprecated: 1.0, message: "Use `entries`.")
     open var colors: [NSUIColor?]
     {
@@ -548,7 +548,7 @@ open class Legend: ComponentBase
                     entries.append(LegendEntry())
                 }
                 entries[i].formColor = newValue[i]
-                
+
                 if newValue[i] == nil
                 {
                     entries[i].form = .none
@@ -560,8 +560,8 @@ open class Legend: ComponentBase
             }
         }
     }
-    
-    /// This property is deprecated - Use `entries`.
+
+    // This property is deprecated - Use `entries`.
     @available(*, deprecated: 1.0, message: "Use `entries`.")
     open var labels: [String?]
     {
@@ -586,9 +586,9 @@ open class Legend: ComponentBase
             }
         }
     }
-    
-    
-    /// This property is deprecated - Use `extraEntries`.
+
+
+    // This property is deprecated - Use `extraEntries`.
     @available(*, deprecated: 1.0, message: "Use `extraEntries`.")
     open var extraColors: [NSUIColor?]
     {
@@ -610,11 +610,11 @@ open class Legend: ComponentBase
             {
                 extraEntries.removeSubrange(newValue.count ..< extraEntries.count)
             }
-            
+
             for i in 0 ..< newValue.count
             {
                 extraEntries[i].formColor = newValue[i]
-                
+
                 if newValue[i] == nil
                 {
                     extraEntries[i].form = .none
@@ -626,8 +626,8 @@ open class Legend: ComponentBase
             }
         }
     }
-    
-    /// This property is deprecated - Use `extraEntries`.
+
+    // This property is deprecated - Use `extraEntries`.
     @available(*, deprecated: 1.0, message: "Use `extraEntries`.")
     open var extraLabels: [String?]
     {
@@ -646,28 +646,28 @@ open class Legend: ComponentBase
             {
                 extraEntries.removeSubrange(newValue.count ..< extraEntries.count)
             }
-            
+
             for i in 0 ..< newValue.count
             {
                 extraEntries[i].label = newValue[i]
             }
         }
     }
-    
-    /// This constructor is deprecated - Use `init(entries:)`
+
+    // This constructor is deprecated - Use `init(entries:)`
     @available(*, deprecated: 1.0, message: "Use `init(entries:)`")
     public init(colors: [NSUIColor?], labels: [String?])
     {
         super.init()
-        
+
         var entries = [LegendEntry]()
-        
+
         for i in 0 ..< min(colors.count, labels.count)
         {
             let entry = LegendEntry()
             entry.formColor = colors[i]
             entry.label = labels[i]
-            
+
             if entry.formColor == nil
             {
                 entry.form = .none
@@ -676,27 +676,27 @@ open class Legend: ComponentBase
             {
                 entry.form = .empty
             }
-            
+
             entries.append(entry)
         }
-        
+
         self.entries = entries
     }
-    
-    /// This constructor is deprecated - Use `init(entries:)`
+
+    // This constructor is deprecated - Use `init(entries:)`
     @available(*, deprecated: 1.0, message: "Use `init(entries:)`")
     public init(colors: [NSObject], labels: [NSObject])
     {
         super.init()
-        
+
         var entries = [LegendEntry]()
-        
+
         for i in 0 ..< min(colors.count, labels.count)
         {
             let entry = LegendEntry()
             entry.formColor = colors[i] as? NSUIColor
             entry.label = labels[i] as? String
-            
+
             if entry.formColor == nil
             {
                 entry.form = .none
@@ -705,62 +705,62 @@ open class Legend: ComponentBase
             {
                 entry.form = .empty
             }
-            
+
             entries.append(entry)
         }
-        
+
         self.entries = entries
     }
-    
-    /// This property is deprecated - Use `extraEntries`
+
+    // This property is deprecated - Use `extraEntries`
     @available(*, deprecated: 1.0, message: "Use `extraEntries`")
     open var extraColorsObjc: [NSObject]
     {
         return ChartUtils.bridgedObjCGetNSUIColorArray(swift: extraColors)
     }
-    
-    /// This property is deprecated - Use `extraLabels`
+
+    // This property is deprecated - Use `extraLabels`
     @available(*, deprecated: 1.0, message: "Use `extraLabels`")
     open var extraLabelsObjc: [NSObject]
     {
         return ChartUtils.bridgedObjCGetStringArray(swift: extraLabels)
     }
-    
-    /// This property is deprecated - Use `colors`
+
+    // This property is deprecated - Use `colors`
     @available(*, deprecated: 1.0, message: "Use `colors`")
     open var colorsObjc: [NSObject]
     {
         get { return ChartUtils.bridgedObjCGetNSUIColorArray(swift: colors) }
         set { self.colors = ChartUtils.bridgedObjCGetNSUIColorArray(objc: newValue) }
     }
-    
-    /// This property is deprecated - Use `labels`
+
+    // This property is deprecated - Use `labels`
     @available(*, deprecated: 1.0, message: "Use `labels`")
     open var labelsObjc: [NSObject]
     {
         get { return ChartUtils.bridgedObjCGetStringArray(swift: labels) }
         set { self.labels = ChartUtils.bridgedObjCGetStringArray(objc: newValue) }
     }
-    
-    /// This function is deprecated - Use `entries`
+
+    // This function is deprecated - Use `entries`
     @available(*, deprecated: 1.0, message: "Use `entries`")
     open func getLabel(_ index: Int) -> String?
     {
         return entries[index].label
     }
-    
-    /// This function is deprecated - Use `Use `extra(entries:)`
+
+    // This function is deprecated - Use `Use `extra(entries:)`
     @available(*, deprecated: 1.0, message: "Use `extra(entries:)`")
     open func setExtra(colors: [NSUIColor?], labels: [String?])
     {
         var entries = [LegendEntry]()
-        
+
         for i in 0 ..< min(colors.count, labels.count)
         {
             let entry = LegendEntry()
             entry.formColor = colors[i]
             entry.label = labels[i]
-            
+
             if entry.formColor == nil
             {
                 entry.form = .none
@@ -769,25 +769,25 @@ open class Legend: ComponentBase
             {
                 entry.form = .empty
             }
-            
+
             entries.append(entry)
         }
-        
+
         self.extraEntries = entries
     }
-    
-    /// This function is deprecated - Use `Use `extra(entries:)`
+
+    // This function is deprecated - Use `Use `extra(entries:)`
     @available(*, deprecated: 1.0, message: "Use `extra(entries:)`")
     open func setExtra(colors: [NSObject], labels: [NSObject])
     {
         var entries = [LegendEntry]()
-        
+
         for i in 0 ..< min(colors.count, labels.count)
         {
             let entry = LegendEntry()
             entry.formColor = colors[i] as? NSUIColor
             entry.label = labels[i] as? String
-            
+
             if entry.formColor == nil
             {
                 entry.form = .none
@@ -796,25 +796,25 @@ open class Legend: ComponentBase
             {
                 entry.form = .empty
             }
-            
+
             entries.append(entry)
         }
-        
+
         self.extraEntries = entries
     }
-    
-    /// This function is deprecated - Use `Use `setCustom(entries:)`
+
+    // This function is deprecated - Use `Use `setCustom(entries:)`
     @available(*, deprecated: 1.0, message: "Use `setCustom(entries:)`")
     open func setCustom(colors: [NSUIColor?], labels: [String?])
     {
         var entries = [LegendEntry]()
-        
+
         for i in 0 ..< min(colors.count, labels.count)
         {
             let entry = LegendEntry()
             entry.formColor = colors[i]
             entry.label = labels[i]
-            
+
             if entry.formColor == nil
             {
                 entry.form = .none
@@ -823,25 +823,25 @@ open class Legend: ComponentBase
             {
                 entry.form = .empty
             }
-            
+
             entries.append(entry)
         }
-        
+
         setCustom(entries: entries)
     }
-    
-    /// This function is deprecated - Use `Use `setCustom(entries:)`
+
+    // This function is deprecated - Use `Use `setCustom(entries:)`
     @available(*, deprecated: 1.0, message: "Use `setCustom(entries:)`")
     open func setCustom(colors: [NSObject], labels: [NSObject])
     {
         var entries = [LegendEntry]()
-        
+
         for i in 0 ..< min(colors.count, labels.count)
         {
             let entry = LegendEntry()
             entry.formColor = colors[i] as? NSUIColor
             entry.label = labels[i] as? String
-            
+
             if entry.formColor == nil
             {
                 entry.form = .none
@@ -850,10 +850,10 @@ open class Legend: ComponentBase
             {
                 entry.form = .empty
             }
-            
+
             entries.append(entry)
         }
-        
+
         setCustom(entries: entries)
     }
 }

--- a/Source/Charts/Components/LegendEntry.swift
+++ b/Source/Charts/Components/LegendEntry.swift
@@ -23,15 +23,15 @@ open class LegendEntry: NSObject
     {
         super.init()
     }
-    
-    /// - parameter label:                  The legend entry text.
-    ///                                     A `nil` label will start a group.
-    /// - parameter form:                   The form to draw for this entry.
-    /// - parameter formSize:               Set to NaN to use the legend's default.
-    /// - parameter formLineWidth:          Set to NaN to use the legend's default.
-    /// - parameter formLineDashPhase:      Line dash configuration.
-    /// - parameter formLineDashLengths:    Line dash configurationas NaN to use the legend's default.
-    /// - parameter formColor:              The color for drawing the form.
+
+    // - parameter label:                  The legend entry text.
+    //                                     A `nil` label will start a group.
+    // - parameter form:                   The form to draw for this entry.
+    // - parameter formSize:               Set to NaN to use the legend's default.
+    // - parameter formLineWidth:          Set to NaN to use the legend's default.
+    // - parameter formLineDashPhase:      Line dash configuration.
+    // - parameter formLineDashLengths:    Line dash configurationas NaN to use the legend's default.
+    // - parameter formColor:              The color for drawing the form.
     public init(label: String?,
                 form: Legend.Form,
                 formSize: CGFloat,
@@ -48,44 +48,44 @@ open class LegendEntry: NSObject
         self.formLineDashLengths = formLineDashLengths
         self.formColor = formColor
     }
-    
-    /// The legend entry text.
-    /// A `nil` label will start a group.
+
+    // The legend entry text.
+    // A `nil` label will start a group.
     open var label: String?
-    
-    /// The form to draw for this entry.
-    ///
-    /// `None` will avoid drawing a form, and any related space.
-    /// `Empty` will avoid drawing a form, but keep its space.
-    /// `Default` will use the Legend's default.
+
+    // The form to draw for this entry.
+    //
+    // `None` will avoid drawing a form, and any related space.
+    // `Empty` will avoid drawing a form, but keep its space.
+    // `Default` will use the Legend's default.
     open var form: Legend.Form = .default
-    
-    /// Form size will be considered except for when .None is used
-    ///
-    /// Set as NaN to use the legend's default
+
+    // Form size will be considered except for when .None is used
+    //
+    // Set as NaN to use the legend's default
     open var formSize: CGFloat = CGFloat.nan
-    
-    /// Line width used for shapes that consist of lines.
-    ///
-    /// Set to NaN to use the legend's default.
+
+    // Line width used for shapes that consist of lines.
+    //
+    // Set to NaN to use the legend's default.
     open var formLineWidth: CGFloat = CGFloat.nan
-    
-    /// Line dash configuration for shapes that consist of lines.
-    ///
-    /// This is how much (in pixels) into the dash pattern are we starting from.
-    ///
-    /// Set to NaN to use the legend's default.
+
+    // Line dash configuration for shapes that consist of lines.
+    //
+    // This is how much (in pixels) into the dash pattern are we starting from.
+    //
+    // Set to NaN to use the legend's default.
     open var formLineDashPhase: CGFloat = 0.0
-    
-    /// Line dash configuration for shapes that consist of lines.
-    ///
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
-    ///
-    /// Set to nil to use the legend's default.
+
+    // Line dash configuration for shapes that consist of lines.
+    //
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    //
+    // Set to nil to use the legend's default.
     open var formLineDashLengths: [CGFloat]?
-    
-    /// The color for drawing the form
+
+    // The color for drawing the form
     open var formColor: NSUIColor?
 }

--- a/Source/Charts/Components/MarkerImage.swift
+++ b/Source/Charts/Components/MarkerImage.swift
@@ -19,29 +19,29 @@ import CoreGraphics
 @objc(ChartMarkerImage)
 open class MarkerImage: NSObject, IMarker
 {
-    /// The marker image to render
+    // The marker image to render
     open var image: NSUIImage?
-    
+
     open var offset: CGPoint = CGPoint()
-    
+
     open weak var chartView: ChartViewBase?
-    
-    /// As long as size is 0.0/0.0 - it will default to the image's size
+
+    // As long as size is 0.0/0.0 - it will default to the image's size
     open var size: CGSize = CGSize()
-    
+
     public override init()
     {
         super.init()
     }
-    
+
     open func offsetForDrawing(atPoint point: CGPoint) -> CGPoint
     {
         var offset = self.offset
-        
+
         let chart = self.chartView
-        
+
         var size = self.size
-        
+
         if size.width == 0.0 && image != nil
         {
             size.width = image?.size.width ?? 0.0
@@ -50,10 +50,10 @@ open class MarkerImage: NSObject, IMarker
         {
             size.height = image?.size.height ?? 0.0
         }
-        
+
         let width = size.width
         let height = size.height
-        
+
         if point.x + offset.x < 0.0
         {
             offset.x = -point.x
@@ -62,7 +62,7 @@ open class MarkerImage: NSObject, IMarker
         {
             offset.x = chart!.bounds.size.width - point.x - width
         }
-        
+
         if point.y + offset.y < 0
         {
             offset.y = -point.y
@@ -71,21 +71,21 @@ open class MarkerImage: NSObject, IMarker
         {
             offset.y = chart!.bounds.size.height - point.y - height
         }
-        
+
         return offset
     }
-    
+
     open func refreshContent(entry: ChartDataEntry, highlight: Highlight)
     {
         // Do nothing here...
     }
-    
+
     open func draw(context: CGContext, point: CGPoint)
     {
         let offset = self.offsetForDrawing(atPoint: point)
-        
+
         var size = self.size
-        
+
         if size.width == 0.0 && image != nil
         {
             size.width = image?.size.width ?? 0.0
@@ -94,13 +94,13 @@ open class MarkerImage: NSObject, IMarker
         {
             size.height = image?.size.height ?? 0.0
         }
-        
+
         let rect = CGRect(
             x: point.x + offset.x,
             y: point.y + offset.y,
             width: size.width,
             height: size.height)
-        
+
         NSUIGraphicsPushContext(context)
         image!.draw(in: rect)
         NSUIGraphicsPopContext()

--- a/Source/Charts/Components/XAxis.swift
+++ b/Source/Charts/Components/XAxis.swift
@@ -24,50 +24,50 @@ open class XAxis: AxisBase
         case topInside
         case bottomInside
     }
-    
-    /// width of the x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
+
+    // width of the x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
     open var labelWidth = CGFloat(1.0)
-    
-    /// height of the x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
+
+    // height of the x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
     open var labelHeight = CGFloat(1.0)
-    
-    /// width of the (rotated) x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
+
+    // width of the (rotated) x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
     open var labelRotatedWidth = CGFloat(1.0)
-    
-    /// height of the (rotated) x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
+
+    // height of the (rotated) x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
     open var labelRotatedHeight = CGFloat(1.0)
-    
-    /// This is the angle for drawing the X axis labels (in degrees)
+
+    // This is the angle for drawing the X axis labels (in degrees)
     open var labelRotationAngle = CGFloat(0.0)
 
-    /// if set to true, the chart will avoid that the first and last label entry in the chart "clip" off the edge of the chart
+    // if set to true, the chart will avoid that the first and last label entry in the chart "clip" off the edge of the chart
     open var avoidFirstLastClippingEnabled = false
-    
-    /// the position of the x-labels relative to the chart
+
+    // the position of the x-labels relative to the chart
     open var labelPosition = LabelPosition.top
-    
-    /// if set to true, word wrapping the labels will be enabled.
-    /// word wrapping is done using `(value width * labelRotatedWidth)`
-    ///
-    /// - note: currently supports all charts except pie/radar/horizontal-bar*
+
+    // if set to true, word wrapping the labels will be enabled.
+    // word wrapping is done using `(value width * labelRotatedWidth)`
+    //
+    // - note: currently supports all charts except pie/radar/horizontal-bar*
     open var wordWrapEnabled = false
-    
-    /// - returns: `true` if word wrapping the labels is enabled
+
+    // - returns: `true` if word wrapping the labels is enabled
     open var isWordWrapEnabled: Bool { return wordWrapEnabled }
-    
-    /// the width for wrapping the labels, as percentage out of one value width.
-    /// used only when isWordWrapEnabled = true.
-    /// 
-    /// **default**: 1.0
+
+    // the width for wrapping the labels, as percentage out of one value width.
+    // used only when isWordWrapEnabled = true.
+    //
+    // **default**: 1.0
     open var wordWrapWidthPercent: CGFloat = 1.0
-    
+
     public override init()
     {
         super.init()
-        
+
         self.yOffset = 4.0
     }
-    
+
     open var isAvoidFirstLastClippingEnabled: Bool
     {
         return avoidFirstLastClippingEnabled

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -17,9 +17,9 @@ import CoreGraphics
 #endif
 
 
-/// Class representing the y-axis labels settings and its entries.
-/// Be aware that not all features the YLabels class provides are suitable for the RadarChart.
-/// Customizations that affect the value range of the axis need to be applied before setting data for the chart.
+// Class representing the y-axis labels settings and its entries.
+// Be aware that not all features the YLabels class provides are suitable for the RadarChart.
+// Customizations that affect the value range of the axis need to be applied before setting data for the chart.
 @objc(ChartYAxis)
 open class YAxis: AxisBase
 {
@@ -29,85 +29,85 @@ open class YAxis: AxisBase
         case outsideChart
         case insideChart
     }
-    
-    ///  Enum that specifies the axis a DataSet should be plotted against, either Left or Right.
+
+    //  Enum that specifies the axis a DataSet should be plotted against, either Left or Right.
     @objc
     public enum AxisDependency: Int
     {
         case left
         case right
     }
-    
-    /// indicates if the bottom y-label entry is drawn or not
+
+    // indicates if the bottom y-label entry is drawn or not
     open var drawBottomYLabelEntryEnabled = true
-    
-    /// indicates if the top y-label entry is drawn or not
+
+    // indicates if the top y-label entry is drawn or not
     open var drawTopYLabelEntryEnabled = true
-    
-    /// flag that indicates if the axis is inverted or not
+
+    // flag that indicates if the axis is inverted or not
     open var inverted = false
-    
-    /// flag that indicates if the zero-line should be drawn regardless of other grid lines
+
+    // flag that indicates if the zero-line should be drawn regardless of other grid lines
     open var drawZeroLineEnabled = false
-    
-    /// Color of the zero line
+
+    // Color of the zero line
     open var zeroLineColor: NSUIColor? = NSUIColor.gray
-    
-    /// Width of the zero line
+
+    // Width of the zero line
     open var zeroLineWidth: CGFloat = 1.0
-    
-    /// This is how much (in pixels) into the dash pattern are we starting from.
+
+    // This is how much (in pixels) into the dash pattern are we starting from.
     open var zeroLineDashPhase = CGFloat(0.0)
-    
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     open var zeroLineDashLengths: [CGFloat]?
 
-    /// axis space from the largest value to the top in percent of the total axis range
+    // axis space from the largest value to the top in percent of the total axis range
     open var spaceTop = CGFloat(0.1)
 
-    /// axis space from the smallest value to the bottom in percent of the total axis range
+    // axis space from the smallest value to the bottom in percent of the total axis range
     open var spaceBottom = CGFloat(0.1)
-    
-    /// the position of the y-labels relative to the chart
+
+    // the position of the y-labels relative to the chart
     open var labelPosition = LabelPosition.outsideChart
-    
-    /// the side this axis object represents
+
+    // the side this axis object represents
     fileprivate var _axisDependency = AxisDependency.left
-    
-    /// the minimum width that the axis should take
-    /// 
-    /// **default**: 0.0
+
+    // the minimum width that the axis should take
+    //
+    // **default**: 0.0
     open var minWidth = CGFloat(0)
-    
-    /// the maximum width that the axis can take.
-    /// use Infinity for disabling the maximum.
-    /// 
-    /// **default**: CGFloat.infinity
+
+    // the maximum width that the axis can take.
+    // use Infinity for disabling the maximum.
+    //
+    // **default**: CGFloat.infinity
     open var maxWidth = CGFloat(CGFloat.infinity)
-    
+
     public override init()
     {
         super.init()
-        
+
         self.yOffset = 0.0
     }
-    
+
     public init(position: AxisDependency)
     {
         super.init()
-        
+
         _axisDependency = position
-        
+
         self.yOffset = 0.0
     }
-    
+
     open var axisDependency: AxisDependency
     {
         return _axisDependency
     }
-    
+
     open func requiredSize() -> CGSize
     {
         let label = getLongestLabel() as NSString
@@ -117,13 +117,13 @@ open class YAxis: AxisBase
         size.width = max(minWidth, min(size.width, maxWidth > 0.0 ? maxWidth : size.width))
         return size
     }
-    
+
     open func getRequiredHeightSpace() -> CGFloat
     {
         return requiredSize().height
     }
-    
-    /// - returns: `true` if this axis needs horizontal offset, `false` ifno offset is needed.
+
+    // - returns: `true` if this axis needs horizontal offset, `false` ifno offset is needed.
     open var needsOffset: Bool
     {
         if isEnabled && isDrawLabelsEnabled && labelPosition == .outsideChart
@@ -135,45 +135,45 @@ open class YAxis: AxisBase
             return false
         }
     }
-    
+
     open var isInverted: Bool { return inverted }
-    
+
     open override func calculate(min dataMin: Double, max dataMax: Double)
     {
         // if custom, use value as is, else use data value
         var min = _customAxisMin ? _axisMinimum : dataMin
         var max = _customAxisMax ? _axisMaximum : dataMax
-        
+
         // temporary range (before calculations)
         let range = abs(max - min)
-        
+
         // in case all values are equal
         if range == 0.0
         {
             max = max + 1.0
             min = min - 1.0
         }
-        
+
         // bottom-space only effects non-custom min
         if !_customAxisMin
         {
             let bottomSpace = range * Double(spaceBottom)
             _axisMinimum = (min - bottomSpace)
         }
-        
+
         // top-space only effects non-custom max
         if !_customAxisMax
         {
             let topSpace = range * Double(spaceTop)
             _axisMaximum = (max + topSpace)
         }
-        
+
         // calc actual range
         axisRange = abs(_axisMaximum - _axisMinimum)
     }
-    
+
     open var isDrawBottomYLabelEntryEnabled: Bool { return drawBottomYLabelEntryEnabled }
-    
+
     open var isDrawTopYLabelEntryEnabled: Bool { return drawTopYLabelEntryEnabled }
 
 }

--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -37,7 +37,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     
     // MARK: - Data functions and accessors
     
-    /// Use this method to tell the data set that the underlying data has changed
+    // Use this method to tell the data set that the underlying data has changed
     open func notifyDataSetChanged()
     {
         calcMinMax()
@@ -185,21 +185,21 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// All the colors that are used for this DataSet.
-    /// Colors are reused as soon as the number of Entries the DataSet represents is higher than the size of the colors array.
+    // All the colors that are used for this DataSet.
+    // Colors are reused as soon as the number of Entries the DataSet represents is higher than the size of the colors array.
     open var colors = [NSUIColor]()
     
-    /// List representing all colors that are used for drawing the actual values for this DataSet
+    // List representing all colors that are used for drawing the actual values for this DataSet
     open var valueColors = [NSUIColor]()
 
-    /// The label string that describes the DataSet.
+    // The label string that describes the DataSet.
     open var label: String? = "DataSet"
     
-    /// The axis this DataSet should be plotted against.
+    // The axis this DataSet should be plotted against.
     open var axisDependency = YAxis.AxisDependency.left
     
-    /// - returns: The color at the given index of the DataSet's color array.
-    /// This prevents out-of-bounds by performing a modulus on the color index, so colours will repeat themselves.
+    // - returns: The color at the given index of the DataSet's color array.
+    // This prevents out-of-bounds by performing a modulus on the color index, so colours will repeat themselves.
     open func color(atIndex index: Int) -> NSUIColor
     {
         var index = index
@@ -210,39 +210,39 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
         return colors[index % colors.count]
     }
     
-    /// Resets all colors of this DataSet and recreates the colors array.
+    // Resets all colors of this DataSet and recreates the colors array.
     open func resetColors()
     {
         colors.removeAll(keepingCapacity: false)
     }
     
-    /// Adds a new color to the colors array of the DataSet.
-    /// - parameter color: the color to add
+    // Adds a new color to the colors array of the DataSet.
+    // - parameter color: the color to add
     open func addColor(_ color: NSUIColor)
     {
         colors.append(color)
     }
     
-    /// Sets the one and **only** color that should be used for this DataSet.
-    /// Internally, this recreates the colors array and adds the specified color.
-    /// - parameter color: the color to set
+    // Sets the one and **only** color that should be used for this DataSet.
+    // Internally, this recreates the colors array and adds the specified color.
+    // - parameter color: the color to set
     open func setColor(_ color: NSUIColor)
     {
         colors.removeAll(keepingCapacity: false)
         colors.append(color)
     }
     
-    /// Sets colors to a single color a specific alpha value.
-    /// - parameter color: the color to set
-    /// - parameter alpha: alpha to apply to the set `color`
+    // Sets colors to a single color a specific alpha value.
+    // - parameter color: the color to set
+    // - parameter alpha: alpha to apply to the set `color`
     open func setColor(_ color: NSUIColor, alpha: CGFloat)
     {
         setColor(color.withAlphaComponent(alpha))
     }
     
-    /// Sets colors with a specific alpha value.
-    /// - parameter colors: the colors to set
-    /// - parameter alpha: alpha to apply to the set `colors`
+    // Sets colors with a specific alpha value.
+    // - parameter colors: the colors to set
+    // - parameter alpha: alpha to apply to the set `colors`
     open func setColors(_ colors: [NSUIColor], alpha: CGFloat)
     {
         var colorsWithAlpha = colors
@@ -255,24 +255,24 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
         self.colors = colorsWithAlpha
     }
     
-    /// Sets colors with a specific alpha value.
-    /// - parameter colors: the colors to set
-    /// - parameter alpha: alpha to apply to the set `colors`
+    // Sets colors with a specific alpha value.
+    // - parameter colors: the colors to set
+    // - parameter alpha: alpha to apply to the set `colors`
     open func setColors(_ colors: NSUIColor...)
     {
         self.colors = colors
     }
     
-    /// if true, value highlighting is enabled
+    // if true, value highlighting is enabled
     open var highlightEnabled = true
     
-    /// - returns: `true` if value highlighting is enabled for this dataset
+    // - returns: `true` if value highlighting is enabled for this dataset
     open var isHighlightEnabled: Bool { return highlightEnabled }
     
-    /// Custom formatter that is used instead of the auto-formatter if set
+    // Custom formatter that is used instead of the auto-formatter if set
     internal var _valueFormatter: IValueFormatter?
     
-    /// Custom formatter that is used instead of the auto-formatter if set
+    // Custom formatter that is used instead of the auto-formatter if set
     open var valueFormatter: IValueFormatter?
     {
         get
@@ -297,9 +297,9 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
         return _valueFormatter == nil
     }
     
-    /// Sets/get a single color for value text.
-    /// Setting the color clears the colors array and adds a single color.
-    /// Getting will return the first color in the array.
+    // Sets/get a single color for value text.
+    // Setting the color clears the colors array and adds a single color.
+    // Getting will return the first color in the array.
     open var valueTextColor: NSUIColor
     {
         get
@@ -313,7 +313,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
         }
     }
     
-    /// - returns: The color at the specified index that is used for drawing the values inside the chart. Uses modulus internally.
+    // - returns: The color at the specified index that is used for drawing the values inside the chart. Uses modulus internally.
     open func valueTextColorAt(_ index: Int) -> NSUIColor
     {
         var index = index
@@ -324,67 +324,67 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
         return valueColors[index % valueColors.count]
     }
     
-    /// the font for the value-text labels
+    // the font for the value-text labels
     open var valueFont: NSUIFont = NSUIFont.systemFont(ofSize: 7.0)
     
-    /// The form to draw for this dataset in the legend.
+    // The form to draw for this dataset in the legend.
     open var form = Legend.Form.default
     
-    /// The form size to draw for this dataset in the legend.
-    ///
-    /// Return `NaN` to use the default legend form size.
+    // The form size to draw for this dataset in the legend.
+    //
+    // Return `NaN` to use the default legend form size.
     open var formSize: CGFloat = CGFloat.nan
     
-    /// The line width for drawing the form of this dataset in the legend
-    ///
-    /// Return `NaN` to use the default legend form line width.
+    // The line width for drawing the form of this dataset in the legend
+    //
+    // Return `NaN` to use the default legend form line width.
     open var formLineWidth: CGFloat = CGFloat.nan
     
-    /// Line dash configuration for legend shapes that consist of lines.
-    ///
-    /// This is how much (in pixels) into the dash pattern are we starting from.
+    // Line dash configuration for legend shapes that consist of lines.
+    //
+    // This is how much (in pixels) into the dash pattern are we starting from.
     open var formLineDashPhase: CGFloat = 0.0
     
-    /// Line dash configuration for legend shapes that consist of lines.
-    ///
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    // Line dash configuration for legend shapes that consist of lines.
+    //
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     open var formLineDashLengths: [CGFloat]? = nil
     
-    /// Set this to true to draw y-values on the chart.
-    ///
-    /// - note: For bar and line charts: if `maxVisibleCount` is reached, no values will be drawn even if this is enabled.
+    // Set this to true to draw y-values on the chart.
+    //
+    // - note: For bar and line charts: if `maxVisibleCount` is reached, no values will be drawn even if this is enabled.
     open var drawValuesEnabled = true
     
-    /// - returns: `true` if y-value drawing is enabled, `false` ifnot
+    // - returns: `true` if y-value drawing is enabled, `false` ifnot
     open var isDrawValuesEnabled: Bool
     {
         return drawValuesEnabled
     }
 
-    /// Set this to true to draw y-icons on the chart.
-    ///
-    /// - note: For bar and line charts: if `maxVisibleCount` is reached, no icons will be drawn even if this is enabled.
+    // Set this to true to draw y-icons on the chart.
+    //
+    // - note: For bar and line charts: if `maxVisibleCount` is reached, no icons will be drawn even if this is enabled.
     open var drawIconsEnabled = true
     
-    /// Returns true if y-icon drawing is enabled, false if not
+    // Returns true if y-icon drawing is enabled, false if not
     open var isDrawIconsEnabled: Bool
     {
         return drawIconsEnabled
     }
     
-    /// Offset of icons drawn on the chart.  
-    ///
-    /// For all charts except Pie and Radar it will be ordinary (x offset, y offset).
-    ///
-    /// For Pie and Radar chart it will be (y offset, distance from center offset); so if you want icon to be rendered under value, you should increase X component of CGPoint, and if you want icon to be rendered closet to center, you should decrease height component of CGPoint.
+    // Offset of icons drawn on the chart.  
+    //
+    // For all charts except Pie and Radar it will be ordinary (x offset, y offset).
+    //
+    // For Pie and Radar chart it will be (y offset, distance from center offset); so if you want icon to be rendered under value, you should increase X component of CGPoint, and if you want icon to be rendered closet to center, you should decrease height component of CGPoint.
     open var iconsOffset = CGPoint(x: 0, y: 0)
     
-    /// Set the visibility of this DataSet. If not visible, the DataSet will not be drawn to the chart upon refreshing it.
+    // Set the visibility of this DataSet. If not visible, the DataSet will not be drawn to the chart upon refreshing it.
     open var visible = true
     
-    /// - returns: `true` if this DataSet is visible inside the chart, or `false` ifit is currently hidden.
+    // - returns: `true` if this DataSet is visible inside the chart, or `false` ifit is currently hidden.
     open var isVisible: Bool
     {
         return visible

--- a/Source/Charts/Data/Implementations/Standard/BarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartData.swift
@@ -24,18 +24,18 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
         super.init(dataSets: dataSets)
     }
     
-    /// The width of the bars on the x-axis, in values (not pixels)
-    ///
-    /// **default**: 0.85
+    // The width of the bars on the x-axis, in values (not pixels)
+    //
+    // **default**: 0.85
     open var barWidth = Double(0.85)
     
-    /// Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
-    /// Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
-    /// Do not forget to call notifyDataSetChanged() on your BarChart object after calling this method.
-    ///
-    /// - parameter the starting point on the x-axis where the grouping should begin
-    /// - parameter groupSpace: The space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
-    /// - parameter barSpace: The space between individual bars in values (not pixels) e.g. 0.1f for bar width 1f
+    // Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
+    // Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
+    // Do not forget to call notifyDataSetChanged() on your BarChart object after calling this method.
+    //
+    // - parameter the starting point on the x-axis where the grouping should begin
+    // - parameter groupSpace: The space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
+    // - parameter barSpace: The space between individual bars in values (not pixels) e.g. 0.1f for bar width 1f
     open func groupBars(fromX: Double, groupSpace: Double, barSpace: Double)
     {
         let setCount = _dataSets.count
@@ -94,10 +94,10 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
         notifyDataChanged()
     }
     
-    /// In case of grouped bars, this method returns the space an individual group of bar needs on the x-axis.
-    ///
-    /// - parameter groupSpace:
-    /// - parameter barSpace:
+    // In case of grouped bars, this method returns the space an individual group of bar needs on the x-axis.
+    //
+    // - parameter groupSpace:
+    // - parameter barSpace:
     open func groupWidth(groupSpace: Double, barSpace: Double) -> Double
     {
         return Double(_dataSets.count) * (self.barWidth + barSpace) + groupSpace

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -13,16 +13,16 @@ import Foundation
 
 open class BarChartDataEntry: ChartDataEntry
 {
-    /// the values the stacked barchart holds
+    // the values the stacked barchart holds
     fileprivate var _yVals: [Double]?
     
-    /// the ranges for the individual stack values - automatically calculated
+    // the ranges for the individual stack values - automatically calculated
     fileprivate var _ranges: [Range]?
     
-    /// the sum of all negative values this entry (if stacked) contains
+    // the sum of all negative values this entry (if stacked) contains
     fileprivate var _negativeSum: Double = 0.0
     
-    /// the sum of all positive values this entry (if stacked) contains
+    // the sum of all positive values this entry (if stacked) contains
     fileprivate var _positiveSum: Double = 0.0
     
     public required init()
@@ -30,31 +30,31 @@ open class BarChartDataEntry: ChartDataEntry
         super.init()
     }
     
-    /// Constructor for normal bars (not stacked).
+    // Constructor for normal bars (not stacked).
     public override init(x: Double, y: Double)
     {
         super.init(x: x, y: y)
     }
     
-    /// Constructor for normal bars (not stacked).
+    // Constructor for normal bars (not stacked).
     public override init(x: Double, y: Double, data: AnyObject?)
     {
         super.init(x: x, y: y, data: data)
     }
     
-    /// Constructor for normal bars (not stacked).
+    // Constructor for normal bars (not stacked).
     public override init(x: Double, y: Double, icon: NSUIImage?)
     {
         super.init(x: x, y: y, icon: icon)
     }
     
-    /// Constructor for normal bars (not stacked).
+    // Constructor for normal bars (not stacked).
     public override init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: x, y: y, icon: icon, data: data)
     }
     
-    /// Constructor for stacked bar entries.
+    // Constructor for stacked bar entries.
     public init(x: Double, yValues: [Double])
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues))
@@ -63,7 +63,7 @@ open class BarChartDataEntry: ChartDataEntry
         calcRanges()
     }
     
-    /// This constructor is misleading, please use the `data` argument instead of `label`.
+    // This constructor is misleading, please use the `data` argument instead of `label`.
     @available(*, deprecated: 1.0, message: "Use `data` argument instead of `label`.")
     public init(x: Double, yValues: [Double], label: String)
     {
@@ -73,7 +73,7 @@ open class BarChartDataEntry: ChartDataEntry
         calcRanges()
     }
     
-    /// Constructor for stacked bar entries. One data object for whole stack
+    // Constructor for stacked bar entries. One data object for whole stack
     public init(x: Double, yValues: [Double], data: AnyObject?)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), data: data)
@@ -82,7 +82,7 @@ open class BarChartDataEntry: ChartDataEntry
         calcRanges()
     }
     
-    /// Constructor for stacked bar entries. One data object for whole stack
+    // Constructor for stacked bar entries. One data object for whole stack
     public init(x: Double, yValues: [Double], icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), icon: icon, data: data)
@@ -91,7 +91,7 @@ open class BarChartDataEntry: ChartDataEntry
         calcRanges()
     }
     
-    /// Constructor for stacked bar entries. One data object for whole stack
+    // Constructor for stacked bar entries. One data object for whole stack
     public init(x: Double, yValues: [Double], icon: NSUIImage?)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), icon: icon)
@@ -119,13 +119,13 @@ open class BarChartDataEntry: ChartDataEntry
         return remainder
     }
     
-    /// - returns: The sum of all negative values this entry (if stacked) contains. (this is a positive number)
+    // - returns: The sum of all negative values this entry (if stacked) contains. (this is a positive number)
     open var negativeSum: Double
     {
         return _negativeSum
     }
     
-    /// - returns: The sum of all positive values this entry (if stacked) contains.
+    // - returns: The sum of all positive values this entry (if stacked) contains.
     open var positiveSum: Double
     {
         return _positiveSum
@@ -159,9 +159,9 @@ open class BarChartDataEntry: ChartDataEntry
         _positiveSum = sumPos
     }
     
-    /// Splits up the stack-values of the given bar-entry into Range objects.
-    /// - parameter entry:
-    /// - returns:
+    // Splits up the stack-values of the given bar-entry into Range objects.
+    // - parameter entry:
+    // - returns:
     open func calcRanges()
     {
         let values = yValues
@@ -203,10 +203,10 @@ open class BarChartDataEntry: ChartDataEntry
     
     // MARK: Accessors
     
-    /// the values the stacked barchart holds
+    // the values the stacked barchart holds
     open var isStacked: Bool { return _yVals != nil }
     
-    /// the values the stacked barchart holds
+    // the values the stacked barchart holds
     open var yValues: [Double]?
     {
         get { return self._yVals }
@@ -219,7 +219,7 @@ open class BarChartDataEntry: ChartDataEntry
         }
     }
     
-    /// - returns: The ranges of the individual stack-entries. Will return null if this entry is not stacked.
+    // - returns: The ranges of the individual stack-entries. Will return null if this entry is not stacked.
     open var ranges: [Range]?
     {
         return _ranges
@@ -236,10 +236,10 @@ open class BarChartDataEntry: ChartDataEntry
         return copy
     }
     
-    /// Calculates the sum across all values of the given stack.
-    ///
-    /// - parameter vals:
-    /// - returns:
+    // Calculates the sum across all values of the given stack.
+    //
+    // - parameter vals:
+    // - returns:
     fileprivate static func calcSum(values: [Double]?) -> Double
     {
         guard let values = values

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -37,15 +37,15 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
 
     // MARK: - Data functions and accessors
     
-    /// the maximum number of bars that are stacked upon each other, this value
-    /// is calculated from the Entries that are added to the DataSet
+    // the maximum number of bars that are stacked upon each other, this value
+    // is calculated from the Entries that are added to the DataSet
     fileprivate var _stackSize = 1
     
-    /// the overall entry count, including counting each stack-value individually
+    // the overall entry count, including counting each stack-value individually
     fileprivate var _entryCountStacks = 0
     
-    /// Calculates the total number of entries this DataSet represents, including
-    /// stacks. All values belonging to a stack are calculated separately.
+    // Calculates the total number of entries this DataSet represents, including
+    // stacks. All values belonging to a stack are calculated separately.
     fileprivate func calcEntryCountIncludingStacks(entries: [BarChartDataEntry])
     {
         _entryCountStacks = 0
@@ -63,7 +63,7 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
         }
     }
     
-    /// calculates the maximum stacksize that occurs in the Entries array of this DataSet
+    // calculates the maximum stacksize that occurs in the Entries array of this DataSet
     fileprivate func calcStackSize(entries: [BarChartDataEntry])
     {
         for i in 0 ..< entries.count
@@ -114,39 +114,39 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
         }
     }
     
-    /// - returns: The maximum number of bars that can be stacked upon another in this DataSet.
+    // - returns: The maximum number of bars that can be stacked upon another in this DataSet.
     open var stackSize: Int
     {
         return _stackSize
     }
     
-    /// - returns: `true` if this DataSet is stacked (stacksize > 1) or not.
+    // - returns: `true` if this DataSet is stacked (stacksize > 1) or not.
     open var isStacked: Bool
     {
         return _stackSize > 1 ? true : false
     }
     
-    /// - returns: The overall entry count, including counting each stack-value individually
+    // - returns: The overall entry count, including counting each stack-value individually
     open var entryCountStacks: Int
     {
         return _entryCountStacks
     }
     
-    /// array of labels used to describe the different values of the stacked bars
+    // array of labels used to describe the different values of the stacked bars
     open var stackLabels: [String] = ["Stack"]
     
     // MARK: - Styling functions and accessors
     
-    /// the color used for drawing the bar-shadows. The bar shadows is a surface behind the bar that indicates the maximum value
+    // the color used for drawing the bar-shadows. The bar shadows is a surface behind the bar that indicates the maximum value
     open var barShadowColor = NSUIColor(red: 215.0/255.0, green: 215.0/255.0, blue: 215.0/255.0, alpha: 1.0)
 
-    /// the width used for drawing borders around the bars. If borderWidth == 0, no border will be drawn.
+    // the width used for drawing borders around the bars. If borderWidth == 0, no border will be drawn.
     open var barBorderWidth : CGFloat = 0.0
 
-    /// the color drawing borders around the bars.
+    // the color drawing borders around the bars.
     open var barBorderColor = NSUIColor.black
 
-    /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
+    // the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     open var highlightAlpha = CGFloat(120.0 / 255.0)
     
     // MARK: - NSCopying

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartData.swift
@@ -24,7 +24,7 @@ open class BubbleChartData: BarLineScatterCandleBubbleChartData
         super.init(dataSets: dataSets)
     }
     
-    /// Sets the width of the circle that surrounds the bubble when highlighted for all DataSet objects this data object contains
+    // Sets the width of the circle that surrounds the bubble when highlighted for all DataSet objects this data object contains
     open func setHighlightCircleWidth(_ width: CGFloat)
     {
         for set in (_dataSets as? [IBubbleChartDataSet])!

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
@@ -14,7 +14,7 @@ import CoreGraphics
 
 open class BubbleChartDataEntry: ChartDataEntry
 {
-    /// The size of the bubble.
+    // The size of the bubble.
     open var size = CGFloat(0.0)
     
     public required init()
@@ -22,9 +22,9 @@ open class BubbleChartDataEntry: ChartDataEntry
         super.init()
     }
     
-    /// - parameter x: The index on the x-axis.
-    /// - parameter y: The value on the y-axis.
-    /// - parameter size: The size of the bubble.
+    // - parameter x: The index on the x-axis.
+    // - parameter y: The value on the y-axis.
+    // - parameter size: The size of the bubble.
     public init(x: Double, y: Double, size: CGFloat)
     {
         super.init(x: x, y: y)
@@ -32,10 +32,10 @@ open class BubbleChartDataEntry: ChartDataEntry
         self.size = size
     }
     
-    /// - parameter x: The index on the x-axis.
-    /// - parameter y: The value on the y-axis.
-    /// - parameter size: The size of the bubble.
-    /// - parameter data: Spot for additional data this Entry represents.
+    // - parameter x: The index on the x-axis.
+    // - parameter y: The value on the y-axis.
+    // - parameter size: The size of the bubble.
+    // - parameter data: Spot for additional data this Entry represents.
     public init(x: Double, y: Double, size: CGFloat, data: AnyObject?)
     {
         super.init(x: x, y: y, data: data)
@@ -43,10 +43,10 @@ open class BubbleChartDataEntry: ChartDataEntry
         self.size = size
     }
     
-    /// - parameter x: The index on the x-axis.
-    /// - parameter y: The value on the y-axis.
-    /// - parameter size: The size of the bubble.
-    /// - parameter icon: icon image
+    // - parameter x: The index on the x-axis.
+    // - parameter y: The value on the y-axis.
+    // - parameter size: The size of the bubble.
+    // - parameter icon: icon image
     public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?)
     {
         super.init(x: x, y: y, icon: icon)
@@ -54,11 +54,11 @@ open class BubbleChartDataEntry: ChartDataEntry
         self.size = size
     }
     
-    /// - parameter x: The index on the x-axis.
-    /// - parameter y: The value on the y-axis.
-    /// - parameter size: The size of the bubble.
-    /// - parameter icon: icon image
-    /// - parameter data: Spot for additional data this Entry represents.
+    // - parameter x: The index on the x-axis.
+    // - parameter y: The value on the y-axis.
+    // - parameter size: The size of the bubble.
+    // - parameter icon: icon image
+    // - parameter data: Spot for additional data this Entry represents.
     public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: x, y: y, icon: icon, data: data)

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataSet.swift
@@ -40,7 +40,7 @@ open class BubbleChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBubbleCh
     
     // MARK: - Styling functions and accessors
     
-    /// Sets/gets the width of the circle that surrounds the bubble when highlighted
+    // Sets/gets the width of the circle that surrounds the bubble when highlighted
     open var highlightCircleWidth: CGFloat = 2.5
     
     // MARK: - NSCopying

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
@@ -13,16 +13,16 @@ import Foundation
 
 open class CandleChartDataEntry: ChartDataEntry
 {
-    /// shadow-high value
+    // shadow-high value
     open var high = Double(0.0)
     
-    /// shadow-low value
+    // shadow-low value
     open var low = Double(0.0)
     
-    /// close value
+    // close value
     open var close = Double(0.0)
     
-    /// open value
+    // open value
     open var open = Double(0.0)
     
     public required init()
@@ -70,19 +70,19 @@ open class CandleChartDataEntry: ChartDataEntry
         self.close = close
     }
     
-    /// - returns: The overall range (difference) between shadow-high and shadow-low.
+    // - returns: The overall range (difference) between shadow-high and shadow-low.
     open var shadowRange: Double
     {
         return abs(high - low)
     }
     
-    /// - returns: The body size (difference between open and close).
+    // - returns: The body size (difference between open and close).
     open var bodyRange: Double
     {
         return abs(open - close)
     }
     
-    /// the center value of the candle. (Middle value between high and low)
+    // the center value of the candle. (Middle value between high and low)
     open override var y: Double
     {
         get

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
@@ -72,13 +72,13 @@ open class CandleChartDataSet: LineScatterCandleRadarChartDataSet, ICandleChartD
     
     // MARK: - Styling functions and accessors
     
-    /// the space between the candle entries
-    ///
-    /// **default**: 0.1 (10%)
+    // the space between the candle entries
+    //
+    // **default**: 0.1 (10%)
     fileprivate var _barSpace = CGFloat(0.1)
     
-    /// the space that is left out on the left and right side of each candle,
-    /// **default**: 0.1 (10%), max 0.45, min 0.0
+    // the space that is left out on the left and right side of each candle,
+    // **default**: 0.1 (10%), max 0.45, min 0.0
     open var barSpace: CGFloat
     {
         set
@@ -102,46 +102,46 @@ open class CandleChartDataSet: LineScatterCandleRadarChartDataSet, ICandleChartD
         }
     }
     
-    /// should the candle bars show?
-    /// when false, only "ticks" will show
-    ///
-    /// **default**: true
+    // should the candle bars show?
+    // when false, only "ticks" will show
+    //
+    // **default**: true
     open var showCandleBar: Bool = true
     
-    /// the width of the candle-shadow-line in pixels.
-    ///
-    /// **default**: 1.5
+    // the width of the candle-shadow-line in pixels.
+    //
+    // **default**: 1.5
     open var shadowWidth = CGFloat(1.5)
     
-    /// the color of the shadow line
+    // the color of the shadow line
     open var shadowColor: NSUIColor?
     
-    /// use candle color for the shadow
+    // use candle color for the shadow
     open var shadowColorSameAsCandle = false
     
-    /// Is the shadow color same as the candle color?
+    // Is the shadow color same as the candle color?
     open var isShadowColorSameAsCandle: Bool { return shadowColorSameAsCandle }
     
-    /// color for open == close
+    // color for open == close
     open var neutralColor: NSUIColor?
     
-    /// color for open > close
+    // color for open > close
     open var increasingColor: NSUIColor?
     
-    /// color for open < close
+    // color for open < close
     open var decreasingColor: NSUIColor?
     
-    /// Are increasing values drawn as filled?
-    /// increasing candlesticks are traditionally hollow
+    // Are increasing values drawn as filled?
+    // increasing candlesticks are traditionally hollow
     open var increasingFilled = false
     
-    /// Are increasing values drawn as filled?
+    // Are increasing values drawn as filled?
     open var isIncreasingFilled: Bool { return increasingFilled }
     
-    /// Are decreasing values drawn as filled?
-    /// descreasing candlesticks are traditionally filled
+    // Are decreasing values drawn as filled?
+    // descreasing candlesticks are traditionally filled
     open var decreasingFilled = true
     
-    /// Are decreasing values drawn as filled?
+    // Are decreasing values drawn as filled?
     open var isDecreasingFilled: Bool { return decreasingFilled }
 }

--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -50,8 +50,8 @@ open class ChartData: NSObject
         notifyDataChanged()
     }
     
-    /// Call this method to let the ChartData know that the underlying data has changed.
-    /// Calling this performs all necessary recalculations needed when the contained data has changed.
+    // Call this method to let the ChartData know that the underlying data has changed.
+    // Calling this performs all necessary recalculations needed when the contained data has changed.
     open func notifyDataChanged()
     {
         calcMinMax()
@@ -68,7 +68,7 @@ open class ChartData: NSObject
         calcMinMax()
     }
     
-    /// calc minimum and maximum y value over all datasets
+    // calc minimum and maximum y value over all datasets
     open func calcMinMax()
     {
         _yMax = -Double.greatestFiniteMagnitude
@@ -137,7 +137,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// Adjusts the current minimum and maximum values based on the provided Entry object.
+    // Adjusts the current minimum and maximum values based on the provided Entry object.
     open func calcMinMax(entry e: ChartDataEntry, axis: YAxis.AxisDependency)
     {
         if _yMax < e.y
@@ -186,7 +186,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// Adjusts the minimum and maximum values based on the given DataSet.
+    // Adjusts the minimum and maximum values based on the given DataSet.
     open func calcMinMax(dataSet d: IChartDataSet)
     {
         if _yMax < d.yMax
@@ -235,13 +235,13 @@ open class ChartData: NSObject
         }
     }
     
-    /// - returns: The number of LineDataSets this object contains
+    // - returns: The number of LineDataSets this object contains
     open var dataSetCount: Int
     {
         return _dataSets.count
     }
     
-    /// - returns: The smallest y-value the data object contains.
+    // - returns: The smallest y-value the data object contains.
     open var yMin: Double
     {
         return _yMin
@@ -279,7 +279,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// - returns: The greatest y-value the data object contains.
+    // - returns: The greatest y-value the data object contains.
     open var yMax: Double
     {
         return _yMax
@@ -317,18 +317,18 @@ open class ChartData: NSObject
         }
     }
     
-    /// - returns: The minimum x-value the data object contains.
+    // - returns: The minimum x-value the data object contains.
     open var xMin: Double
     {
         return _xMin
     }
-    /// - returns: The maximum x-value the data object contains.
+    // - returns: The maximum x-value the data object contains.
     open var xMax: Double
     {
         return _xMax
     }
     
-    /// - returns: All DataSet objects this ChartData object holds.
+    // - returns: All DataSet objects this ChartData object holds.
     open var dataSets: [IChartDataSet]
     {
         get
@@ -342,14 +342,14 @@ open class ChartData: NSObject
         }
     }
     
-    /// Retrieve the index of a ChartDataSet with a specific label from the ChartData. Search can be case sensitive or not.
-    /// 
-    /// **IMPORTANT: This method does calculations at runtime, do not over-use in performance critical situations.**
-    ///
-    /// - parameter dataSets: the DataSet array to search
-    /// - parameter type:
-    /// - parameter ignorecase: if true, the search is not case-sensitive
-    /// - returns: The index of the DataSet Object with the given label. Sensitive or not.
+    // Retrieve the index of a ChartDataSet with a specific label from the ChartData. Search can be case sensitive or not.
+    // 
+    // **IMPORTANT: This method does calculations at runtime, do not over-use in performance critical situations.**
+    //
+    // - parameter dataSets: the DataSet array to search
+    // - parameter type:
+    // - parameter ignorecase: if true, the search is not case-sensitive
+    // - returns: The index of the DataSet Object with the given label. Sensitive or not.
     internal func getDataSetIndexByLabel(_ label: String, ignorecase: Bool) -> Int
     {
         if ignorecase
@@ -380,7 +380,7 @@ open class ChartData: NSObject
         return -1
     }
     
-    /// - returns: The labels of all DataSets as a string array.
+    // - returns: The labels of all DataSets as a string array.
     internal func dataSetLabels() -> [String]
     {
         var types = [String]()
@@ -398,10 +398,10 @@ open class ChartData: NSObject
         return types
     }
     
-    /// Get the Entry for a corresponding highlight object
-    ///
-    /// - parameter highlight:
-    /// - returns: The entry that is highlighted
+    // Get the Entry for a corresponding highlight object
+    //
+    // - parameter highlight:
+    // - returns: The entry that is highlighted
     open func entryForHighlight(_ highlight: Highlight) -> ChartDataEntry?
     {
         if highlight.dataSetIndex >= dataSets.count
@@ -414,11 +414,11 @@ open class ChartData: NSObject
         }
     }
     
-    /// **IMPORTANT: This method does calculations at runtime. Use with care in performance critical situations.**
-    ///
-    /// - parameter label:
-    /// - parameter ignorecase:
-    /// - returns: The DataSet Object with the given label. Sensitive or not.
+    // **IMPORTANT: This method does calculations at runtime. Use with care in performance critical situations.**
+    //
+    // - parameter label:
+    // - parameter ignorecase:
+    // - returns: The DataSet Object with the given label. Sensitive or not.
     open func getDataSetByLabel(_ label: String, ignorecase: Bool) -> IChartDataSet?
     {
         let index = getDataSetIndexByLabel(label, ignorecase: ignorecase)
@@ -450,10 +450,10 @@ open class ChartData: NSObject
         _dataSets.append(dataSet)
     }
     
-    /// Removes the given DataSet from this data object.
-    /// Also recalculates all minimum and maximum values.
-    ///
-    /// - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
+    // Removes the given DataSet from this data object.
+    // Also recalculates all minimum and maximum values.
+    //
+    // - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
     @discardableResult open func removeDataSet(_ dataSet: IChartDataSet!) -> Bool
     {
         if dataSet === nil
@@ -472,10 +472,10 @@ open class ChartData: NSObject
         return false
     }
     
-    /// Removes the DataSet at the given index in the DataSet array from the data object. 
-    /// Also recalculates all minimum and maximum values. 
-    ///
-    /// - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
+    // Removes the DataSet at the given index in the DataSet array from the data object. 
+    // Also recalculates all minimum and maximum values. 
+    //
+    // - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
     @discardableResult open func removeDataSetByIndex(_ index: Int) -> Bool
     {
         if index >= _dataSets.count || index < 0
@@ -490,7 +490,7 @@ open class ChartData: NSObject
         return true
     }
     
-    /// Adds an Entry to the DataSet at the specified index. Entries are added to the end of the list.
+    // Adds an Entry to the DataSet at the specified index. Entries are added to the end of the list.
     open func addEntry(_ e: ChartDataEntry, dataSetIndex: Int)
     {
         if _dataSets.count > dataSetIndex && dataSetIndex >= 0
@@ -507,7 +507,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// Removes the given Entry object from the DataSet at the specified index.
+    // Removes the given Entry object from the DataSet at the specified index.
     @discardableResult open func removeEntry(_ entry: ChartDataEntry, dataSetIndex: Int) -> Bool
     {
         // entry outofbounds
@@ -527,9 +527,9 @@ open class ChartData: NSObject
         return removed
     }
     
-    /// Removes the Entry object closest to the given xIndex from the ChartDataSet at the
-    /// specified index. 
-    /// - returns: `true` if an entry was removed, `false` ifno Entry was found that meets the specified requirements.
+    // Removes the Entry object closest to the given xIndex from the ChartDataSet at the
+    // specified index. 
+    // - returns: `true` if an entry was removed, `false` ifno Entry was found that meets the specified requirements.
     @discardableResult open func removeEntry(xValue: Double, dataSetIndex: Int) -> Bool
     {
         if dataSetIndex >= _dataSets.count
@@ -545,7 +545,7 @@ open class ChartData: NSObject
         return false
     }
     
-    /// - returns: The DataSet that contains the provided Entry, or null, if no DataSet contains this entry.
+    // - returns: The DataSet that contains the provided Entry, or null, if no DataSet contains this entry.
     open func getDataSetForEntry(_ e: ChartDataEntry!) -> IChartDataSet?
     {
         if e == nil
@@ -566,7 +566,7 @@ open class ChartData: NSObject
         return nil
     }
 
-    /// - returns: The index of the provided DataSet in the DataSet array of this data object, or -1 if it does not exist.
+    // - returns: The index of the provided DataSet in the DataSet array of this data object, or -1 if it does not exist.
     open func indexOfDataSet(_ dataSet: IChartDataSet) -> Int
     {
         for i in 0 ..< _dataSets.count
@@ -580,7 +580,7 @@ open class ChartData: NSObject
         return -1
     }
     
-    /// - returns: The first DataSet from the datasets-array that has it's dependency on the left axis. Returns null if no DataSet with left dependency could be found.
+    // - returns: The first DataSet from the datasets-array that has it's dependency on the left axis. Returns null if no DataSet with left dependency could be found.
     open func getFirstLeft(dataSets: [IChartDataSet]) -> IChartDataSet?
     {
         for dataSet in dataSets
@@ -594,7 +594,7 @@ open class ChartData: NSObject
         return nil
     }
     
-    /// - returns: The first DataSet from the datasets-array that has it's dependency on the right axis. Returns null if no DataSet with right dependency could be found.
+    // - returns: The first DataSet from the datasets-array that has it's dependency on the right axis. Returns null if no DataSet with right dependency could be found.
     open func getFirstRight(dataSets: [IChartDataSet]) -> IChartDataSet?
     {
         for dataSet in _dataSets
@@ -608,7 +608,7 @@ open class ChartData: NSObject
         return nil
     }
     
-    /// - returns: All colors used across all DataSet objects this object represents.
+    // - returns: All colors used across all DataSet objects this object represents.
     open func getColors() -> [NSUIColor]?
     {
         var clrcnt = 0
@@ -633,7 +633,7 @@ open class ChartData: NSObject
         return colors
     }
     
-    /// Sets a custom IValueFormatter for all DataSets this data object contains.
+    // Sets a custom IValueFormatter for all DataSets this data object contains.
     open func setValueFormatter(_ formatter: IValueFormatter?)
     {
         guard let formatter = formatter
@@ -645,7 +645,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// Sets the color of the value-text (color in which the value-labels are drawn) for all DataSets this data object contains.
+    // Sets the color of the value-text (color in which the value-labels are drawn) for all DataSets this data object contains.
     open func setValueTextColor(_ color: NSUIColor!)
     {
         for set in dataSets
@@ -654,7 +654,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// Sets the font for all value-labels for all DataSets this data object contains.
+    // Sets the font for all value-labels for all DataSets this data object contains.
     open func setValueFont(_ font: NSUIFont!)
     {
         for set in dataSets
@@ -663,7 +663,7 @@ open class ChartData: NSObject
         }
     }
     
-    /// Enables / disables drawing values (value-text) for all DataSets this data object contains.
+    // Enables / disables drawing values (value-text) for all DataSets this data object contains.
     open func setDrawValues(_ enabled: Bool)
     {
         for set in dataSets
@@ -672,8 +672,8 @@ open class ChartData: NSObject
         }
     }
     
-    /// Enables / disables highlighting values for all DataSets this data object contains.
-    /// If set to true, this means that values can be highlighted programmatically or by touch gesture.
+    // Enables / disables highlighting values for all DataSets this data object contains.
+    // If set to true, this means that values can be highlighted programmatically or by touch gesture.
     open var highlightEnabled: Bool
     {
         get
@@ -697,19 +697,19 @@ open class ChartData: NSObject
         }
     }
     
-    /// if true, value highlightning is enabled
+    // if true, value highlightning is enabled
     open var isHighlightEnabled: Bool { return highlightEnabled }
     
-    /// Clears this data object from all DataSets and removes all Entries.
-    /// Don't forget to invalidate the chart after this.
+    // Clears this data object from all DataSets and removes all Entries.
+    // Don't forget to invalidate the chart after this.
     open func clearValues()
     {
         dataSets.removeAll(keepingCapacity: false)
         notifyDataChanged()
     }
     
-    /// Checks if this data object contains the specified DataSet. 
-    /// - returns: `true` if so, `false` ifnot.
+    // Checks if this data object contains the specified DataSet. 
+    // - returns: `true` if so, `false` ifnot.
     open func contains(dataSet: IChartDataSet) -> Bool
     {
         for set in dataSets
@@ -723,7 +723,7 @@ open class ChartData: NSObject
         return false
     }
     
-    /// - returns: The total entry count across all DataSet objects this data object contains.
+    // - returns: The total entry count across all DataSet objects this data object contains.
     open var entryCount: Int
     {
         var count = 0
@@ -736,7 +736,7 @@ open class ChartData: NSObject
         return count
     }
 
-    /// - returns: The DataSet object with the maximum number of entries or null if there are no DataSets.
+    // - returns: The DataSet object with the maximum number of entries or null if there are no DataSets.
     open var maxEntryCountSet: IChartDataSet?
     {
         if _dataSets.count == 0

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -13,7 +13,7 @@ import Foundation
 
 open class ChartDataEntry: ChartDataEntryBase
 {
-    /// the x value
+    // the x value
     open var x = Double(0.0)
     
     public required init()
@@ -21,9 +21,9 @@ open class ChartDataEntry: ChartDataEntryBase
         super.init()
     }
     
-    /// An Entry represents one single entry in the chart.
-    /// - parameter x: the x value
-    /// - parameter y: the y value (the actual value of the entry)
+    // An Entry represents one single entry in the chart.
+    // - parameter x: the x value
+    // - parameter y: the y value (the actual value of the entry)
     public init(x: Double, y: Double)
     {
         super.init(y: y)
@@ -31,10 +31,10 @@ open class ChartDataEntry: ChartDataEntryBase
         self.x = x
     }
     
-    /// An Entry represents one single entry in the chart.
-    /// - parameter x: the x value
-    /// - parameter y: the y value (the actual value of the entry)
-    /// - parameter data: Space for additional data this Entry represents.
+    // An Entry represents one single entry in the chart.
+    // - parameter x: the x value
+    // - parameter y: the y value (the actual value of the entry)
+    // - parameter data: Space for additional data this Entry represents.
     
     public init(x: Double, y: Double, data: AnyObject?)
     {
@@ -45,10 +45,10 @@ open class ChartDataEntry: ChartDataEntryBase
         self.data = data
     }
     
-    /// An Entry represents one single entry in the chart.
-    /// - parameter x: the x value
-    /// - parameter y: the y value (the actual value of the entry)
-    /// - parameter icon: icon image
+    // An Entry represents one single entry in the chart.
+    // - parameter x: the x value
+    // - parameter y: the y value (the actual value of the entry)
+    // - parameter icon: icon image
     
     public init(x: Double, y: Double, icon: NSUIImage?)
     {
@@ -57,11 +57,11 @@ open class ChartDataEntry: ChartDataEntryBase
         self.x = x
     }
     
-    /// An Entry represents one single entry in the chart.
-    /// - parameter x: the x value
-    /// - parameter y: the y value (the actual value of the entry)
-    /// - parameter icon: icon image
-    /// - parameter data: Space for additional data this Entry represents.
+    // An Entry represents one single entry in the chart.
+    // - parameter x: the x value
+    // - parameter y: the y value (the actual value of the entry)
+    // - parameter icon: icon image
+    // - parameter data: Space for additional data this Entry represents.
     
     public init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
     {

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -13,13 +13,13 @@ import Foundation
 
 open class ChartDataEntryBase: NSObject
 {
-    /// the y value
+    // the y value
     open var y = Double(0.0)
     
-    /// optional spot for additional data this Entry represents
+    // optional spot for additional data this Entry represents
     open var data: AnyObject?
     
-    /// optional icon image
+    // optional icon image
     open var icon: NSUIImage?
     
     public override required init()
@@ -27,8 +27,8 @@ open class ChartDataEntryBase: NSObject
         super.init()
     }
     
-    /// An Entry represents one single entry in the chart.
-    /// - parameter y: the y value (the actual value of the entry)
+    // An Entry represents one single entry in the chart.
+    // - parameter y: the y value (the actual value of the entry)
     public init(y: Double)
     {
         super.init()
@@ -36,8 +36,8 @@ open class ChartDataEntryBase: NSObject
         self.y = y
     }
     
-    /// - parameter y: the y value (the actual value of the entry)
-    /// - parameter data: Space for additional data this Entry represents.
+    // - parameter y: the y value (the actual value of the entry)
+    // - parameter data: Space for additional data this Entry represents.
     
     public init(y: Double, data: AnyObject?)
     {
@@ -47,8 +47,8 @@ open class ChartDataEntryBase: NSObject
         self.data = data
     }
     
-    /// - parameter y: the y value (the actual value of the entry)
-    /// - parameter icon: icon image
+    // - parameter y: the y value (the actual value of the entry)
+    // - parameter icon: icon image
     
     public init(y: Double, icon: NSUIImage?)
     {
@@ -58,9 +58,9 @@ open class ChartDataEntryBase: NSObject
         self.icon = icon
     }
     
-    /// - parameter y: the y value (the actual value of the entry)
-    /// - parameter icon: icon image
-    /// - parameter data: Space for additional data this Entry represents.
+    // - parameter y: the y value (the actual value of the entry)
+    // - parameter icon: icon image
+    // - parameter data: Space for additional data this Entry represents.
     
     public init(y: Double, icon: NSUIImage?, data: AnyObject?)
     {

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-/// Determines how to round DataSet index values for `ChartDataSet.entryIndex(x, rounding)` when an exact x-value is not found.
+// Determines how to round DataSet index values for `ChartDataSet.entryIndex(x, rounding)` when an exact x-value is not found.
 @objc
 public enum ChartDataSetRounding: Int
 {
@@ -20,8 +20,8 @@ public enum ChartDataSetRounding: Int
     case closest = 2
 }
 
-/// The DataSet class represents one group or type of entries (Entry) in the Chart that belong together.
-/// It is designed to logically separate different groups of values inside the Chart (e.g. the values for a specific line in the LineChart, or the values of a specific group of bars in the BarChart).
+// The DataSet class represents one group or type of entries (Entry) in the Chart that belong together.
+// It is designed to logically separate different groups of values inside the Chart (e.g. the values for a specific line in the LineChart, or the values of a specific group of bars in the BarChart).
 open class ChartDataSet: ChartBaseDataSet
 {
     public required init()
@@ -54,24 +54,24 @@ open class ChartDataSet: ChartBaseDataSet
     
     // MARK: - Data functions and accessors
     
-    /// the entries that this dataset represents / holds together
+    // the entries that this dataset represents / holds together
     internal var _values: [ChartDataEntry]!
     
-    /// maximum y-value in the value array
+    // maximum y-value in the value array
     internal var _yMax: Double = -Double.greatestFiniteMagnitude
     
-    /// minimum y-value in the value array
+    // minimum y-value in the value array
     internal var _yMin: Double = Double.greatestFiniteMagnitude
     
-    /// maximum x-value in the value array
+    // maximum x-value in the value array
     internal var _xMax: Double = -Double.greatestFiniteMagnitude
     
-    /// minimum x-value in the value array
+    // minimum x-value in the value array
     internal var _xMin: Double = Double.greatestFiniteMagnitude
     
-    /// *
-    /// - note: Calls `notifyDataSetChanged()` after setting a new value.
-    /// - returns: The array of y-values that this DataSet represents.
+    // *
+    // - note: Calls `notifyDataSetChanged()` after setting a new value.
+    // - returns: The array of y-values that this DataSet represents.
     open var values: [ChartDataEntry]
     {
         get
@@ -85,7 +85,7 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    /// Use this method to tell the data set that the underlying data has changed
+    // Use this method to tell the data set that the underlying data has changed
     open override func notifyDataSetChanged()
     {
         calcMinMax()
@@ -155,33 +155,33 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    /// Updates the min and max x and y value of this DataSet based on the given Entry.
-    ///
-    /// - parameter e:
+    // Updates the min and max x and y value of this DataSet based on the given Entry.
+    //
+    // - parameter e:
     internal func calcMinMax(entry e: ChartDataEntry)
     {
         calcMinMaxX(entry: e)
         calcMinMaxY(entry: e)
     }
     
-    /// - returns: The minimum y-value this DataSet holds
+    // - returns: The minimum y-value this DataSet holds
     open override var yMin: Double { return _yMin }
     
-    /// - returns: The maximum y-value this DataSet holds
+    // - returns: The maximum y-value this DataSet holds
     open override var yMax: Double { return _yMax }
     
-    /// - returns: The minimum x-value this DataSet holds
+    // - returns: The minimum x-value this DataSet holds
     open override var xMin: Double { return _xMin }
     
-    /// - returns: The maximum x-value this DataSet holds
+    // - returns: The maximum x-value this DataSet holds
     open override var xMax: Double { return _xMax }
     
-    /// - returns: The number of y-values this DataSet represents
+    // - returns: The number of y-values this DataSet represents
     open override var entryCount: Int { return _values?.count ?? 0 }
     
-    /// - returns: The entry object found at the given index (not x-value!)
-    /// - throws: out of bounds
-    /// if `i` is out of bounds, it may throw an out-of-bounds exception
+    // - returns: The entry object found at the given index (not x-value!)
+    // - throws: out of bounds
+    // if `i` is out of bounds, it may throw an out-of-bounds exception
     open override func entryForIndex(_ i: Int) -> ChartDataEntry?
     {
         guard i >= 0 && i < _values.count else {
@@ -190,12 +190,12 @@ open class ChartDataSet: ChartBaseDataSet
         return _values[i]
     }
     
-    /// - returns: The first Entry object found at the given x-value with binary search.
-    /// If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value according to the rounding.
-    /// nil if no Entry object at that x-value.
-    /// - parameter xValue: the x-value
-    /// - parameter closestToY: If there are multiple y-values for the specified x-value,
-    /// - parameter rounding: determine whether to round up/down/closest if there is no Entry matching the provided x-value
+    // - returns: The first Entry object found at the given x-value with binary search.
+    // If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value according to the rounding.
+    // nil if no Entry object at that x-value.
+    // - parameter xValue: the x-value
+    // - parameter closestToY: If there are multiple y-values for the specified x-value,
+    // - parameter rounding: determine whether to round up/down/closest if there is no Entry matching the provided x-value
     open override func entryForXValue(
         _ xValue: Double,
         closestToY yValue: Double,
@@ -209,11 +209,11 @@ open class ChartDataSet: ChartBaseDataSet
         return nil
     }
     
-    /// - returns: The first Entry object found at the given x-value with binary search.
-    /// If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value.
-    /// nil if no Entry object at that x-value.
-    /// - parameter xValue: the x-value
-    /// - parameter closestToY: If there are multiple y-values for the specified x-value,
+    // - returns: The first Entry object found at the given x-value with binary search.
+    // If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value.
+    // nil if no Entry object at that x-value.
+    // - parameter xValue: the x-value
+    // - parameter closestToY: If there are multiple y-values for the specified x-value,
     open override func entryForXValue(
         _ xValue: Double,
         closestToY yValue: Double) -> ChartDataEntry?
@@ -221,8 +221,8 @@ open class ChartDataSet: ChartBaseDataSet
         return entryForXValue(xValue, closestToY: yValue, rounding: .closest)
     }
     
-    /// - returns: All Entry objects found at the given xIndex with binary search.
-    /// An empty array if no Entry object at that index.
+    // - returns: All Entry objects found at the given xIndex with binary search.
+    // An empty array if no Entry object at that index.
     open override func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
     {
         var entries = [ChartDataEntry]()
@@ -279,12 +279,12 @@ open class ChartDataSet: ChartBaseDataSet
         return entries
     }
     
-    /// - returns: The array-index of the specified entry.
-    /// If the no Entry at the specified x-value is found, this method returns the index of the Entry at the closest x-value according to the rounding.
-    ///
-    /// - parameter xValue: x-value of the entry to search for
-    /// - parameter closestToY: If there are multiple y-values for the specified x-value,
-    /// - parameter rounding: Rounding method if exact value was not found
+    // - returns: The array-index of the specified entry.
+    // If the no Entry at the specified x-value is found, this method returns the index of the Entry at the closest x-value according to the rounding.
+    //
+    // - parameter xValue: x-value of the entry to search for
+    // - parameter closestToY: If there are multiple y-values for the specified x-value,
+    // - parameter rounding: Rounding method if exact value was not found
     open override func entryIndex(
         x xValue: Double,
         closestToY yValue: Double,
@@ -387,9 +387,9 @@ open class ChartDataSet: ChartBaseDataSet
         return closest
     }
     
-    /// - returns: The array-index of the specified entry
-    ///
-    /// - parameter e: the entry to search for
+    // - returns: The array-index of the specified entry
+    //
+    // - parameter e: the entry to search for
     open override func entryIndex(entry e: ChartDataEntry) -> Int
     {
         for i in 0 ..< _values.count
@@ -403,11 +403,11 @@ open class ChartDataSet: ChartBaseDataSet
         return -1
     }
     
-    /// Adds an Entry to the DataSet dynamically.
-    /// Entries are added to the end of the list.
-    /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
-    /// - parameter e: the entry to add
-    /// - returns: True
+    // Adds an Entry to the DataSet dynamically.
+    // Entries are added to the end of the list.
+    // This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
+    // - parameter e: the entry to add
+    // - returns: True
     open override func addEntry(_ e: ChartDataEntry) -> Bool
     {
         if _values == nil
@@ -422,11 +422,11 @@ open class ChartDataSet: ChartBaseDataSet
         return true
     }
     
-    /// Adds an Entry to the DataSet dynamically.
-    /// Entries are added to their appropriate index respective to it's x-index.
-    /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
-    /// - parameter e: the entry to add
-    /// - returns: True
+    // Adds an Entry to the DataSet dynamically.
+    // Entries are added to their appropriate index respective to it's x-index.
+    // This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
+    // - parameter e: the entry to add
+    // - returns: True
     open override func addEntryOrdered(_ e: ChartDataEntry) -> Bool
     {
         if _values == nil
@@ -453,10 +453,10 @@ open class ChartDataSet: ChartBaseDataSet
         return true
     }
     
-    /// Removes an Entry from the DataSet dynamically.
-    /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
-    /// - parameter entry: the entry to remove
-    /// - returns: `true` if the entry was removed successfully, else if the entry does not exist
+    // Removes an Entry from the DataSet dynamically.
+    // This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
+    // - parameter entry: the entry to remove
+    // - returns: `true` if the entry was removed successfully, else if the entry does not exist
     open override func removeEntry(_ entry: ChartDataEntry) -> Bool
     {
         var removed = false
@@ -479,9 +479,9 @@ open class ChartDataSet: ChartBaseDataSet
         return removed
     }
     
-    /// Removes the first Entry (at index 0) of this DataSet from the entries array.
-    ///
-    /// - returns: `true` if successful, `false` ifnot.
+    // Removes the first Entry (at index 0) of this DataSet from the entries array.
+    //
+    // - returns: `true` if successful, `false` ifnot.
     open override func removeFirst() -> Bool
     {
         let entry: ChartDataEntry? = _values.isEmpty ? nil : _values.removeFirst()
@@ -496,9 +496,9 @@ open class ChartDataSet: ChartBaseDataSet
         return removed
     }
     
-    /// Removes the last Entry (at index size-1) of this DataSet from the entries array.
-    ///
-    /// - returns: `true` if successful, `false` ifnot.
+    // Removes the last Entry (at index size-1) of this DataSet from the entries array.
+    //
+    // - returns: `true` if successful, `false` ifnot.
     open override func removeLast() -> Bool
     {
         let entry: ChartDataEntry? = _values.isEmpty ? nil : _values.removeLast()
@@ -513,8 +513,8 @@ open class ChartDataSet: ChartBaseDataSet
         return removed
     }
     
-    /// Checks if this DataSet contains the specified Entry.
-    /// - returns: `true` if contains the entry, `false` ifnot.
+    // Checks if this DataSet contains the specified Entry.
+    // - returns: `true` if contains the entry, `false` ifnot.
     open override func contains(_ e: ChartDataEntry) -> Bool
     {
         for entry in _values
@@ -528,7 +528,7 @@ open class ChartDataSet: ChartBaseDataSet
         return false
     }
     
-    /// Removes all values from this DataSet and recalculates min and max value.
+    // Removes all values from this DataSet and recalculates min and max value.
     open override func clear()
     {
         _values.removeAll(keepingCapacity: true)

--- a/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
@@ -159,7 +159,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         }
     }
     
-    /// - returns: All data objects in row: line-bar-scatter-candle-bubble if not null.
+    // - returns: All data objects in row: line-bar-scatter-candle-bubble if not null.
     open var allData: [ChartData]
     {
         var data = [ChartData]()
@@ -262,10 +262,10 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
     }
     
     
-    /// Get the Entry for a corresponding highlight object
-    ///
-    /// - parameter highlight:
-    /// - returns: The entry that is highlighted
+    // Get the Entry for a corresponding highlight object
+    //
+    // - parameter highlight:
+    // - returns: The entry that is highlighted
     open override func entryForHighlight(_ highlight: Highlight) -> ChartDataEntry?
     {
         let dataObjects = allData

--- a/Source/Charts/Data/Implementations/Standard/LineChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartData.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-/// Data object that encapsulates all data associated with a LineChart.
+// Data object that encapsulates all data associated with a LineChart.
 open class LineChartData: ChartData
 {
     public override init()

--- a/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
@@ -46,16 +46,16 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// The drawing mode for this line dataset
-    ///
-    /// **default**: Linear
+    // The drawing mode for this line dataset
+    //
+    // **default**: Linear
     open var mode: Mode = Mode.linear
     
     fileprivate var _cubicIntensity = CGFloat(0.2)
     
-    /// Intensity for cubic lines (min = 0.05, max = 1)
-    ///
-    /// **default**: 0.2
+    // Intensity for cubic lines (min = 0.05, max = 1)
+    //
+    // **default**: 0.2
     open var cubicIntensity: CGFloat
     {
         get
@@ -108,16 +108,16 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     @available(*, deprecated: 1.0, message: "Use `mode` instead.")
     open var isDrawSteppedEnabled: Bool { return drawSteppedEnabled }
     
-    /// The radius of the drawn circles.
+    // The radius of the drawn circles.
     open var circleRadius = CGFloat(8.0)
     
-    /// The hole radius of the drawn circles
+    // The hole radius of the drawn circles
     open var circleHoleRadius = CGFloat(4.0)
     
     open var circleColors = [NSUIColor]()
     
-    /// - returns: The color at the given index of the DataSet's circle-color array.
-    /// Performs a IndexOutOfBounds check by modulus.
+    // - returns: The color at the given index of the DataSet's circle-color array.
+    // Performs a IndexOutOfBounds check by modulus.
     open func getCircleColor(atIndex index: Int) -> NSUIColor?
     {
         let size = circleColors.count
@@ -129,8 +129,8 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
         return circleColors[index]
     }
     
-    /// Sets the one and ONLY color that should be used for this DataSet.
-    /// Internally, this recreates the colors array and adds the specified color.
+    // Sets the one and ONLY color that should be used for this DataSet.
+    // Internally, this recreates the colors array and adds the specified color.
     open func setCircleColor(_ color: NSUIColor)
     {
         circleColors.removeAll(keepingCapacity: false)
@@ -143,42 +143,42 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
         circleColors.append(contentsOf: colors)
     }
     
-    /// Resets the circle-colors array and creates a new one
+    // Resets the circle-colors array and creates a new one
     open func resetCircleColors(_ index: Int)
     {
         circleColors.removeAll(keepingCapacity: false)
     }
     
-    /// If true, drawing circles is enabled
+    // If true, drawing circles is enabled
     open var drawCirclesEnabled = true
     
-    /// - returns: `true` if drawing circles for this DataSet is enabled, `false` ifnot
+    // - returns: `true` if drawing circles for this DataSet is enabled, `false` ifnot
     open var isDrawCirclesEnabled: Bool { return drawCirclesEnabled }
     
-    /// The color of the inner circle (the circle-hole).
+    // The color of the inner circle (the circle-hole).
     open var circleHoleColor: NSUIColor? = NSUIColor.white
     
-    /// `true` if drawing circles for this DataSet is enabled, `false` ifnot
+    // `true` if drawing circles for this DataSet is enabled, `false` ifnot
     open var drawCircleHoleEnabled = true
     
-    /// - returns: `true` if drawing the circle-holes is enabled, `false` ifnot.
+    // - returns: `true` if drawing the circle-holes is enabled, `false` ifnot.
     open var isDrawCircleHoleEnabled: Bool { return drawCircleHoleEnabled }
     
-    /// This is how much (in pixels) into the dash pattern are we starting from.
+    // This is how much (in pixels) into the dash pattern are we starting from.
     open var lineDashPhase = CGFloat(0.0)
     
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     open var lineDashLengths: [CGFloat]?
     
-    /// Line cap type, default is CGLineCap.Butt
+    // Line cap type, default is CGLineCap.Butt
     open var lineCapType = CGLineCap.butt
     
-    /// formatter for customizing the position of the fill-line
+    // formatter for customizing the position of the fill-line
     fileprivate var _fillFormatter: IFillFormatter = DefaultFillFormatter()
     
-    /// Sets a custom IFillFormatter to the chart that handles the position of the filled-line for each DataSet. Set this to null to use the default logic.
+    // Sets a custom IFillFormatter to the chart that handles the position of the filled-line for each DataSet. Set this to null to use the default logic.
     open var fillFormatter: IFillFormatter?
     {
         get

--- a/Source/Charts/Data/Implementations/Standard/LineRadarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineRadarChartDataSet.swift
@@ -19,10 +19,10 @@ open class LineRadarChartDataSet: LineScatterCandleRadarChartDataSet, ILineRadar
     
     // MARK: - Styling functions and accessors
     
-    /// The color that is used for filling the line surface area.
+    // The color that is used for filling the line surface area.
     fileprivate var _fillColor = NSUIColor(red: 140.0/255.0, green: 234.0/255.0, blue: 255.0/255.0, alpha: 1.0)
     
-    /// The color that is used for filling the line surface area.
+    // The color that is used for filling the line surface area.
     open var fillColor: NSUIColor
     {
         get { return _fillColor }
@@ -33,19 +33,19 @@ open class LineRadarChartDataSet: LineScatterCandleRadarChartDataSet, ILineRadar
         }
     }
     
-    /// The object that is used for filling the area below the line.
-    /// **default**: nil
+    // The object that is used for filling the area below the line.
+    // **default**: nil
     open var fill: Fill?
     
-    /// The alpha value that is used for filling the line surface,
-    /// **default**: 0.33
+    // The alpha value that is used for filling the line surface,
+    // **default**: 0.33
     open var fillAlpha = CGFloat(0.33)
     
     fileprivate var _lineWidth = CGFloat(1.0)
     
-    /// line width of the chart (min = 0.0, max = 10)
-    ///
-    /// **default**: 1
+    // line width of the chart (min = 0.0, max = 10)
+    //
+    // **default**: 1
     open var lineWidth: CGFloat
     {
         get
@@ -69,12 +69,12 @@ open class LineRadarChartDataSet: LineScatterCandleRadarChartDataSet, ILineRadar
         }
     }
     
-    /// Set to `true` if the DataSet should be drawn filled (surface), and not just as a line.
-    /// Disabling this will give great performance boost.
-    /// Please note that this method uses the path clipping for drawing the filled area (with images, gradients and layers).
+    // Set to `true` if the DataSet should be drawn filled (surface), and not just as a line.
+    // Disabling this will give great performance boost.
+    // Please note that this method uses the path clipping for drawing the filled area (with images, gradients and layers).
     open var drawFilledEnabled = false
     
-    /// - returns: `true` if filled drawing is enabled, `false` ifnot
+    // - returns: `true` if filled drawing is enabled, `false` ifnot
     open var isDrawFilledEnabled: Bool
     {
         return drawFilledEnabled

--- a/Source/Charts/Data/Implementations/Standard/LineScatterCandleRadarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineScatterCandleRadarChartDataSet.swift
@@ -18,20 +18,20 @@ open class LineScatterCandleRadarChartDataSet: BarLineScatterCandleBubbleChartDa
     
     // MARK: - Styling functions and accessors
     
-    /// Enables / disables the horizontal highlight-indicator. If disabled, the indicator is not drawn.
+    // Enables / disables the horizontal highlight-indicator. If disabled, the indicator is not drawn.
     open var drawHorizontalHighlightIndicatorEnabled = true
     
-    /// Enables / disables the vertical highlight-indicator. If disabled, the indicator is not drawn.
+    // Enables / disables the vertical highlight-indicator. If disabled, the indicator is not drawn.
     open var drawVerticalHighlightIndicatorEnabled = true
     
-    /// - returns: `true` if horizontal highlight indicator lines are enabled (drawn)
+    // - returns: `true` if horizontal highlight indicator lines are enabled (drawn)
     open var isHorizontalHighlightIndicatorEnabled: Bool { return drawHorizontalHighlightIndicatorEnabled }
     
-    /// - returns: `true` if vertical highlight indicator lines are enabled (drawn)
+    // - returns: `true` if vertical highlight indicator lines are enabled (drawn)
     open var isVerticalHighlightIndicatorEnabled: Bool { return drawVerticalHighlightIndicatorEnabled }
     
-    /// Enables / disables both vertical and horizontal highlight-indicators.
-    /// :param: enabled
+    // Enables / disables both vertical and horizontal highlight-indicators.
+    // :param: enabled
     open func setDrawHighlightIndicators(_ enabled: Bool)
     {
         drawHorizontalHighlightIndicatorEnabled = enabled

--- a/Source/Charts/Data/Implementations/Standard/PieChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartData.swift
@@ -85,10 +85,10 @@ open class PieChartData: ChartData
         super.addDataSet(d)
     }
     
-    /// Removes the DataSet at the given index in the DataSet array from the data object.
-    /// Also recalculates all minimum and maximum values.
-    ///
-    /// - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
+    // Removes the DataSet at the given index in the DataSet array from the data object.
+    // Also recalculates all minimum and maximum values.
+    //
+    // - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
     open override func removeDataSetByIndex(_ index: Int) -> Bool
     {
         if index >= _dataSets.count || index < 0
@@ -99,7 +99,7 @@ open class PieChartData: ChartData
         return false
     }
     
-    /// - returns: The total y-value sum across all DataSet objects the this object represents.
+    // - returns: The total y-value sum across all DataSet objects the this object represents.
     open var yValueSum: Double
     {
         guard let dataSet = dataSet else { return 0.0 }

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
@@ -19,33 +19,33 @@ open class PieChartDataEntry: ChartDataEntry
         super.init()
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter label: The label for the x-axis
+    // - parameter value: The value on the y-axis
+    // - parameter label: The label for the x-axis
     public convenience init(value: Double, label: String?)
     {
         self.init(value: value, label: label, icon: nil, data: nil)
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter label: The label for the x-axis
-    /// - parameter data: Spot for additional data this Entry represents
+    // - parameter value: The value on the y-axis
+    // - parameter label: The label for the x-axis
+    // - parameter data: Spot for additional data this Entry represents
     public convenience init(value: Double, label: String?, data: AnyObject?)
     {
         self.init(value: value, label: label, icon: nil, data: data)
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter label: The label for the x-axis
-    /// - parameter icon: icon image
+    // - parameter value: The value on the y-axis
+    // - parameter label: The label for the x-axis
+    // - parameter icon: icon image
     public convenience init(value: Double, label: String?, icon: NSUIImage?)
     {
         self.init(value: value, label: label, icon: icon, data: nil)
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter label: The label for the x-axis
-    /// - parameter icon: icon image
-    /// - parameter data: Spot for additional data this Entry represents
+    // - parameter value: The value on the y-axis
+    // - parameter label: The label for the x-axis
+    // - parameter icon: icon image
+    // - parameter data: Spot for additional data this Entry represents
     public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: 0.0, y: value, icon: icon, data: data)
@@ -53,29 +53,29 @@ open class PieChartDataEntry: ChartDataEntry
         self.label = label
     }
     
-    /// - parameter value: The value on the y-axis
+    // - parameter value: The value on the y-axis
     public convenience init(value: Double)
     {
         self.init(value: value, label: nil, icon: nil, data: nil)
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter data: Spot for additional data this Entry represents
+    // - parameter value: The value on the y-axis
+    // - parameter data: Spot for additional data this Entry represents
     public convenience init(value: Double, data: AnyObject?)
     {
         self.init(value: value, label: nil, icon: nil, data: data)
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter icon: icon image
+    // - parameter value: The value on the y-axis
+    // - parameter icon: icon image
     public convenience init(value: Double, icon: NSUIImage?)
     {
         self.init(value: value, label: nil, icon: icon, data: nil)
     }
     
-    /// - parameter value: The value on the y-axis
-    /// - parameter icon: icon image
-    /// - parameter data: Spot for additional data this Entry represents
+    // - parameter value: The value on the y-axis
+    // - parameter icon: icon image
+    // - parameter data: Spot for additional data this Entry represents
     public convenience init(value: Double, icon: NSUIImage?, data: AnyObject?)
     {
         self.init(value: value, label: nil, icon: icon, data: data)

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
@@ -48,9 +48,9 @@ open class PieChartDataSet: ChartDataSet, IPieChartDataSet
     
     fileprivate var _sliceSpace = CGFloat(0.0)
     
-    /// the space in pixels between the pie-slices
-    /// **default**: 0
-    /// **maximum**: 20
+    // the space in pixels between the pie-slices
+    // **default**: 0
+    // **maximum**: 20
     open var sliceSpace: CGFloat
     {
         get
@@ -72,37 +72,37 @@ open class PieChartDataSet: ChartDataSet, IPieChartDataSet
         }
     }
 
-    /// When enabled, slice spacing will be 0.0 when the smallest value is going to be smaller than the slice spacing itself.
+    // When enabled, slice spacing will be 0.0 when the smallest value is going to be smaller than the slice spacing itself.
     open var automaticallyDisableSliceSpacing: Bool = false
     
-    /// indicates the selection distance of a pie slice
+    // indicates the selection distance of a pie slice
     open var selectionShift = CGFloat(18.0)
     
     open var xValuePosition: ValuePosition = .insideSlice
     open var yValuePosition: ValuePosition = .insideSlice
     
-    /// When valuePosition is OutsideSlice, indicates line color
+    // When valuePosition is OutsideSlice, indicates line color
     open var valueLineColor: NSUIColor? = NSUIColor.black
     
-    /// When valuePosition is OutsideSlice, indicates line width
+    // When valuePosition is OutsideSlice, indicates line width
     open var valueLineWidth: CGFloat = 1.0
     
-    /// When valuePosition is OutsideSlice, indicates offset as percentage out of the slice size
+    // When valuePosition is OutsideSlice, indicates offset as percentage out of the slice size
     open var valueLinePart1OffsetPercentage: CGFloat = 0.75
     
-    /// When valuePosition is OutsideSlice, indicates length of first half of the line
+    // When valuePosition is OutsideSlice, indicates length of first half of the line
     open var valueLinePart1Length: CGFloat = 0.3
     
-    /// When valuePosition is OutsideSlice, indicates length of second half of the line
+    // When valuePosition is OutsideSlice, indicates length of second half of the line
     open var valueLinePart2Length: CGFloat = 0.4
     
-    /// When valuePosition is OutsideSlice, this allows variable line length
+    // When valuePosition is OutsideSlice, this allows variable line length
     open var valueLineVariableLength: Bool = true
     
-    /// the font for the slice-text labels
+    // the font for the slice-text labels
     open var entryLabelFont: NSUIFont? = nil
     
-    /// the color for the slice-text labels
+    // the color for the slice-text labels
     open var entryLabelColor: NSUIColor? = nil
     
     // MARK: - NSCopying

--- a/Source/Charts/Data/Implementations/Standard/RadarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartData.swift
@@ -20,10 +20,10 @@ open class RadarChartData: ChartData
     open var highlightLineDashPhase = CGFloat(0.0)
     open var highlightLineDashLengths: [CGFloat]?
     
-    /// Sets labels that should be drawn around the RadarChart at the end of each web line.
+    // Sets labels that should be drawn around the RadarChart at the end of each web line.
     open var labels = [String]()
     
-    /// Sets the labels that should be drawn around the RadarChart at the end of each web line.
+    // Sets the labels that should be drawn around the RadarChart at the end of each web line.
     open func setLabels(_ labels: String...)
     {
         self.labels = labels

--- a/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
@@ -19,14 +19,14 @@ open class RadarChartDataEntry: ChartDataEntry
         super.init()
     }
     
-    /// - parameter value: The value on the y-axis.
-    /// - parameter data: Spot for additional data this Entry represents.
+    // - parameter value: The value on the y-axis.
+    // - parameter data: Spot for additional data this Entry represents.
     public init(value: Double, data: AnyObject?)
     {
         super.init(x: 0.0, y: value, data: data)
     }
     
-    /// - parameter value: The value on the y-axis.
+    // - parameter value: The value on the y-axis.
     public convenience init(value: Double)
     {
         self.init(value: value, data: nil)

--- a/Source/Charts/Data/Implementations/Standard/RadarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartDataSet.swift
@@ -36,17 +36,17 @@ open class RadarChartDataSet: LineRadarChartDataSet, IRadarChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// flag indicating whether highlight circle should be drawn or not
-    /// **default**: false
+    // flag indicating whether highlight circle should be drawn or not
+    // **default**: false
     open var drawHighlightCircleEnabled: Bool = false
     
-    /// - returns: `true` if highlight circle should be drawn, `false` ifnot
+    // - returns: `true` if highlight circle should be drawn, `false` ifnot
     open var isDrawHighlightCircleEnabled: Bool { return drawHighlightCircleEnabled }
     
     open var highlightCircleFillColor: NSUIColor? = NSUIColor.white
     
-    /// The stroke color for highlight circle.
-    /// If `nil`, the color of the dataset is taken.
+    // The stroke color for highlight circle.
+    // If `nil`, the color of the dataset is taken.
     open var highlightCircleStrokeColor: NSUIColor?
     
     open var highlightCircleStrokeAlpha: CGFloat = 0.3

--- a/Source/Charts/Data/Implementations/Standard/ScatterChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ScatterChartData.swift
@@ -24,7 +24,7 @@ open class ScatterChartData: BarLineScatterCandleBubbleChartData
         super.init(dataSets: dataSets)
     }
     
-    /// - returns: The maximum shape-size across all DataSets.
+    // - returns: The maximum shape-size across all DataSets.
     open func getGreatestShapeSize() -> CGFloat
     {
         var max = CGFloat(0.0)

--- a/Source/Charts/Data/Implementations/Standard/ScatterChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ScatterChartDataSet.swift
@@ -27,27 +27,27 @@ open class ScatterChartDataSet: LineScatterCandleRadarChartDataSet, IScatterChar
         case chevronDown
     }
     
-    /// The size the scatter shape will have
+    // The size the scatter shape will have
     open var scatterShapeSize = CGFloat(10.0)
     
-    /// The radius of the hole in the shape (applies to Square, Circle and Triangle)
-    /// **default**: 0.0
+    // The radius of the hole in the shape (applies to Square, Circle and Triangle)
+    // **default**: 0.0
     open var scatterShapeHoleRadius: CGFloat = 0.0
     
-    /// Color for the hole in the shape. Setting to `nil` will behave as transparent.
-    /// **default**: nil
+    // Color for the hole in the shape. Setting to `nil` will behave as transparent.
+    // **default**: nil
     open var scatterShapeHoleColor: NSUIColor? = nil
     
-    /// Sets the ScatterShape this DataSet should be drawn with.
-    /// This will search for an available IShapeRenderer and set this renderer for the DataSet
+    // Sets the ScatterShape this DataSet should be drawn with.
+    // This will search for an available IShapeRenderer and set this renderer for the DataSet
     open func setScatterShape(_ shape: Shape)
     {
         self.shapeRenderer = ScatterChartDataSet.renderer(forShape: shape)
     }
     
-    /// The IShapeRenderer responsible for rendering this DataSet.
-    /// This can also be used to set a custom IShapeRenderer aside from the default ones.
-    /// **default**: `SquareShapeRenderer`
+    // The IShapeRenderer responsible for rendering this DataSet.
+    // This can also be used to set a custom IShapeRenderer aside from the default ones.
+    // **default**: `SquareShapeRenderer`
     open var shapeRenderer: IShapeRenderer? = SquareShapeRenderer()
     
     open class func renderer(forShape shape: Shape) -> IShapeRenderer

--- a/Source/Charts/Data/Interfaces/IBarChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IBarChartDataSet.swift
@@ -19,24 +19,24 @@ public protocol IBarChartDataSet: IBarLineScatterCandleBubbleChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// - returns: `true` if this DataSet is stacked (stacksize > 1) or not.
+    // - returns: `true` if this DataSet is stacked (stacksize > 1) or not.
     var isStacked: Bool { get }
     
-    /// - returns: The maximum number of bars that can be stacked upon another in this DataSet.
+    // - returns: The maximum number of bars that can be stacked upon another in this DataSet.
     var stackSize: Int { get }
     
-    /// the color used for drawing the bar-shadows. The bar shadows is a surface behind the bar that indicates the maximum value
+    // the color used for drawing the bar-shadows. The bar shadows is a surface behind the bar that indicates the maximum value
     var barShadowColor: NSUIColor { get set }
     
-    /// the width used for drawing borders around the bars. If borderWidth == 0, no border will be drawn.
+    // the width used for drawing borders around the bars. If borderWidth == 0, no border will be drawn.
     var barBorderWidth : CGFloat { get set }
 
-    /// the color drawing borders around the bars.
+    // the color drawing borders around the bars.
     var barBorderColor: NSUIColor { get set }
 
-    /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
+    // the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     var highlightAlpha: CGFloat { get set }
     
-    /// array of labels used to describe the different values of the stacked bars
+    // array of labels used to describe the different values of the stacked bars
     var stackLabels: [String] { get set }
 }

--- a/Source/Charts/Data/Interfaces/IBubbleChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IBubbleChartDataSet.swift
@@ -22,6 +22,6 @@ public protocol IBubbleChartDataSet: IBarLineScatterCandleBubbleChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// Sets/gets the width of the circle that surrounds the bubble when highlighted
+    // Sets/gets the width of the circle that surrounds the bubble when highlighted
     var highlightCircleWidth: CGFloat { get set }
 }

--- a/Source/Charts/Data/Interfaces/ICandleChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ICandleChartDataSet.swift
@@ -19,48 +19,48 @@ public protocol ICandleChartDataSet: ILineScatterCandleRadarChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// the space that is left out on the left and right side of each candle,
-    /// **default**: 0.1 (10%), max 0.45, min 0.0
+    // the space that is left out on the left and right side of each candle,
+    // **default**: 0.1 (10%), max 0.45, min 0.0
     var barSpace: CGFloat { get set }
     
-    /// should the candle bars show?
-    /// when false, only "ticks" will show
-    ///
-    /// **default**: true
+    // should the candle bars show?
+    // when false, only "ticks" will show
+    //
+    // **default**: true
     var showCandleBar: Bool { get set }
     
-    /// the width of the candle-shadow-line in pixels.
-    ///
-    /// **default**: 3.0
+    // the width of the candle-shadow-line in pixels.
+    //
+    // **default**: 3.0
     var shadowWidth: CGFloat { get set }
     
-    /// the color of the shadow line
+    // the color of the shadow line
     var shadowColor: NSUIColor? { get set }
     
-    /// use candle color for the shadow
+    // use candle color for the shadow
     var shadowColorSameAsCandle: Bool { get set }
     
-    /// Is the shadow color same as the candle color?
+    // Is the shadow color same as the candle color?
     var isShadowColorSameAsCandle: Bool { get }
     
-    /// color for open == close
+    // color for open == close
     var neutralColor: NSUIColor? { get set }
     
-    /// color for open > close
+    // color for open > close
     var increasingColor: NSUIColor? { get set }
     
-    /// color for open < close
+    // color for open < close
     var decreasingColor: NSUIColor? { get set }
     
-    /// Are increasing values drawn as filled?
+    // Are increasing values drawn as filled?
     var increasingFilled: Bool { get set }
     
-    /// Are increasing values drawn as filled?
+    // Are increasing values drawn as filled?
     var isIncreasingFilled: Bool { get }
     
-    /// Are decreasing values drawn as filled?
+    // Are decreasing values drawn as filled?
     var decreasingFilled: Bool { get set }
     
-    /// Are decreasing values drawn as filled?
+    // Are decreasing values drawn as filled?
     var isDecreasingFilled: Bool { get }
 }

--- a/Source/Charts/Data/Interfaces/IChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IChartDataSet.swift
@@ -16,161 +16,161 @@ public protocol IChartDataSet
 {
     // MARK: - Data functions and accessors
     
-    /// Use this method to tell the data set that the underlying data has changed
+    // Use this method to tell the data set that the underlying data has changed
     func notifyDataSetChanged()
     
-    /// Calculates the minimum and maximum x and y values (_xMin, _xMax, _yMin, _yMax).
+    // Calculates the minimum and maximum x and y values (_xMin, _xMax, _yMin, _yMax).
     func calcMinMax()
     
-    /// Calculates the min and max y-values from the Entry closest to the given fromX to the Entry closest to the given toX value.
-    /// This is only needed for the autoScaleMinMax feature.
+    // Calculates the min and max y-values from the Entry closest to the given fromX to the Entry closest to the given toX value.
+    // This is only needed for the autoScaleMinMax feature.
     func calcMinMaxY(fromX: Double, toX: Double)
     
-    /// - returns: The minimum y-value this DataSet holds
+    // - returns: The minimum y-value this DataSet holds
     var yMin: Double { get }
     
-    /// - returns: The maximum y-value this DataSet holds
+    // - returns: The maximum y-value this DataSet holds
     var yMax: Double { get }
     
-    /// - returns: The minimum x-value this DataSet holds
+    // - returns: The minimum x-value this DataSet holds
     var xMin: Double { get }
     
-    /// - returns: The maximum x-value this DataSet holds
+    // - returns: The maximum x-value this DataSet holds
     var xMax: Double { get }
     
-    /// - returns: The number of y-values this DataSet represents
+    // - returns: The number of y-values this DataSet represents
     var entryCount: Int { get }
     
-    /// - returns: The entry object found at the given index (not x-value!)
-    /// - throws: out of bounds
-    /// if `i` is out of bounds, it may throw an out-of-bounds exception
+    // - returns: The entry object found at the given index (not x-value!)
+    // - throws: out of bounds
+    // if `i` is out of bounds, it may throw an out-of-bounds exception
     func entryForIndex(_ i: Int) -> ChartDataEntry?
     
-    /// - returns: The first Entry object found at the given x-value with binary search.
-    /// If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value according to the rounding.
-    /// nil if no Entry object at that x-value.
-    /// - parameter xValue: the x-value
-    /// - parameter closestToY: If there are multiple y-values for the specified x-value,
-    /// - parameter rounding: determine whether to round up/down/closest if there is no Entry matching the provided x-value
+    // - returns: The first Entry object found at the given x-value with binary search.
+    // If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value according to the rounding.
+    // nil if no Entry object at that x-value.
+    // - parameter xValue: the x-value
+    // - parameter closestToY: If there are multiple y-values for the specified x-value,
+    // - parameter rounding: determine whether to round up/down/closest if there is no Entry matching the provided x-value
     func entryForXValue(
         _ xValue: Double,
         closestToY yValue: Double,
         rounding: ChartDataSetRounding) -> ChartDataEntry?
     
-    /// - returns: The first Entry object found at the given x-value with binary search.
-    /// If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value.
-    /// nil if no Entry object at that x-value.
-    /// - parameter xValue: the x-value
-    /// - parameter closestToY: If there are multiple y-values for the specified x-value,
+    // - returns: The first Entry object found at the given x-value with binary search.
+    // If the no Entry at the specified x-value is found, this method returns the Entry at the closest x-value.
+    // nil if no Entry object at that x-value.
+    // - parameter xValue: the x-value
+    // - parameter closestToY: If there are multiple y-values for the specified x-value,
     func entryForXValue(
         _ xValue: Double,
         closestToY yValue: Double) -> ChartDataEntry?
     
-    /// - returns: All Entry objects found at the given x-value with binary search.
-    /// An empty array if no Entry object at that x-value.
+    // - returns: All Entry objects found at the given x-value with binary search.
+    // An empty array if no Entry object at that x-value.
     func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
     
-    /// - returns: The array-index of the specified entry.
-    /// If the no Entry at the specified x-value is found, this method returns the index of the Entry at the closest x-value according to the rounding.
-    ///
-    /// - parameter xValue: x-value of the entry to search for
-    /// - parameter closestToY: If there are multiple y-values for the specified x-value,
-    /// - parameter rounding: Rounding method if exact value was not found
+    // - returns: The array-index of the specified entry.
+    // If the no Entry at the specified x-value is found, this method returns the index of the Entry at the closest x-value according to the rounding.
+    //
+    // - parameter xValue: x-value of the entry to search for
+    // - parameter closestToY: If there are multiple y-values for the specified x-value,
+    // - parameter rounding: Rounding method if exact value was not found
     func entryIndex(
         x xValue: Double,
         closestToY yValue: Double,
         rounding: ChartDataSetRounding) -> Int
     
-    /// - returns: The array-index of the specified entry
-    ///
-    /// - parameter e: the entry to search for
+    // - returns: The array-index of the specified entry
+    //
+    // - parameter e: the entry to search for
     func entryIndex(entry e: ChartDataEntry) -> Int
     
-    /// Adds an Entry to the DataSet dynamically.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// Entries are added to the end of the list.
-    /// - parameter e: the entry to add
-    /// - returns: `true` if the entry was added successfully, `false` ifthis feature is not supported
+    // Adds an Entry to the DataSet dynamically.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // Entries are added to the end of the list.
+    // - parameter e: the entry to add
+    // - returns: `true` if the entry was added successfully, `false` ifthis feature is not supported
     func addEntry(_ e: ChartDataEntry) -> Bool
     
-    /// Adds an Entry to the DataSet dynamically.
-    /// Entries are added to their appropriate index in the values array respective to their x-position.
-    /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// Entries are added to the end of the list.
-    /// - parameter e: the entry to add
-    /// - returns: `true` if the entry was added successfully, `false` ifthis feature is not supported
+    // Adds an Entry to the DataSet dynamically.
+    // Entries are added to their appropriate index in the values array respective to their x-position.
+    // This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // Entries are added to the end of the list.
+    // - parameter e: the entry to add
+    // - returns: `true` if the entry was added successfully, `false` ifthis feature is not supported
     func addEntryOrdered(_ e: ChartDataEntry) -> Bool
     
-    /// Removes an Entry from the DataSet dynamically.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// - parameter entry: the entry to remove
-    /// - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
+    // Removes an Entry from the DataSet dynamically.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // - parameter entry: the entry to remove
+    // - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
     func removeEntry(_ entry: ChartDataEntry) -> Bool
     
-    /// Removes the Entry object at the given index in the values array from the DataSet.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// - parameter index: the index of the entry to remove
-    /// - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
+    // Removes the Entry object at the given index in the values array from the DataSet.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // - parameter index: the index of the entry to remove
+    // - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
     func removeEntry(index: Int) -> Bool
     
-    /// Removes the Entry object closest to the given x-value from the DataSet.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// - parameter x: the x-value to remove
-    /// - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
+    // Removes the Entry object closest to the given x-value from the DataSet.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // - parameter x: the x-value to remove
+    // - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
     func removeEntry(x: Double) -> Bool
     
-    /// Removes the first Entry (at index 0) of this DataSet from the entries array.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
+    // Removes the first Entry (at index 0) of this DataSet from the entries array.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
     func removeFirst() -> Bool
     
-    /// Removes the last Entry (at index 0) of this DataSet from the entries array.
-    ///
-    /// *optional feature, can return `false` ifnot implemented*
-    ///
-    /// - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
+    // Removes the last Entry (at index 0) of this DataSet from the entries array.
+    //
+    // *optional feature, can return `false` ifnot implemented*
+    //
+    // - returns: `true` if the entry was removed successfully, `false` ifthe entry does not exist or if this feature is not supported
     func removeLast() -> Bool
     
-    /// Checks if this DataSet contains the specified Entry.
-    ///
-    /// - returns: `true` if contains the entry, `false` ifnot.
+    // Checks if this DataSet contains the specified Entry.
+    //
+    // - returns: `true` if contains the entry, `false` ifnot.
     func contains(_ e: ChartDataEntry) -> Bool
     
-    /// Removes all values from this DataSet and does all necessary recalculations.
-    ///
-    /// *optional feature, could throw if not implemented*
+    // Removes all values from this DataSet and does all necessary recalculations.
+    //
+    // *optional feature, could throw if not implemented*
     func clear()
     
     // MARK: - Styling functions and accessors
     
-    /// The label string that describes the DataSet.
+    // The label string that describes the DataSet.
     var label: String? { get }
     
-    /// The axis this DataSet should be plotted against.
+    // The axis this DataSet should be plotted against.
     var axisDependency: YAxis.AxisDependency { get }
     
-    /// List representing all colors that are used for drawing the actual values for this DataSet
+    // List representing all colors that are used for drawing the actual values for this DataSet
     var valueColors: [NSUIColor] { get }
     
-    /// All the colors that are used for this DataSet.
-    /// Colors are reused as soon as the number of Entries the DataSet represents is higher than the size of the colors array.
+    // All the colors that are used for this DataSet.
+    // Colors are reused as soon as the number of Entries the DataSet represents is higher than the size of the colors array.
     var colors: [NSUIColor] { get }
     
-    /// - returns: The color at the given index of the DataSet's color array.
-    /// This prevents out-of-bounds by performing a modulus on the color index, so colours will repeat themselves.
+    // - returns: The color at the given index of the DataSet's color array.
+    // This prevents out-of-bounds by performing a modulus on the color index, so colours will repeat themselves.
     func color(atIndex: Int) -> NSUIColor
     
     func resetColors()
@@ -179,82 +179,82 @@ public protocol IChartDataSet
     
     func setColor(_ color: NSUIColor)
     
-    /// if true, value highlighting is enabled
+    // if true, value highlighting is enabled
     var highlightEnabled: Bool { get set }
     
-    /// - returns: `true` if value highlighting is enabled for this dataset
+    // - returns: `true` if value highlighting is enabled for this dataset
     var isHighlightEnabled: Bool { get }
     
-    /// Custom formatter that is used instead of the auto-formatter if set
+    // Custom formatter that is used instead of the auto-formatter if set
     var valueFormatter: IValueFormatter? { get set }
     
-    /// - returns: `true` if the valueFormatter object of this DataSet is null.
+    // - returns: `true` if the valueFormatter object of this DataSet is null.
     var needsFormatter: Bool { get }
     
-    /// Sets/get a single color for value text.
-    /// Setting the color clears the colors array and adds a single color.
-    /// Getting will return the first color in the array.
+    // Sets/get a single color for value text.
+    // Setting the color clears the colors array and adds a single color.
+    // Getting will return the first color in the array.
     var valueTextColor: NSUIColor { get set }
     
-    /// - returns: The color at the specified index that is used for drawing the values inside the chart. Uses modulus internally.
+    // - returns: The color at the specified index that is used for drawing the values inside the chart. Uses modulus internally.
     func valueTextColorAt(_ index: Int) -> NSUIColor
     
-    /// the font for the value-text labels
+    // the font for the value-text labels
     var valueFont: NSUIFont { get set }
     
-    /// The form to draw for this dataset in the legend.
-    ///
-    /// Return `.Default` to use the default legend form.
+    // The form to draw for this dataset in the legend.
+    //
+    // Return `.Default` to use the default legend form.
     var form: Legend.Form { get }
     
-    /// The form size to draw for this dataset in the legend.
-    ///
-    /// Return `NaN` to use the default legend form size.
+    // The form size to draw for this dataset in the legend.
+    //
+    // Return `NaN` to use the default legend form size.
     var formSize: CGFloat { get }
     
-    /// The line width for drawing the form of this dataset in the legend
-    ///
-    /// Return `NaN` to use the default legend form line width.
+    // The line width for drawing the form of this dataset in the legend
+    //
+    // Return `NaN` to use the default legend form line width.
     var formLineWidth: CGFloat { get }
     
-    /// Line dash configuration for legend shapes that consist of lines.
-    ///
-    /// This is how much (in pixels) into the dash pattern are we starting from.
+    // Line dash configuration for legend shapes that consist of lines.
+    //
+    // This is how much (in pixels) into the dash pattern are we starting from.
     var formLineDashPhase: CGFloat { get }
     
-    /// Line dash configuration for legend shapes that consist of lines.
-    ///
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    // Line dash configuration for legend shapes that consist of lines.
+    //
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     var formLineDashLengths: [CGFloat]? { get }
     
-    /// Set this to true to draw y-values on the chart.
-    ///
-    /// - note: For bar and line charts: if `maxVisibleCount` is reached, no values will be drawn even if this is enabled.
+    // Set this to true to draw y-values on the chart.
+    //
+    // - note: For bar and line charts: if `maxVisibleCount` is reached, no values will be drawn even if this is enabled.
     var drawValuesEnabled: Bool { get set }
     
-    /// - returns: `true` if y-value drawing is enabled, `false` ifnot
+    // - returns: `true` if y-value drawing is enabled, `false` ifnot
     var isDrawValuesEnabled: Bool { get }
     
-    /// Set this to true to draw y-icons on the chart
-    ///
-    /// - note: For bar and line charts: if `maxVisibleCount` is reached, no icons will be drawn even if this is enabled.
+    // Set this to true to draw y-icons on the chart
+    //
+    // - note: For bar and line charts: if `maxVisibleCount` is reached, no icons will be drawn even if this is enabled.
     var drawIconsEnabled: Bool { get set }
     
-    /// Returns true if y-icon drawing is enabled, false if not
+    // Returns true if y-icon drawing is enabled, false if not
     var isDrawIconsEnabled: Bool { get }
     
-    /// Offset of icons drawn on the chart.
-    ///
-    /// For all charts except Pie and Radar it will be ordinary (x offset, y offset).
-    ///
-    /// For Pie and Radar chart it will be (y offset, distance from center offset); so if you want icon to be rendered under value, you should increase X component of CGPoint, and if you want icon to be rendered closet to center, you should decrease height component of CGPoint.
+    // Offset of icons drawn on the chart.
+    //
+    // For all charts except Pie and Radar it will be ordinary (x offset, y offset).
+    //
+    // For Pie and Radar chart it will be (y offset, distance from center offset); so if you want icon to be rendered under value, you should increase X component of CGPoint, and if you want icon to be rendered closet to center, you should decrease height component of CGPoint.
     var iconsOffset: CGPoint { get set }
     
-    /// Set the visibility of this DataSet. If not visible, the DataSet will not be drawn to the chart upon refreshing it.
+    // Set the visibility of this DataSet. If not visible, the DataSet will not be drawn to the chart upon refreshing it.
     var visible: Bool { get set }
     
-    /// - returns: `true` if this DataSet is visible inside the chart, or `false` ifit is currently hidden.
+    // - returns: `true` if this DataSet is visible inside the chart, or `false` ifit is currently hidden.
     var isVisible: Bool { get }
 }

--- a/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
@@ -20,14 +20,14 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// The drawing mode for this line dataset
-    ///
-    /// **default**: Linear
+    // The drawing mode for this line dataset
+    //
+    // **default**: Linear
     var mode: LineChartDataSet.Mode { get set }
     
-    /// Intensity for cubic lines (min = 0.05, max = 1)
-    ///
-    /// **default**: 0.2
+    // Intensity for cubic lines (min = 0.05, max = 1)
+    //
+    // **default**: 0.2
     var cubicIntensity: CGFloat { get set }
     
     @available(*, deprecated: 1.0, message: "Use `mode` instead.")
@@ -42,51 +42,51 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     @available(*, deprecated: 1.0, message: "Use `mode` instead.")
     var isDrawSteppedEnabled: Bool { get }
 
-    /// The radius of the drawn circles.
+    // The radius of the drawn circles.
     var circleRadius: CGFloat { get set }
     
-    /// The hole radius of the drawn circles.
+    // The hole radius of the drawn circles.
     var circleHoleRadius: CGFloat { get set }
     
     var circleColors: [NSUIColor] { get set }
     
-    /// - returns: The color at the given index of the DataSet's circle-color array.
-    /// Performs a IndexOutOfBounds check by modulus.
+    // - returns: The color at the given index of the DataSet's circle-color array.
+    // Performs a IndexOutOfBounds check by modulus.
     func getCircleColor(atIndex: Int) -> NSUIColor?
     
-    /// Sets the one and ONLY color that should be used for this DataSet.
-    /// Internally, this recreates the colors array and adds the specified color.
+    // Sets the one and ONLY color that should be used for this DataSet.
+    // Internally, this recreates the colors array and adds the specified color.
     func setCircleColor(_ color: NSUIColor)
     
-    /// Resets the circle-colors array and creates a new one
+    // Resets the circle-colors array and creates a new one
     func resetCircleColors(_ index: Int)
     
-    /// If true, drawing circles is enabled
+    // If true, drawing circles is enabled
     var drawCirclesEnabled: Bool { get set }
     
-    /// - returns: `true` if drawing circles for this DataSet is enabled, `false` ifnot
+    // - returns: `true` if drawing circles for this DataSet is enabled, `false` ifnot
     var isDrawCirclesEnabled: Bool { get }
     
-    /// The color of the inner circle (the circle-hole).
+    // The color of the inner circle (the circle-hole).
     var circleHoleColor: NSUIColor? { get set }
     
-    /// `true` if drawing circles for this DataSet is enabled, `false` ifnot
+    // `true` if drawing circles for this DataSet is enabled, `false` ifnot
     var drawCircleHoleEnabled: Bool { get set }
     
-    /// - returns: `true` if drawing the circle-holes is enabled, `false` ifnot.
+    // - returns: `true` if drawing the circle-holes is enabled, `false` ifnot.
     var isDrawCircleHoleEnabled: Bool { get }
     
-    /// This is how much (in pixels) into the dash pattern are we starting from.
+    // This is how much (in pixels) into the dash pattern are we starting from.
     var lineDashPhase: CGFloat { get }
     
-    /// This is the actual dash pattern.
-    /// I.e. [2, 3] will paint [--   --   ]
-    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    // This is the actual dash pattern.
+    // I.e. [2, 3] will paint [--   --   ]
+    // [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     var lineDashLengths: [CGFloat]? { get set }
     
-    /// Line cap type, default is CGLineCap.Butt
+    // Line cap type, default is CGLineCap.Butt
     var lineCapType: CGLineCap { get set }
     
-    /// Sets a custom IFillFormatter to the chart that handles the position of the filled-line for each DataSet. Set this to null to use the default logic.
+    // Sets a custom IFillFormatter to the chart that handles the position of the filled-line for each DataSet. Set this to null to use the default logic.
     var fillFormatter: IFillFormatter? { get set }
 }

--- a/Source/Charts/Data/Interfaces/ILineRadarChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineRadarChartDataSet.swift
@@ -19,27 +19,27 @@ public protocol ILineRadarChartDataSet: ILineScatterCandleRadarChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// The color that is used for filling the line surface area.
+    // The color that is used for filling the line surface area.
     var fillColor: NSUIColor { get set }
 
-    /// - returns: The object that is used for filling the area below the line.
-    /// **default**: nil
+    // - returns: The object that is used for filling the area below the line.
+    // **default**: nil
     var fill: Fill? { get set }
     
-    /// The alpha value that is used for filling the line surface.
-    /// **default**: 0.33
+    // The alpha value that is used for filling the line surface.
+    // **default**: 0.33
     var fillAlpha: CGFloat { get set }
     
-    /// line width of the chart (min = 0.0, max = 10)
-    ///
-    /// **default**: 1
+    // line width of the chart (min = 0.0, max = 10)
+    //
+    // **default**: 1
     var lineWidth: CGFloat { get set }
     
-    /// Set to `true` if the DataSet should be drawn filled (surface), and not just as a line.
-    /// Disabling this will give great performance boost.
-    /// Please note that this method uses the path clipping for drawing the filled area (with images, gradients and layers).
+    // Set to `true` if the DataSet should be drawn filled (surface), and not just as a line.
+    // Disabling this will give great performance boost.
+    // Please note that this method uses the path clipping for drawing the filled area (with images, gradients and layers).
     var drawFilledEnabled: Bool { get set }
     
-    /// - returns: `true` if filled drawing is enabled, `false` ifnot
+    // - returns: `true` if filled drawing is enabled, `false` ifnot
     var isDrawFilledEnabled: Bool { get }
 }

--- a/Source/Charts/Data/Interfaces/ILineScatterCandleRadarChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineScatterCandleRadarChartDataSet.swift
@@ -18,19 +18,19 @@ public protocol ILineScatterCandleRadarChartDataSet: IBarLineScatterCandleBubble
     
     // MARK: - Styling functions and accessors
     
-    /// Enables / disables the horizontal highlight-indicator. If disabled, the indicator is not drawn.
+    // Enables / disables the horizontal highlight-indicator. If disabled, the indicator is not drawn.
     var drawHorizontalHighlightIndicatorEnabled: Bool { get set }
     
-    /// Enables / disables the vertical highlight-indicator. If disabled, the indicator is not drawn.
+    // Enables / disables the vertical highlight-indicator. If disabled, the indicator is not drawn.
     var drawVerticalHighlightIndicatorEnabled: Bool { get set }
     
-    /// - returns: `true` if horizontal highlight indicator lines are enabled (drawn)
+    // - returns: `true` if horizontal highlight indicator lines are enabled (drawn)
     var isHorizontalHighlightIndicatorEnabled: Bool { get }
     
-    /// - returns: `true` if vertical highlight indicator lines are enabled (drawn)
+    // - returns: `true` if vertical highlight indicator lines are enabled (drawn)
     var isVerticalHighlightIndicatorEnabled: Bool { get }
     
-    /// Enables / disables both vertical and horizontal highlight-indicators.
-    /// :param: enabled
+    // Enables / disables both vertical and horizontal highlight-indicators.
+    // :param: enabled
     func setDrawHighlightIndicators(_ enabled: Bool)
 }

--- a/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
@@ -21,41 +21,41 @@ public protocol IPieChartDataSet: IChartDataSet
 {
     // MARK: - Styling functions and accessors
     
-    /// the space in pixels between the pie-slices
-    /// **default**: 0
-    /// **maximum**: 20
+    // the space in pixels between the pie-slices
+    // **default**: 0
+    // **maximum**: 20
     var sliceSpace: CGFloat { get set }
     
-    /// When enabled, slice spacing will be 0.0 when the smallest value is going to be smaller than the slice spacing itself.
+    // When enabled, slice spacing will be 0.0 when the smallest value is going to be smaller than the slice spacing itself.
     var automaticallyDisableSliceSpacing: Bool { get set }
     
-    /// indicates the selection distance of a pie slice
+    // indicates the selection distance of a pie slice
     var selectionShift: CGFloat { get set }
     
     var xValuePosition: PieChartDataSet.ValuePosition { get set }
     var yValuePosition: PieChartDataSet.ValuePosition { get set }
     
-    /// When valuePosition is OutsideSlice, indicates line color
+    // When valuePosition is OutsideSlice, indicates line color
     var valueLineColor: NSUIColor? { get set }
     
-    /// When valuePosition is OutsideSlice, indicates line width
+    // When valuePosition is OutsideSlice, indicates line width
     var valueLineWidth: CGFloat { get set }
     
-    /// When valuePosition is OutsideSlice, indicates offset as percentage out of the slice size
+    // When valuePosition is OutsideSlice, indicates offset as percentage out of the slice size
     var valueLinePart1OffsetPercentage: CGFloat { get set }
     
-    /// When valuePosition is OutsideSlice, indicates length of first half of the line
+    // When valuePosition is OutsideSlice, indicates length of first half of the line
     var valueLinePart1Length: CGFloat { get set }
     
-    /// When valuePosition is OutsideSlice, indicates length of second half of the line
+    // When valuePosition is OutsideSlice, indicates length of second half of the line
     var valueLinePart2Length: CGFloat { get set }
     
-    /// When valuePosition is OutsideSlice, this allows variable line length
+    // When valuePosition is OutsideSlice, this allows variable line length
     var valueLineVariableLength: Bool { get set }
     
-    /// the font for the slice-text labels
+    // the font for the slice-text labels
     var entryLabelFont: NSUIFont? { get set }
     
-    /// the color for the slice-text labels
+    // the color for the slice-text labels
     var entryLabelColor: NSUIColor? { get set }
 }

--- a/Source/Charts/Data/Interfaces/IRadarChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IRadarChartDataSet.swift
@@ -19,15 +19,15 @@ public protocol IRadarChartDataSet: ILineRadarChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// flag indicating whether highlight circle should be drawn or not
+    // flag indicating whether highlight circle should be drawn or not
     var drawHighlightCircleEnabled: Bool { get set }
     
     var isDrawHighlightCircleEnabled: Bool { get }
     
     var highlightCircleFillColor: NSUIColor? { get set }
     
-    /// The stroke color for highlight circle.
-    /// If `nil`, the color of the dataset is taken.
+    // The stroke color for highlight circle.
+    // If `nil`, the color of the dataset is taken.
     var highlightCircleStrokeColor: NSUIColor? { get set }
     
     var highlightCircleStrokeAlpha: CGFloat { get set }

--- a/Source/Charts/Data/Interfaces/IScatterChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IScatterChartDataSet.swift
@@ -19,18 +19,18 @@ public protocol IScatterChartDataSet: ILineScatterCandleRadarChartDataSet
     
     // MARK: - Styling functions and accessors
     
-    /// - returns: The size the scatter shape will have
+    // - returns: The size the scatter shape will have
     var scatterShapeSize: CGFloat { get }
     
-    /// - returns: The radius of the hole in the shape (applies to Square, Circle and Triangle)
-    /// Set this to <= 0 to remove holes.
-    /// **default**: 0.0
+    // - returns: The radius of the hole in the shape (applies to Square, Circle and Triangle)
+    // Set this to <= 0 to remove holes.
+    // **default**: 0.0
     var scatterShapeHoleRadius: CGFloat { get }
     
-    /// - returns: Color for the hole in the shape. Setting to `nil` will behave as transparent.
-    /// **default**: nil
+    // - returns: Color for the hole in the shape. Setting to `nil` will behave as transparent.
+    // **default**: nil
     var scatterShapeHoleColor: NSUIColor? { get }
     
-    /// - returns: The IShapeRenderer responsible for rendering this DataSet.
+    // - returns: The IShapeRenderer responsible for rendering this DataSet.
     var shapeRenderer: IShapeRenderer? { get }
 }

--- a/Source/Charts/Filters/DataApproximator.swift
+++ b/Source/Charts/Filters/DataApproximator.swift
@@ -14,7 +14,7 @@ import Foundation
 @objc(ChartDataApproximator)
 open class DataApproximator: NSObject
 {
-    /// uses the douglas peuker algorithm to reduce the given arraylist of entries
+    // uses the douglas peuker algorithm to reduce the given arraylist of entries
     open class func reduceWithDouglasPeuker(_ points: [CGPoint], tolerance: CGFloat) -> [CGPoint]
     {
         // if a shape has 2 or less points it cannot be reduced
@@ -49,12 +49,12 @@ open class DataApproximator: NSObject
         return reducedEntries
     }
 
-    /// apply the Douglas-Peucker-Reduction to an array of `CGPoint`s with a given tolerance
-    ///
-    /// - parameter points:
-    /// - parameter tolerance:
-    /// - parameter start:
-    /// - parameter end:
+    // apply the Douglas-Peucker-Reduction to an array of `CGPoint`s with a given tolerance
+    //
+    // - parameter points:
+    // - parameter tolerance:
+    // - parameter start:
+    // - parameter end:
     open class func reduceWithDouglasPeuker(
         points: [CGPoint],
         tolerance: CGFloat,

--- a/Source/Charts/Formatters/DefaultFillFormatter.swift
+++ b/Source/Charts/Formatters/DefaultFillFormatter.swift
@@ -16,7 +16,7 @@ import CoreGraphics
     import UIKit
 #endif
 
-/// Default formatter that calculates the position of the filled line.
+// Default formatter that calculates the position of the filled line.
 @objc(ChartDefaultFillFormatter)
 open class DefaultFillFormatter: NSObject, IFillFormatter
 {

--- a/Source/Charts/Formatters/IAxisValueFormatter.swift
+++ b/Source/Charts/Formatters/IAxisValueFormatter.swift
@@ -11,19 +11,19 @@
 
 import Foundation
 
-/// An interface for providing custom axis Strings.
+// An interface for providing custom axis Strings.
 @objc(IChartAxisValueFormatter)
 public protocol IAxisValueFormatter : NSObjectProtocol
 {
     
-    /// Called when a value from an axis is formatted before being drawn.
-    ///
-    /// For performance reasons, avoid excessive calculations and memory allocations inside this method.
-    ///
-    /// - returns: The customized label that is drawn on the x-axis.
-    /// - parameter value:           the value that is currently being drawn
-    /// - parameter axis:            the axis that the value belongs to
-    ///
+    // Called when a value from an axis is formatted before being drawn.
+    //
+    // For performance reasons, avoid excessive calculations and memory allocations inside this method.
+    //
+    // - returns: The customized label that is drawn on the x-axis.
+    // - parameter value:           the value that is currently being drawn
+    // - parameter axis:            the axis that the value belongs to
+    //
     func stringForValue(_ value: Double,
                         axis: AxisBase?) -> String
     

--- a/Source/Charts/Formatters/IFillFormatter.swift
+++ b/Source/Charts/Formatters/IFillFormatter.swift
@@ -12,10 +12,10 @@
 import Foundation
 import CoreGraphics
 
-/// Protocol for providing a custom logic to where the filling line of a LineDataSet should end. This of course only works if setFillEnabled(...) is set to true.
+// Protocol for providing a custom logic to where the filling line of a LineDataSet should end. This of course only works if setFillEnabled(...) is set to true.
 @objc(IChartFillFormatter)
 public protocol IFillFormatter
 {
-    /// - returns: The vertical (y-axis) position where the filled-line of the LineDataSet should end.
+    // - returns: The vertical (y-axis) position where the filled-line of the LineDataSet should end.
     func getFillLinePosition(dataSet: ILineChartDataSet, dataProvider: LineChartDataProvider) -> CGFloat
 }

--- a/Source/Charts/Formatters/IValueFormatter.swift
+++ b/Source/Charts/Formatters/IValueFormatter.swift
@@ -11,29 +11,29 @@
 
 import Foundation
 
-/// Interface that allows custom formatting of all values inside the chart before they are being drawn to the screen.
-///
-/// Simply create your own formatting class and let it implement ValueFormatter.
-///
-/// Then override the getFormattedValue(...) method and return whatever you want.
+// Interface that allows custom formatting of all values inside the chart before they are being drawn to the screen.
+//
+// Simply create your own formatting class and let it implement ValueFormatter.
+//
+// Then override the getFormattedValue(...) method and return whatever you want.
 @objc(IChartValueFormatter)
 public protocol IValueFormatter : NSObjectProtocol
 {
     
-    /// Called when a value (from labels inside the chart) is formatted before being drawn.
-    ///
-    /// For performance reasons, avoid excessive calculations and memory allocations inside this method.
-    ///
-    /// - returns: The formatted label ready for being drawn
-    ///
-    /// - parameter value:           The value to be formatted
-    ///
-    /// - parameter axis:            The entry the value belongs to - in e.g. BarChart, this is of class BarEntry
-    ///
-    /// - parameter dataSetIndex:    The index of the DataSet the entry in focus belongs to
-    ///
-    /// - parameter viewPortHandler: provides information about the current chart state (scale, translation, ...)
-    ///
+    // Called when a value (from labels inside the chart) is formatted before being drawn.
+    //
+    // For performance reasons, avoid excessive calculations and memory allocations inside this method.
+    //
+    // - returns: The formatted label ready for being drawn
+    //
+    // - parameter value:           The value to be formatted
+    //
+    // - parameter axis:            The entry the value belongs to - in e.g. BarChart, this is of class BarEntry
+    //
+    // - parameter dataSetIndex:    The index of the DataSet the entry in focus belongs to
+    //
+    // - parameter viewPortHandler: provides information about the current chart state (scale, translation, ...)
+    //
     func stringForValue(_ value: Double,
                         entry: ChartDataEntry,
                         dataSetIndex: Int,

--- a/Source/Charts/Formatters/IndexAxisValueFormatter.swift
+++ b/Source/Charts/Formatters/IndexAxisValueFormatter.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-/// This formatter is used for passing an array of x-axis labels, on whole x steps.
+// This formatter is used for passing an array of x-axis labels, on whole x steps.
 @objc(ChartIndexAxisValueFormatter)
 open class IndexAxisValueFormatter: NSObject, IAxisValueFormatter
 {

--- a/Source/Charts/Highlight/BarHighlighter.swift
+++ b/Source/Charts/Highlight/BarHighlighter.swift
@@ -53,12 +53,12 @@ open class BarHighlighter: ChartHighlighter
         return (chart as? BarChartDataProvider)?.barData
     }
     
-    /// This method creates the Highlight object that also indicates which value of a stacked BarEntry has been selected.
-    /// - parameter high: the Highlight to work with looking for stacked values
-    /// - parameter set:
-    /// - parameter xIndex:
-    /// - parameter yValue:
-    /// - returns:
+    // This method creates the Highlight object that also indicates which value of a stacked BarEntry has been selected.
+    // - parameter high: the Highlight to work with looking for stacked values
+    // - parameter set:
+    // - parameter xIndex:
+    // - parameter yValue:
+    // - returns:
     open func getStackedHighlight(high: Highlight,
                                   set: IBarChartDataSet,
                                   xValue: Double,
@@ -96,10 +96,10 @@ open class BarHighlighter: ChartHighlighter
         return nil
     }
     
-    /// - returns: The index of the closest value inside the values array / ranges (stacked barchart) to the value given as a parameter.
-    /// - parameter entry:
-    /// - parameter value:
-    /// - returns:
+    // - returns: The index of the closest value inside the values array / ranges (stacked barchart) to the value given as a parameter.
+    // - parameter entry:
+    // - parameter value:
+    // - returns:
     open func getClosestStackIndex(ranges: [Range]?, value: Double) -> Int
     {
         if ranges == nil

--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -14,7 +14,7 @@ import CoreGraphics
 
 open class ChartHighlighter : NSObject, IHighlighter
 {
-    /// instance of the data-provider
+    // instance of the data-provider
     open weak var chart: ChartDataProvider?
     
     public init(chart: ChartDataProvider)
@@ -29,9 +29,9 @@ open class ChartHighlighter : NSObject, IHighlighter
         return getHighlight(xValue: xVal, x: x, y: y)
     }
     
-    /// - returns: The corresponding x-pos for a given touch-position in pixels.
-    /// - parameter x:
-    /// - returns:
+    // - returns: The corresponding x-pos for a given touch-position in pixels.
+    // - parameter x:
+    // - returns:
     open func getValsForTouch(x: CGFloat, y: CGFloat) -> CGPoint
     {
         guard let chart = self.chart as? BarLineScatterCandleBubbleChartDataProvider
@@ -41,11 +41,11 @@ open class ChartHighlighter : NSObject, IHighlighter
         return chart.getTransformer(forAxis: YAxis.AxisDependency.left).valueForTouchPoint(x: x, y: y)
     }
     
-    /// - returns: The corresponding ChartHighlight for a given x-value and xy-touch position in pixels.
-    /// - parameter xValue:
-    /// - parameter x:
-    /// - parameter y:
-    /// - returns:
+    // - returns: The corresponding ChartHighlight for a given x-value and xy-touch position in pixels.
+    // - parameter xValue:
+    // - parameter x:
+    // - parameter y:
+    // - returns:
     open func getHighlight(xValue xVal: Double, x: CGFloat, y: CGFloat) -> Highlight?
     {
         guard let chart = chart
@@ -67,12 +67,12 @@ open class ChartHighlighter : NSObject, IHighlighter
         return detail
     }
     
-    /// - returns: A list of Highlight objects representing the entries closest to the given xVal.
-    /// The returned list contains two objects per DataSet (closest rounding up, closest rounding down).
-    /// - parameter xValue: the transformed x-value of the x-touch position
-    /// - parameter x: touch position
-    /// - parameter y: touch position
-    /// - returns:
+    // - returns: A list of Highlight objects representing the entries closest to the given xVal.
+    // The returned list contains two objects per DataSet (closest rounding up, closest rounding down).
+    // - parameter xValue: the transformed x-value of the x-touch position
+    // - parameter x: touch position
+    // - parameter y: touch position
+    // - returns:
     open func getHighlights(xValue: Double, x: CGFloat, y: CGFloat) -> [Highlight]
     {
         var vals = [Highlight]()
@@ -101,7 +101,7 @@ open class ChartHighlighter : NSObject, IHighlighter
         return vals
     }
     
-    /// - returns: An array of `Highlight` objects corresponding to the selected xValue and dataSetIndex.
+    // - returns: An array of `Highlight` objects corresponding to the selected xValue and dataSetIndex.
     internal func buildHighlights(
         dataSet set: IChartDataSet,
         dataSetIndex: Int,
@@ -135,7 +135,7 @@ open class ChartHighlighter : NSObject, IHighlighter
 
     // - MARK: - Utilities
     
-    /// - returns: The `ChartHighlight` of the closest value on the x-y cartesian axes
+    // - returns: The `ChartHighlight` of the closest value on the x-y cartesian axes
     internal func closestSelectionDetailByPixel(
         closestValues: [Highlight],
         x: CGFloat,
@@ -165,7 +165,7 @@ open class ChartHighlighter : NSObject, IHighlighter
         return closest
     }
     
-    /// - returns: The minimum distance from a touch-y-value (in pixels) to the closest y-value (in pixels) that is displayed in the chart.
+    // - returns: The minimum distance from a touch-y-value (in pixels) to the closest y-value (in pixels) that is displayed in the chart.
     internal func getMinimumDistance(
         closestValues: [Highlight],
         y: CGFloat,

--- a/Source/Charts/Highlight/CombinedHighlighter.swift
+++ b/Source/Charts/Highlight/CombinedHighlighter.swift
@@ -15,7 +15,7 @@ import CoreGraphics
 @objc(CombinedChartHighlighter)
 open class CombinedHighlighter: ChartHighlighter
 {
-    /// bar highlighter for supporting stacked highlighting
+    // bar highlighter for supporting stacked highlighting
     fileprivate var barHighlighter: BarHighlighter?
     
     public init(chart: CombinedChartDataProvider, barDataProvider: BarChartDataProvider)

--- a/Source/Charts/Highlight/Highlight.swift
+++ b/Source/Charts/Highlight/Highlight.swift
@@ -14,36 +14,36 @@ import Foundation
 @objc(ChartHighlight)
 open class Highlight: NSObject
 {
-    /// the x-value of the highlighted value
+    // the x-value of the highlighted value
     fileprivate var _x = Double.nan
     
-    /// the y-value of the highlighted value
+    // the y-value of the highlighted value
     fileprivate var _y = Double.nan
     
-    /// the x-pixel of the highlight
+    // the x-pixel of the highlight
     fileprivate var _xPx = CGFloat.nan
     
-    /// the y-pixel of the highlight
+    // the y-pixel of the highlight
     fileprivate var _yPx = CGFloat.nan
     
-    /// the index of the data object - in case it refers to more than one
+    // the index of the data object - in case it refers to more than one
     open var dataIndex = Int(-1)
     
-    /// the index of the dataset the highlighted value is in
+    // the index of the dataset the highlighted value is in
     fileprivate var _dataSetIndex = Int(0)
     
-    /// index which value of a stacked bar entry is highlighted
-    /// 
-    /// **default**: -1
+    // index which value of a stacked bar entry is highlighted
+    // 
+    // **default**: -1
     fileprivate var _stackIndex = Int(-1)
     
-    /// the axis the highlighted value belongs to
+    // the axis the highlighted value belongs to
     fileprivate var _axis: YAxis.AxisDependency = YAxis.AxisDependency.left
     
-    /// the x-position (pixels) on which this highlight object was last drawn
+    // the x-position (pixels) on which this highlight object was last drawn
     open var drawX: CGFloat = 0.0
     
-    /// the y-position (pixels) on which this highlight object was last drawn
+    // the y-position (pixels) on which this highlight object was last drawn
     open var drawY: CGFloat = 0.0
     
     public override init()
@@ -51,14 +51,14 @@ open class Highlight: NSObject
         super.init()
     }
     
-    /// - parameter x: the x-value of the highlighted value
-    /// - parameter y: the y-value of the highlighted value
-    /// - parameter xPx: the x-pixel of the highlighted value
-    /// - parameter yPx: the y-pixel of the highlighted value
-    /// - parameter dataIndex: the index of the Data the highlighted value belongs to
-    /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
-    /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
-    /// - parameter axis: the axis the highlighted value belongs to
+    // - parameter x: the x-value of the highlighted value
+    // - parameter y: the y-value of the highlighted value
+    // - parameter xPx: the x-pixel of the highlighted value
+    // - parameter yPx: the y-pixel of the highlighted value
+    // - parameter dataIndex: the index of the Data the highlighted value belongs to
+    // - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
+    // - parameter stackIndex: references which value of a stacked-bar entry has been selected
+    // - parameter axis: the axis the highlighted value belongs to
     public init(
         x: Double, y: Double,
         xPx: CGFloat, yPx: CGFloat,
@@ -79,13 +79,13 @@ open class Highlight: NSObject
         _axis = axis
     }
     
-    /// - parameter x: the x-value of the highlighted value
-    /// - parameter y: the y-value of the highlighted value
-    /// - parameter xPx: the x-pixel of the highlighted value
-    /// - parameter yPx: the y-pixel of the highlighted value
-    /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
-    /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
-    /// - parameter axis: the axis the highlighted value belongs to
+    // - parameter x: the x-value of the highlighted value
+    // - parameter y: the y-value of the highlighted value
+    // - parameter xPx: the x-pixel of the highlighted value
+    // - parameter yPx: the y-pixel of the highlighted value
+    // - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
+    // - parameter stackIndex: references which value of a stacked-bar entry has been selected
+    // - parameter axis: the axis the highlighted value belongs to
     public convenience init(
         x: Double, y: Double,
         xPx: CGFloat, yPx: CGFloat,
@@ -100,14 +100,14 @@ open class Highlight: NSObject
                   axis: axis)
     }
     
-    /// - parameter x: the x-value of the highlighted value
-    /// - parameter y: the y-value of the highlighted value
-    /// - parameter xPx: the x-pixel of the highlighted value
-    /// - parameter yPx: the y-pixel of the highlighted value
-    /// - parameter dataIndex: the index of the Data the highlighted value belongs to
-    /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
-    /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
-    /// - parameter axis: the axis the highlighted value belongs to
+    // - parameter x: the x-value of the highlighted value
+    // - parameter y: the y-value of the highlighted value
+    // - parameter xPx: the x-pixel of the highlighted value
+    // - parameter yPx: the y-pixel of the highlighted value
+    // - parameter dataIndex: the index of the Data the highlighted value belongs to
+    // - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
+    // - parameter stackIndex: references which value of a stacked-bar entry has been selected
+    // - parameter axis: the axis the highlighted value belongs to
     public init(
         x: Double, y: Double,
         xPx: CGFloat, yPx: CGFloat,
@@ -124,9 +124,9 @@ open class Highlight: NSObject
         _axis = axis
     }
     
-    /// - parameter x: the x-value of the highlighted value
-    /// - parameter y: the y-value of the highlighted value
-    /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
+    // - parameter x: the x-value of the highlighted value
+    // - parameter y: the y-value of the highlighted value
+    // - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
     public init(x: Double, y: Double, dataSetIndex: Int)
     {
         _x = x
@@ -134,9 +134,9 @@ open class Highlight: NSObject
         _dataSetIndex = dataSetIndex
     }
     
-    /// - parameter x: the x-value of the highlighted value
-    /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
-    /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
+    // - parameter x: the x-value of the highlighted value
+    // - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
+    // - parameter stackIndex: references which value of a stacked-bar entry has been selected
     public convenience init(x: Double, dataSetIndex: Int, stackIndex: Int)
     {
         self.init(x: x, y: Double.nan, dataSetIndex: dataSetIndex)
@@ -153,14 +153,14 @@ open class Highlight: NSObject
     
     open var isStacked: Bool { return _stackIndex >= 0 }
     
-    /// Sets the x- and y-position (pixels) where this highlight was last drawn.
+    // Sets the x- and y-position (pixels) where this highlight was last drawn.
     open func setDraw(x: CGFloat, y: CGFloat)
     {
         self.drawX = x
         self.drawY = y
     }
     
-    /// Sets the x- and y-position (pixels) where this highlight was last drawn.
+    // Sets the x- and y-position (pixels) where this highlight was last drawn.
     open func setDraw(pt: CGPoint)
     {
         self.drawX = pt.x

--- a/Source/Charts/Highlight/IHighlighter.swift
+++ b/Source/Charts/Highlight/IHighlighter.swift
@@ -15,9 +15,9 @@ import CoreGraphics
 @objc(IChartHighlighter)
 public protocol IHighlighter : NSObjectProtocol
 {
-    /// - returns: A Highlight object corresponding to the given x- and y- touch positions in pixels.
-    /// - parameter x:
-    /// - parameter y:
-    /// - returns:
+    // - returns: A Highlight object corresponding to the given x- and y- touch positions in pixels.
+    // - parameter x:
+    // - parameter y:
+    // - returns:
     func getHighlight(x: CGFloat, y: CGFloat) -> Highlight?
 }

--- a/Source/Charts/Highlight/PieRadarHighlighter.swift
+++ b/Source/Charts/Highlight/PieRadarHighlighter.swift
@@ -51,10 +51,10 @@ open class PieRadarHighlighter: ChartHighlighter
         }
     }
     
-    /// - returns: The closest Highlight object of the given objects based on the touch position inside the chart.
-    /// - parameter index:
-    /// - parameter x:
-    /// - parameter y:
+    // - returns: The closest Highlight object of the given objects based on the touch position inside the chart.
+    // - parameter index:
+    // - parameter x:
+    // - parameter y:
     open func closestHighlight(index: Int, x: CGFloat, y: CGFloat) -> Highlight?
     {
         fatalError("closestHighlight(index, x, y) cannot be called on PieRadarChartHighlighter")

--- a/Source/Charts/Highlight/RadarHighlighter.swift
+++ b/Source/Charts/Highlight/RadarHighlighter.swift
@@ -40,10 +40,10 @@ open class RadarHighlighter: PieRadarHighlighter
         return closest
     }
     
-    /// - returns: An array of Highlight objects for the given index.
-    /// The Highlight objects give information about the value at the selected index and DataSet it belongs to.
-    ///
-    /// - parameter index:
+    // - returns: An array of Highlight objects for the given index.
+    // The Highlight objects give information about the value at the selected index and DataSet it belongs to.
+    //
+    // - parameter index:
     internal func getHighlights(forIndex index: Int) -> [Highlight]
     {
         var vals = [Highlight]()

--- a/Source/Charts/Highlight/Range.swift
+++ b/Source/Charts/Highlight/Range.swift
@@ -25,8 +25,8 @@ open class Range: NSObject
         super.init()
     }
 
-    /// - returns: `true` if this range contains (if the value is in between) the given value, `false` ifnot.
-    /// - parameter value:
+    // - returns: `true` if this range contains (if the value is in between) the given value, `false` ifnot.
+    // - parameter value:
     open func contains(_ value: Double) -> Bool
     {
         if value > from && value <= to

--- a/Source/Charts/Interfaces/ChartDataProvider.swift
+++ b/Source/Charts/Interfaces/ChartDataProvider.swift
@@ -15,16 +15,16 @@ import CoreGraphics
 @objc
 public protocol ChartDataProvider
 {
-    /// - returns: The minimum x-value of the chart, regardless of zoom or translation.
+    // - returns: The minimum x-value of the chart, regardless of zoom or translation.
     var chartXMin: Double { get }
     
-    /// - returns: The maximum x-value of the chart, regardless of zoom or translation.
+    // - returns: The maximum x-value of the chart, regardless of zoom or translation.
     var chartXMax: Double { get }
     
-    /// - returns: The minimum y-value of the chart, regardless of zoom or translation.
+    // - returns: The minimum y-value of the chart, regardless of zoom or translation.
     var chartYMin: Double { get }
     
-    /// - returns: The maximum y-value of the chart, regardless of zoom or translation.
+    // - returns: The maximum y-value of the chart, regardless of zoom or translation.
     var chartYMax: Double { get }
     
     var maxHighlightDistance: CGFloat { get }

--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -15,10 +15,10 @@ import CoreGraphics
 @objc(ChartAxisRendererBase)
 open class AxisRendererBase: Renderer
 {
-    /// base axis this axis renderer works with
+    // base axis this axis renderer works with
     open var axis: AxisBase?
     
-    /// transformer to transform values to screen pixels and return
+    // transformer to transform values to screen pixels and return
     open var transformer: Transformer?
     
     public override init()
@@ -34,33 +34,33 @@ open class AxisRendererBase: Renderer
         self.axis = axis
     }
     
-    /// Draws the axis labels on the specified context
+    // Draws the axis labels on the specified context
     open func renderAxisLabels(context: CGContext)
     {
         fatalError("renderAxisLabels() cannot be called on AxisRendererBase")
     }
     
-    /// Draws the grid lines belonging to the axis.
+    // Draws the grid lines belonging to the axis.
     open func renderGridLines(context: CGContext)
     {
         fatalError("renderGridLines() cannot be called on AxisRendererBase")
     }
     
-    /// Draws the line that goes alongside the axis.
+    // Draws the line that goes alongside the axis.
     open func renderAxisLine(context: CGContext)
     {
         fatalError("renderAxisLine() cannot be called on AxisRendererBase")
     }
     
-    /// Draws the LimitLines associated with this axis to the screen.
+    // Draws the LimitLines associated with this axis to the screen.
     open func renderLimitLines(context: CGContext)
     {
         fatalError("renderLimitLines() cannot be called on AxisRendererBase")
     }
     
-    /// Computes the axis values.
-    /// - parameter min: the minimum value in the data object for this axis
-    /// - parameter max: the maximum value in the data object for this axis
+    // Computes the axis values.
+    // - parameter min: the minimum value in the data object for this axis
+    // - parameter max: the maximum value in the data object for this axis
     open func computeAxis(min: Double, max: Double, inverted: Bool)
     {
         var min = min, max = max
@@ -92,7 +92,7 @@ open class AxisRendererBase: Renderer
         computeAxisValues(min: min, max: max)
     }
     
-    /// Sets up the axis values. Computes the desired number of labels between the two given extremes.
+    // Sets up the axis values. Computes the desired number of labels between the two given extremes.
     open func computeAxisValues(min: Double, max: Double)
     {
         guard let axis = self.axis else { return }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -614,7 +614,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         }
     }
     
-    /// Draws a value at the specified x and y position.
+    // Draws a value at the specified x and y position.
     open func drawValue(context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: NSUIFont, align: NSTextAlignment, color: NSUIColor)
     {
         ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: color])
@@ -692,7 +692,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         context.restoreGState()
     }
     
-    /// Sets the drawing position of the highlight object based on the riven bar-rect.
+    // Sets the drawing position of the highlight object based on the riven bar-rect.
     internal func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
     {
         high.setDraw(x: barRect.midX, y: barRect.origin.y)

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -22,7 +22,7 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
         super.init(animator: animator, viewPortHandler: viewPortHandler)
     }
     
-    /// Checks if the provided entry object is in bounds for drawing considering the current animation phase.
+    // Checks if the provided entry object is in bounds for drawing considering the current animation phase.
     internal func isInBoundsX(entry e: ChartDataEntry, dataSet: IBarLineScatterCandleBubbleChartDataSet) -> Bool
     {
         let entryIndex = dataSet.entryIndex(entry: e)
@@ -37,8 +37,8 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
         }
     }
 
-    /// Calculates and returns the x-bounds for the given DataSet in terms of index in their values array.
-    /// This includes minimum and maximum visible x, as well as range.
+    // Calculates and returns the x-bounds for the given DataSet in terms of index in their values array.
+    // This includes minimum and maximum visible x, as well as range.
     internal func xBounds(chart: BarLineScatterCandleBubbleChartDataProvider,
                           dataSet: IBarLineScatterCandleBubbleChartDataSet,
                           animator: Animator?) -> XBounds
@@ -46,22 +46,22 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
         return XBounds(chart: chart, dataSet: dataSet, animator: animator)
     }
     
-    /// - returns: `true` if the DataSet values should be drawn, `false` if not.
+    // - returns: `true` if the DataSet values should be drawn, `false` if not.
     internal func shouldDrawValues(forDataSet set: IChartDataSet) -> Bool
     {
         return set.isVisible && (set.isDrawValuesEnabled || set.isDrawIconsEnabled)
     }
 
-    /// Class representing the bounds of the current viewport in terms of indices in the values array of a DataSet.
+    // Class representing the bounds of the current viewport in terms of indices in the values array of a DataSet.
     open class XBounds
     {
-        /// minimum visible entry index
+        // minimum visible entry index
         open var min: Int = 0
 
-        /// maximum visible entry index
+        // maximum visible entry index
         open var max: Int = 0
 
-        /// range of visible entry indices
+        // range of visible entry indices
         open var range: Int = 0
 
         public init()
@@ -76,7 +76,7 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
             self.set(chart: chart, dataSet: dataSet, animator: animator)
         }
         
-        /// Calculates the minimum and maximum x values as well as the range between them.
+        // Calculates the minimum and maximum x values as well as the range between them.
         open func set(chart: BarLineScatterCandleBubbleChartDataProvider,
                       dataSet: IBarLineScatterCandleBubbleChartDataSet,
                       animator: Animator?)

--- a/Source/Charts/Renderers/ChartDataRendererBase.swift
+++ b/Source/Charts/Renderers/ChartDataRendererBase.swift
@@ -39,16 +39,16 @@ open class DataRenderer: Renderer
         fatalError("drawExtras() cannot be called on DataRenderer")
     }
     
-    /// Draws all highlight indicators for the values that are currently highlighted.
-    ///
-    /// - parameter indices: the highlighted values
+    // Draws all highlight indicators for the values that are currently highlighted.
+    //
+    // - parameter indices: the highlighted values
     open func drawHighlighted(context: CGContext, indices: [Highlight])
     {
         fatalError("drawHighlighted() cannot be called on DataRenderer")
     }
     
-    /// An opportunity for initializing internal buffers used for rendering with a new size.
-    /// Since this might do memory allocations, it should only be called if necessary.
+    // An opportunity for initializing internal buffers used for rendering with a new size.
+    // Since this might do memory allocations, it should only be called if necessary.
     open func initBuffers() { }
     
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -16,10 +16,10 @@ open class CombinedChartRenderer: DataRenderer
 {
     open weak var chart: CombinedChartView?
     
-    /// if set to true, all values are drawn above their bars, instead of below their top
+    // if set to true, all values are drawn above their bars, instead of below their top
     open var drawValueAboveBarEnabled = true
     
-    /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
+    // if set to true, a grey area is drawn behind each bar that indicates the maximum value
     open var drawBarShadowEnabled = false
     
     internal var _renderers = [DataRenderer]()
@@ -35,7 +35,7 @@ open class CombinedChartRenderer: DataRenderer
         createRenderers()
     }
     
-    /// Creates the renderers needed for this combined-renderer in the required order. Also takes the DrawOrder into consideration.
+    // Creates the renderers needed for this combined-renderer in the required order. Also takes the DrawOrder into consideration.
     internal func createRenderers()
     {
         _renderers = [DataRenderer]()
@@ -156,7 +156,7 @@ open class CombinedChartRenderer: DataRenderer
         }
     }
 
-    /// - returns: The sub-renderer object at the specified index.
+    // - returns: The sub-renderer object at the specified index.
     open func getSubRenderer(index: Int) -> DataRenderer?
     {
         if index >= _renderers.count || index < 0
@@ -169,7 +169,7 @@ open class CombinedChartRenderer: DataRenderer
         }
     }
 
-    /// - returns: All sub-renderers.
+    // - returns: All sub-renderers.
     open var subRenderers: [DataRenderer]
     {
         get { return _renderers }
@@ -178,15 +178,15 @@ open class CombinedChartRenderer: DataRenderer
     
     // MARK: Accessors
     
-    /// - returns: `true` if drawing values above bars is enabled, `false` ifnot
+    // - returns: `true` if drawing values above bars is enabled, `false` ifnot
     open var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
     
-    /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
+    // - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
     open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
     
-    /// the order in which the provided data objects should be drawn.
-    /// The earlier you place them in the provided array, the further they will be in the background.
-    /// e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
+    // the order in which the provided data objects should be drawn.
+    // The earlier you place them in the provided array, the further they will be in the background.
+    // e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
     open var drawOrder: [CombinedChartView.DrawOrder]
     {
         get

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -614,7 +614,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
         return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * (viewPortHandler?.scaleY ?? 1.0))
     }
     
-    /// Sets the drawing position of the highlight object based on the riven bar-rect.
+    // Sets the drawing position of the highlight object based on the riven bar-rect.
     internal override func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
     {
         high.setDraw(x: barRect.midY, y: barRect.origin.x + barRect.size.width)

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 @objc(ChartLegendRenderer)
 open class LegendRenderer: Renderer
 {
-    /// the legend object this renderer renders
+    // the legend object this renderer renders
     open var legend: Legend?
 
     public init(viewPortHandler: ViewPortHandler?, legend: Legend?)
@@ -29,7 +29,7 @@ open class LegendRenderer: Renderer
         self.legend = legend
     }
 
-    /// Prepares the legend and calculates all needed forms, labels and colors.
+    // Prepares the legend and calculates all needed forms, labels and colors.
     open func computeLegend(data: ChartData)
     {
         guard
@@ -496,7 +496,7 @@ open class LegendRenderer: Renderer
 
     fileprivate var _formLineSegmentsBuffer = [CGPoint](repeating: CGPoint(), count: 2)
     
-    /// Draws the Legend-form at the given position with the color at the given index.
+    // Draws the Legend-form at the given position with the color at the given index.
     open func drawForm(
         context: CGContext,
         x: CGFloat,
@@ -568,7 +568,7 @@ open class LegendRenderer: Renderer
         }
     }
 
-    /// Draws the provided label at the given position.
+    // Draws the provided label at the given position.
     open func drawLabel(context: CGContext, x: CGFloat, y: CGFloat, label: String, font: NSUIFont, textColor: NSUIColor)
     {
         ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .left, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: textColor])

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -462,7 +462,7 @@ open class LineChartRenderer: LineRadarRenderer
         }
     }
     
-    /// Generates the path that is used for filled drawing.
+    // Generates the path that is used for filled drawing.
     fileprivate func generateFilledPath(dataSet: ILineChartDataSet, fillMin: CGFloat, bounds: XBounds, matrix: CGAffineTransform) -> CGPath
     {
         let phaseY = animator?.phaseY ?? 1.0

--- a/Source/Charts/Renderers/LineRadarRenderer.swift
+++ b/Source/Charts/Renderers/LineRadarRenderer.swift
@@ -20,7 +20,7 @@ open class LineRadarRenderer: LineScatterCandleRadarRenderer
         super.init(animator: animator, viewPortHandler: viewPortHandler)
     }
     
-    /// Draws the provided path in filled mode with the provided drawable.
+    // Draws the provided path in filled mode with the provided drawable.
     open func drawFilledPath(context: CGContext, path: CGPath, fill: Fill, fillAlpha: CGFloat)
     {
         guard let viewPortHandler = self.viewPortHandler
@@ -38,7 +38,7 @@ open class LineRadarRenderer: LineScatterCandleRadarRenderer
         context.restoreGState()
     }
     
-    /// Draws the provided path in filled mode with the provided color and alpha.
+    // Draws the provided path in filled mode with the provided color and alpha.
     open func drawFilledPath(context: CGContext, path: CGPath, fillColor: NSUIColor, fillAlpha: CGFloat)
     {
         context.saveGState()

--- a/Source/Charts/Renderers/LineScatterCandleRadarRenderer.swift
+++ b/Source/Charts/Renderers/LineScatterCandleRadarRenderer.swift
@@ -20,11 +20,11 @@ open class LineScatterCandleRadarRenderer: BarLineScatterCandleBubbleRenderer
         super.init(animator: animator, viewPortHandler: viewPortHandler)
     }
     
-    /// Draws vertical & horizontal highlight-lines if enabled.
-    /// :param: context
-    /// :param: points
-    /// :param: horizontal
-    /// :param: vertical
+    // Draws vertical & horizontal highlight-lines if enabled.
+    // :param: context
+    // :param: points
+    // :param: horizontal
+    // :param: vertical
     open func drawHighlightLines(context: CGContext, point: CGPoint, set: ILineScatterCandleRadarChartDataSet)
     {
         guard let

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -87,7 +87,7 @@ open class PieChartRenderer: DataRenderer
         return spacedRadius
     }
     
-    /// Calculates the sliceSpace to use based on visible values and their size compared to the set sliceSpace.
+    // Calculates the sliceSpace to use based on visible values and their size compared to the set sliceSpace.
     open func getSliceSpace(dataSet: IPieChartDataSet) -> CGFloat
     {
         guard
@@ -556,7 +556,7 @@ open class PieChartRenderer: DataRenderer
         drawCenterText(context: context)
     }
     
-    /// draws the hole in the center of the chart and the transparent circle / hole
+    // draws the hole in the center of the chart and the transparent circle / hole
     fileprivate func drawHole(context: CGContext)
     {
         guard
@@ -615,7 +615,7 @@ open class PieChartRenderer: DataRenderer
         }
     }
     
-    /// draws the description text in the center of the pie chart makes most sense when center-hole is enabled
+    // draws the description text in the center of the pie chart makes most sense when center-hole is enabled
     fileprivate func drawCenterText(context: CGContext)
     {
         guard

--- a/Source/Charts/Renderers/RadarChartRenderer.swift
+++ b/Source/Charts/Renderers/RadarChartRenderer.swift
@@ -48,11 +48,11 @@ open class RadarChartRenderer: LineRadarRenderer
         }
     }
     
-    /// Draws the RadarDataSet
-    ///
-    /// - parameter context:
-    /// - parameter dataSet:
-    /// - parameter mostEntries: the entry count of the dataset with the most entries
+    // Draws the RadarDataSet
+    //
+    // - parameter context:
+    // - parameter dataSet:
+    // - parameter mostEntries: the entry count of the dataset with the most entries
     internal func drawDataSet(context: CGContext, dataSet: IRadarChartDataSet, mostEntries: Int)
     {
         guard let

--- a/Source/Charts/Renderers/Renderer.swift
+++ b/Source/Charts/Renderers/Renderer.swift
@@ -15,7 +15,7 @@ import CoreGraphics
 @objc(ChartRenderer)
 open class Renderer: NSObject
 {
-    /// the component that handles the drawing area of the chart and it's offsets
+    // the component that handles the drawing area of the chart and it's offsets
     open var viewPortHandler: ViewPortHandler?
     
     public override init()

--- a/Source/Charts/Renderers/Scatter/IShapeRenderer.swift
+++ b/Source/Charts/Renderers/Scatter/IShapeRenderer.swift
@@ -14,13 +14,13 @@ import Foundation
 @objc
 public protocol IShapeRenderer : NSObjectProtocol
 {
-    /// Renders the provided ScatterDataSet with a shape.
-    ///
-    /// - parameter context:         CGContext for drawing on
-    /// - parameter dataSet:         The DataSet to be drawn
-    /// - parameter viewPortHandler: Contains information about the current state of the view
-    /// - parameter point:           Position to draw the shape at
-    /// - parameter color:           Color to draw the shape
+    // Renders the provided ScatterDataSet with a shape.
+    //
+    // - parameter context:         CGContext for drawing on
+    // - parameter dataSet:         The DataSet to be drawn
+    // - parameter viewPortHandler: Contains information about the current state of the view
+    // - parameter point:           Position to draw the shape at
+    // - parameter color:           Color to draw the shape
     func renderShape(
         context: CGContext,
         dataSet: IScatterChartDataSet,

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -174,7 +174,7 @@ open class XAxisRenderer: AxisRendererBase
         context.restoreGState()
     }
     
-    /// draws the x-labels on the specified y-position
+    // draws the x-labels on the specified y-position
     open func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint)
     {
         guard

--- a/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
@@ -118,7 +118,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
         }
     }
 
-    /// draws the x-labels on the specified y-position
+    // draws the x-labels on the specified y-position
     open override func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint)
     {
         guard

--- a/Source/Charts/Renderers/XAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererRadarChart.swift
@@ -90,6 +90,6 @@ open class XAxisRendererRadarChart: XAxisRenderer
     
     open override func renderLimitLines(context: CGContext)
     {
-        /// XAxis LimitLines on RadarChart not yet supported.
+        // XAxis LimitLines on RadarChart not yet supported.
     }
 }

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -24,7 +24,7 @@ open class YAxisRenderer: AxisRendererBase
         super.init(viewPortHandler: viewPortHandler, transformer: transformer, axis: yAxis)
     }
     
-    /// draws the y-axis labels to the screen
+    // draws the y-axis labels to the screen
     open override func renderAxisLabels(context: CGContext)
     {
         guard
@@ -126,7 +126,7 @@ open class YAxisRenderer: AxisRendererBase
         context.restoreGState()
     }
     
-    /// draws the y-labels on the specified x-position
+    // draws the y-labels on the specified x-position
     internal func drawYLabels(
         context: CGContext,
         fixedPosition: CGFloat,
@@ -250,7 +250,7 @@ open class YAxisRenderer: AxisRendererBase
         return positions
     }
 
-    /// Draws the zero line at the specified position.
+    // Draws the zero line at the specified position.
     open func drawZeroLine(context: CGContext)
     {
         guard

--- a/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
@@ -23,7 +23,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
         super.init(viewPortHandler: viewPortHandler, yAxis: yAxis, transformer: transformer)
     }
 
-    /// Computes the axis values.
+    // Computes the axis values.
     open override func computeAxis(min: Double, max: Double, inverted: Bool)
     {
         guard
@@ -54,7 +54,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
         computeAxisValues(min: min, max: max)
     }
 
-    /// draws the y-axis labels to the screen
+    // draws the y-axis labels to the screen
     open override func renderAxisLabels(context: CGContext)
     {
         guard
@@ -151,7 +151,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
         context.restoreGState()
     }
 
-    /// draws the y-labels on the specified x-position
+    // draws the y-labels on the specified x-position
     open func drawYLabels(
         context: CGContext,
         fixedPosition: CGFloat,
@@ -226,7 +226,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
         return positions
     }
     
-    /// Draws the zero line at the specified position.
+    // Draws the zero line at the specified position.
     open override func drawZeroLine(context: CGContext)
     {
         guard

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -71,7 +71,7 @@ open class ChartUtils
         }
     }
     
-    /// Calculates the position around a center point, depending on the distance from the center, and the angle of the position around the center.
+    // Calculates the position around a center point, depending on the distance from the center, and the angle of the position around the center.
     internal class func getPosition(center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
     {
         return CGPoint(
@@ -249,7 +249,7 @@ open class ChartUtils
         drawMultilineText(context: context, text: text, knownTextSize: rect.size, point: point, attributes: attributes, constrainedToSize: constrainedToSize, anchor: anchor, angleRadians: angleRadians)
     }
     
-    /// - returns: An angle between 0.0 < 360.0 (not less than zero, less than 360)
+    // - returns: An angle between 0.0 < 360.0 (not less than zero, less than 360)
     internal class func normalizedAngleFromAngle(_ angle: CGFloat) -> CGFloat
     {
         var angle = angle
@@ -268,7 +268,7 @@ open class ChartUtils
         return formatter
     }
     
-    /// - returns: The default value formatter used for all chart components that needs a default
+    // - returns: The default value formatter used for all chart components that needs a default
     open class func defaultValueFormatter() -> IValueFormatter
     {
         return _defaultValueFormatter
@@ -299,7 +299,7 @@ open class ChartUtils
         )
     }
     
-    /// MARK: - Bridging functions
+    // MARK: - Bridging functions
     
     internal class func bridgedObjCGetNSUIColorArray (swift array: [NSUIColor?]) -> [NSObject]
     {

--- a/Source/Charts/Utils/Fill.swift
+++ b/Source/Charts/Utils/Fill.swift
@@ -236,7 +236,7 @@ open class Fill: NSObject
     
     // MARK: Drawing code
     
-    /// Draws the provided path in filled mode with the provided area
+    // Draws the provided path in filled mode with the provided area
     open func fillPath(
         context: CGContext,
         rect: CGRect)

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -332,7 +332,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 			return 1
 		}
         
-        /// FIXME: Currently there are no more than 1 touch in OSX gestures, and not way to create custom touch gestures.
+        // FIXME: Currently there are no more than 1 touch in OSX gestures, and not way to create custom touch gestures.
 		final func nsuiLocationOfTouch(_ touch: Int, inView: NSView?) -> NSPoint
         {
 			return super.location(in: inView)
@@ -341,7 +341,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
     
     extension NSUIRotationGestureRecognizer
     {
-        /// FIXME: Currently there are no velocities in OSX gestures, and not way to create custom touch gestures.
+        // FIXME: Currently there are no velocities in OSX gestures, and not way to create custom touch gestures.
         final var velocity: CGFloat
         {
             return 0.1
@@ -368,7 +368,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
             }
         }
         
-        /// FIXME: Currently there are no more than 1 touch in OSX gestures, and not way to create custom touch gestures.
+        // FIXME: Currently there are no more than 1 touch in OSX gestures, and not way to create custom touch gestures.
         final func nsuiLocationOfTouch(_ touch: Int, inView view: NSView?) -> NSPoint
         {
             return super.location(in: view)

--- a/Source/Charts/Utils/Transformer.swift
+++ b/Source/Charts/Utils/Transformer.swift
@@ -12,14 +12,14 @@
 import Foundation
 import CoreGraphics
 
-/// Transformer class that contains all matrices and is responsible for transforming values into pixels on the screen and backwards.
+// Transformer class that contains all matrices and is responsible for transforming values into pixels on the screen and backwards.
 @objc(ChartTransformer)
 open class Transformer: NSObject
 {
-    /// matrix to map the values to the screen pixels
+    // matrix to map the values to the screen pixels
     internal var _matrixValueToPx = CGAffineTransform.identity
 
-    /// matrix for handling the different offsets of the chart
+    // matrix for handling the different offsets of the chart
     internal var _matrixOffset = CGAffineTransform.identity
 
     internal var _viewPortHandler: ViewPortHandler
@@ -29,7 +29,7 @@ open class Transformer: NSObject
         _viewPortHandler = viewPortHandler
     }
 
-    /// Prepares the matrix that transforms values to pixels. Calculates the scale factors from the charts size and offsets.
+    // Prepares the matrix that transforms values to pixels. Calculates the scale factors from the charts size and offsets.
     open func prepareMatrixValuePx(chartXMin: Double, deltaX: CGFloat, deltaY: CGFloat, chartYMin: Double)
     {
         var scaleX = (_viewPortHandler.contentWidth / deltaX)
@@ -50,7 +50,7 @@ open class Transformer: NSObject
         _matrixValueToPx = _matrixValueToPx.translatedBy(x: CGFloat(-chartXMin), y: CGFloat(-chartYMin))
     }
 
-    /// Prepares the matrix that contains all offsets.
+    // Prepares the matrix that contains all offsets.
     open func prepareMatrixOffset(inverted: Bool)
     {
         if !inverted
@@ -64,7 +64,7 @@ open class Transformer: NSObject
         }
     }
 
-    /// Transform an array of points with all matrices.
+    // Transform an array of points with all matrices.
     // VERY IMPORTANT: Keep matrix order "value-touch-offset" when transforming.
     open func pointValuesToPixel(_ points: inout [CGPoint])
     {
@@ -85,13 +85,13 @@ open class Transformer: NSObject
         return CGPoint(x: x, y: y).applying(valueToPixelMatrix)
     }
     
-    /// Transform a rectangle with all matrices.
+    // Transform a rectangle with all matrices.
     open func rectValueToPixel(_ r: inout CGRect)
     {
         r = r.applying(valueToPixelMatrix)
     }
     
-    /// Transform a rectangle with all matrices with potential animation phases.
+    // Transform a rectangle with all matrices with potential animation phases.
     open func rectValueToPixel(_ r: inout CGRect, phaseY: Double)
     {
         // multiply the height of the rect with the phase
@@ -104,13 +104,13 @@ open class Transformer: NSObject
         r = r.applying(valueToPixelMatrix)
     }
     
-    /// Transform a rectangle with all matrices.
+    // Transform a rectangle with all matrices.
     open func rectValueToPixelHorizontal(_ r: inout CGRect)
     {
         r = r.applying(valueToPixelMatrix)
     }
     
-    /// Transform a rectangle with all matrices with potential animation phases.
+    // Transform a rectangle with all matrices with potential animation phases.
     open func rectValueToPixelHorizontal(_ r: inout CGRect, phaseY: Double)
     {
         // multiply the height of the rect with the phase
@@ -122,7 +122,7 @@ open class Transformer: NSObject
         r = r.applying(valueToPixelMatrix)
     }
 
-    /// transforms multiple rects with all matrices
+    // transforms multiple rects with all matrices
     open func rectValuesToPixel(_ rects: inout [CGRect])
     {
         let trans = valueToPixelMatrix
@@ -133,7 +133,7 @@ open class Transformer: NSObject
         }
     }
     
-    /// Transforms the given array of touch points (pixels) into values on the chart.
+    // Transforms the given array of touch points (pixels) into values on the chart.
     open func pixelsToValues(_ pixels: inout [CGPoint])
     {
         let trans = pixelToValueMatrix
@@ -144,23 +144,23 @@ open class Transformer: NSObject
         }
     }
     
-    /// Transforms the given touch point (pixels) into a value on the chart.
+    // Transforms the given touch point (pixels) into a value on the chart.
     open func pixelToValues(_ pixel: inout CGPoint)
     {
         pixel = pixel.applying(pixelToValueMatrix)
     }
     
-    /// - returns: The x and y values in the chart at the given touch point
-    /// (encapsulated in a CGPoint). This method transforms pixel coordinates to
-    /// coordinates / values in the chart.
+    // - returns: The x and y values in the chart at the given touch point
+    // (encapsulated in a CGPoint). This method transforms pixel coordinates to
+    // coordinates / values in the chart.
     open func valueForTouchPoint(_ point: CGPoint) -> CGPoint
     {
         return point.applying(pixelToValueMatrix)
     }
     
-    /// - returns: The x and y values in the chart at the given touch point
-    /// (x/y). This method transforms pixel coordinates to
-    /// coordinates / values in the chart.
+    // - returns: The x and y values in the chart at the given touch point
+    // (x/y). This method transforms pixel coordinates to
+    // coordinates / values in the chart.
     open func valueForTouchPoint(x: CGFloat, y: CGFloat) -> CGPoint
     {
         return CGPoint(x: x, y: y).applying(pixelToValueMatrix)

--- a/Source/Charts/Utils/TransformerHorizontalBarChart.swift
+++ b/Source/Charts/Utils/TransformerHorizontalBarChart.swift
@@ -15,7 +15,7 @@ import CoreGraphics
 @objc(ChartTransformerHorizontalBarChart)
 open class TransformerHorizontalBarChart: Transformer
 {
-    /// Prepares the matrix that contains all offsets.
+    // Prepares the matrix that contains all offsets.
     open override func prepareMatrixOffset(inverted: Bool)
     {
         if !inverted

--- a/Source/Charts/Utils/ViewPortHandler.swift
+++ b/Source/Charts/Utils/ViewPortHandler.swift
@@ -12,54 +12,54 @@
 import Foundation
 import CoreGraphics
 
-/// Class that contains information about the charts current viewport settings, including offsets, scale & translation levels, ...
+// Class that contains information about the charts current viewport settings, including offsets, scale & translation levels, ...
 @objc(ChartViewPortHandler)
 open class ViewPortHandler: NSObject
 {
-    /// matrix used for touch events
+    // matrix used for touch events
     fileprivate var _touchMatrix = CGAffineTransform.identity
     
-    /// this rectangle defines the area in which graph values can be drawn
+    // this rectangle defines the area in which graph values can be drawn
     fileprivate var _contentRect = CGRect()
     
     fileprivate var _chartWidth = CGFloat(0.0)
     fileprivate var _chartHeight = CGFloat(0.0)
     
-    /// minimum scale value on the y-axis
+    // minimum scale value on the y-axis
     fileprivate var _minScaleY = CGFloat(1.0)
     
-    /// maximum scale value on the y-axis
+    // maximum scale value on the y-axis
     fileprivate var _maxScaleY = CGFloat.greatestFiniteMagnitude
     
-    /// minimum scale value on the x-axis
+    // minimum scale value on the x-axis
     fileprivate var _minScaleX = CGFloat(1.0)
     
-    /// maximum scale value on the x-axis
+    // maximum scale value on the x-axis
     fileprivate var _maxScaleX = CGFloat.greatestFiniteMagnitude
     
-    /// contains the current scale factor of the x-axis
+    // contains the current scale factor of the x-axis
     fileprivate var _scaleX = CGFloat(1.0)
     
-    /// contains the current scale factor of the y-axis
+    // contains the current scale factor of the y-axis
     fileprivate var _scaleY = CGFloat(1.0)
     
-    /// current translation (drag distance) on the x-axis
+    // current translation (drag distance) on the x-axis
     fileprivate var _transX = CGFloat(0.0)
     
-    /// current translation (drag distance) on the y-axis
+    // current translation (drag distance) on the y-axis
     fileprivate var _transY = CGFloat(0.0)
     
-    /// offset that allows the chart to be dragged over its bounds on the x-axis
+    // offset that allows the chart to be dragged over its bounds on the x-axis
     fileprivate var _transOffsetX = CGFloat(0.0)
     
-    /// offset that allows the chart to be dragged over its bounds on the x-axis
+    // offset that allows the chart to be dragged over its bounds on the x-axis
     fileprivate var _transOffsetY = CGFloat(0.0)
     
     public override init()
     {
     }
     
-    /// Constructor - don't forget calling setChartDimens(...)
+    // Constructor - don't forget calling setChartDimens(...)
     public init(width: CGFloat, height: CGFloat)
     {
         super.init()
@@ -172,13 +172,13 @@ open class ViewPortHandler: NSObject
 
     // MARK: - Scaling/Panning etc.
     
-    /// Zooms by the specified zoom factors.
+    // Zooms by the specified zoom factors.
     open func zoom(scaleX: CGFloat, scaleY: CGFloat) -> CGAffineTransform
     {
         return _touchMatrix.scaledBy(x: scaleX, y: scaleY)
     }
     
-    /// Zooms around the specified center
+    // Zooms around the specified center
     open func zoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         var matrix = _touchMatrix.translatedBy(x: x, y: y)
@@ -187,25 +187,25 @@ open class ViewPortHandler: NSObject
         return matrix
     }
     
-    /// Zooms in by 1.4, x and y are the coordinates (in pixels) of the zoom center.
+    // Zooms in by 1.4, x and y are the coordinates (in pixels) of the zoom center.
     open func zoomIn(x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         return zoom(scaleX: 1.4, scaleY: 1.4, x: x, y: y)
     }
     
-    /// Zooms out by 0.7, x and y are the coordinates (in pixels) of the zoom center.
+    // Zooms out by 0.7, x and y are the coordinates (in pixels) of the zoom center.
     open func zoomOut(x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         return zoom(scaleX: 0.7, scaleY: 0.7, x: x, y: y)
     }
     
-    /// Zooms out to original size.
+    // Zooms out to original size.
     open func resetZoom() -> CGAffineTransform
     {
         return zoom(scaleX: 1.0, scaleY: 1.0, x: 0.0, y: 0.0)
     }
     
-    /// Sets the scale factor to the specified values.
+    // Sets the scale factor to the specified values.
     open func setZoom(scaleX: CGFloat, scaleY: CGFloat) -> CGAffineTransform
     {
         var matrix = _touchMatrix
@@ -214,7 +214,7 @@ open class ViewPortHandler: NSObject
         return matrix
     }
     
-    /// Sets the scale factor to the specified values. x and y is pivot.
+    // Sets the scale factor to the specified values. x and y is pivot.
     open func setZoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         var matrix = _touchMatrix
@@ -226,7 +226,7 @@ open class ViewPortHandler: NSObject
         return matrix
     }
     
-    /// Resets all zooming and dragging and makes the chart fit exactly it's bounds.
+    // Resets all zooming and dragging and makes the chart fit exactly it's bounds.
     open func fitScreen() -> CGAffineTransform
     {
         _minScaleX = 1.0
@@ -235,7 +235,7 @@ open class ViewPortHandler: NSObject
         return CGAffineTransform.identity
     }
     
-    /// Translates to the specified point.
+    // Translates to the specified point.
     open func translate(pt: CGPoint) -> CGAffineTransform
     {
         let translateX = pt.x - offsetLeft
@@ -246,9 +246,9 @@ open class ViewPortHandler: NSObject
         return matrix
     }
     
-    /// Centers the viewport around the specified position (x-index and y-value) in the chart.
-    /// Centering the viewport outside the bounds of the chart is not possible.
-    /// Makes most sense in combination with the setScaleMinima(...) method.
+    // Centers the viewport around the specified position (x-index and y-value) in the chart.
+    // Centering the viewport outside the bounds of the chart is not possible.
+    // Makes most sense in combination with the setScaleMinima(...) method.
     open func centerViewPort(pt: CGPoint, chart: ChartViewBase)
     {
         let translateX = pt.x - offsetLeft
@@ -259,7 +259,7 @@ open class ViewPortHandler: NSObject
         let _ = refresh(newMatrix: matrix, chart: chart, invalidate: true)
     }
     
-    /// call this method to refresh the graph with a given matrix
+    // call this method to refresh the graph with a given matrix
     open func refresh(newMatrix: CGAffineTransform, chart: ChartViewBase, invalidate: Bool) -> CGAffineTransform
     {
         _touchMatrix = newMatrix
@@ -272,7 +272,7 @@ open class ViewPortHandler: NSObject
         return _touchMatrix
     }
     
-    /// limits the maximum scale and X translation of the given matrix
+    // limits the maximum scale and X translation of the given matrix
     fileprivate func limitTransAndScale(matrix: inout CGAffineTransform, content: CGRect?)
     {
         // min scale-x is 1
@@ -303,7 +303,7 @@ open class ViewPortHandler: NSObject
         matrix.d = _scaleY
     }
     
-    /// Sets the minimum scale factor for the x-axis
+    // Sets the minimum scale factor for the x-axis
     open func setMinimumScaleX(_ xScale: CGFloat)
     {
         var newValue = xScale
@@ -318,7 +318,7 @@ open class ViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
     
-    /// Sets the maximum scale factor for the x-axis
+    // Sets the maximum scale factor for the x-axis
     open func setMaximumScaleX(_ xScale: CGFloat)
     {
         var newValue = xScale
@@ -333,7 +333,7 @@ open class ViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
     
-    /// Sets the minimum and maximum scale factors for the x-axis
+    // Sets the minimum and maximum scale factors for the x-axis
     open func setMinMaxScaleX(minScaleX: CGFloat, maxScaleX: CGFloat)
     {
         var newMin = minScaleX
@@ -354,7 +354,7 @@ open class ViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
     
-    /// Sets the minimum scale factor for the y-axis
+    // Sets the minimum scale factor for the y-axis
     open func setMinimumScaleY(_ yScale: CGFloat)
     {
         var newValue = yScale
@@ -369,7 +369,7 @@ open class ViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
     
-    /// Sets the maximum scale factor for the y-axis
+    // Sets the maximum scale factor for the y-axis
     open func setMaximumScaleY(_ yScale: CGFloat)
     {
         var newValue = yScale
@@ -448,109 +448,109 @@ open class ViewPortHandler: NSObject
         return (_contentRect.origin.y + _contentRect.size.height) >= normalizedY
     }
     
-    /// - returns: The current x-scale factor
+    // - returns: The current x-scale factor
     open var scaleX: CGFloat
     {
         return _scaleX
     }
     
-    /// - returns: The current y-scale factor
+    // - returns: The current y-scale factor
     open var scaleY: CGFloat
     {
         return _scaleY
     }
     
-    /// - returns: The minimum x-scale factor
+    // - returns: The minimum x-scale factor
     open var minScaleX: CGFloat
     {
         return _minScaleX
     }
     
-    /// - returns: The minimum y-scale factor
+    // - returns: The minimum y-scale factor
     open var minScaleY: CGFloat
     {
         return _minScaleY
     }
     
-    /// - returns: The minimum x-scale factor
+    // - returns: The minimum x-scale factor
     open var maxScaleX: CGFloat
     {
         return _maxScaleX
     }
     
-    /// - returns: The minimum y-scale factor
+    // - returns: The minimum y-scale factor
     open var maxScaleY: CGFloat
     {
         return _maxScaleY
     }
     
-    /// - returns: The translation (drag / pan) distance on the x-axis
+    // - returns: The translation (drag / pan) distance on the x-axis
     open var transX: CGFloat
     {
         return _transX
     }
     
-    /// - returns: The translation (drag / pan) distance on the y-axis
+    // - returns: The translation (drag / pan) distance on the y-axis
     open var transY: CGFloat
     {
         return _transY
     }
     
-    /// if the chart is fully zoomed out, return true
+    // if the chart is fully zoomed out, return true
     open var isFullyZoomedOut: Bool
     {
         return isFullyZoomedOutX && isFullyZoomedOutY
     }
     
-    /// - returns: `true` if the chart is fully zoomed out on it's y-axis (vertical).
+    // - returns: `true` if the chart is fully zoomed out on it's y-axis (vertical).
     open var isFullyZoomedOutY: Bool
     {
         return !(_scaleY > _minScaleY || _minScaleY > 1.0)
     }
     
-    /// - returns: `true` if the chart is fully zoomed out on it's x-axis (horizontal).
+    // - returns: `true` if the chart is fully zoomed out on it's x-axis (horizontal).
     open var isFullyZoomedOutX: Bool
     {
         return !(_scaleX > _minScaleX || _minScaleX > 1.0)
     }
     
-    /// Set an offset in pixels that allows the user to drag the chart over it's bounds on the x-axis.
+    // Set an offset in pixels that allows the user to drag the chart over it's bounds on the x-axis.
     open func setDragOffsetX(_ offset: CGFloat)
     {
         _transOffsetX = offset
     }
     
-    /// Set an offset in pixels that allows the user to drag the chart over it's bounds on the y-axis.
+    // Set an offset in pixels that allows the user to drag the chart over it's bounds on the y-axis.
     open func setDragOffsetY(_ offset: CGFloat)
     {
         _transOffsetY = offset
     }
     
-    /// - returns: `true` if both drag offsets (x and y) are zero or smaller.
+    // - returns: `true` if both drag offsets (x and y) are zero or smaller.
     open var hasNoDragOffset: Bool
     {
         return _transOffsetX <= 0.0 && _transOffsetY <= 0.0
     }
     
-    /// - returns: `true` if the chart is not yet fully zoomed out on the x-axis
+    // - returns: `true` if the chart is not yet fully zoomed out on the x-axis
     open var canZoomOutMoreX: Bool
     {
         return _scaleX > _minScaleX
     }
     
-    /// - returns: `true` if the chart is not yet fully zoomed in on the x-axis
+    // - returns: `true` if the chart is not yet fully zoomed in on the x-axis
     open var canZoomInMoreX: Bool
     {
         return _scaleX < _maxScaleX
     }
     
-    /// - returns: `true` if the chart is not yet fully zoomed out on the y-axis
+    // - returns: `true` if the chart is not yet fully zoomed out on the y-axis
     open var canZoomOutMoreY: Bool
     {
         return _scaleY > _minScaleY
     }
     
-    /// - returns: `true` if the chart is not yet fully zoomed in on the y-axis
+    // - returns: `true` if the chart is not yet fully zoomed in on the y-axis
     open var canZoomInMoreY: Bool
     {
         return _scaleY < _maxScaleY


### PR DESCRIPTION
Multiple comments in multiple files were commented with a triple slash (`///`) which is the correct syntax for C#, but not for Swift. This was causing multiple warnings in Xcode. 

A slash was removed where necessary to give the comments the correct double slash syntax for Swift comments.
