### PR TITLE
Allow turning off drag in X and Y axes separately.

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -29,6 +29,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     fileprivate var _pinchZoomEnabled = false
     fileprivate var _doubleTapToZoomEnabled = true
     fileprivate var _dragEnabled = true
+    fileprivate var _dragYEnabled = true
+    fileprivate var _dragXEnabled = true
     
     fileprivate var _scaleXEnabled = true
     fileprivate var _scaleYEnabled = true
@@ -853,8 +855,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         if gestureRecognizer == _panGestureRecognizer
         {
+            let velocity = _panGestureRecognizer.velocity(in: self)
             if _data === nil || !_dragEnabled ||
-                (self.hasNoDragOffset && self.isFullyZoomedOut && !self.isHighlightPerDragEnabled)
+                (self.hasNoDragOffset && self.isFullyZoomedOut && !self.isHighlightPerDragEnabled) ||
+                (!_dragYEnabled && fabs(velocity.y) > fabs(velocity.x)) ||
+                (!_dragXEnabled && fabs(velocity.y) < fabs(velocity.x))
             {
                 return false
             }
@@ -1517,7 +1522,31 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             if _dragEnabled != newValue
             {
                 _dragEnabled = newValue
+                _dragYEnabled = newValue
+                _dragXEnabled = newValue
             }
+        }
+    }
+    
+    open var dragYEnabled: Bool {
+        get
+        {
+            return _dragYEnabled
+        }
+        set
+        {
+            _dragYEnabled = newValue
+        }
+    }
+    
+    open var dragXEnabled: Bool {
+        get
+        {
+            return _dragXEnabled
+        }
+        set
+        {
+            _dragXEnabled = newValue
         }
     }
     

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -1528,7 +1528,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    open var dragYEnabled: Bool {
+    open var dragYEnabled: Bool 
+    {
         get
         {
             return _dragYEnabled
@@ -1539,7 +1540,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    open var dragXEnabled: Bool {
+    open var dragXEnabled: Bool 
+    {
         get
         {
             return _dragXEnabled


### PR DESCRIPTION
Currently if a chart is inside a scroll view and drag is enabled, the chart pan gesture recognizes all pan events and the containing scroll view doesn't work. 

This PR allows enabling/disabling drag in either axis separately. Probably the most common use case would be enabling scale only in the X direction and enabling drag only in the X direction, so a vertically scrolling scroll view can work normally:
```
chartView.scaleYEnabled = false
chartView.scaleXEnabled = true
chartView.dragYEnabled = false
```