### PR TITLE
Padding/spacing when rotating X-axis labels 90 degree

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -389,17 +389,9 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 {
                 case .top:
                     offsetTop += min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent) + _legend.yOffset
-                    if xAxis.isEnabled && xAxis.isDrawLabelsEnabled
-                    {
-                        offsetTop += xAxis.labelRotatedHeight
-                    }
                     
                 case .bottom:
                     offsetBottom += min(_legend.neededHeight, _viewPortHandler.chartHeight * _legend.maxSizePercent) + _legend.yOffset
-                    if xAxis.isEnabled && xAxis.isDrawLabelsEnabled
-                    {
-                        offsetBottom += xAxis.labelRotatedHeight
-                    }
                     
                 default:
                     break


### PR DESCRIPTION
This is an old bug
The problem is that the height is calculated 2 times

This is to avoid this kind of problem

**Before**
<img width="1557" alt="capture d ecran 2017-05-05 a 11 48 32" src="https://cloud.githubusercontent.com/assets/6251463/25751824/91eefdd8-31b6-11e7-9b81-27472dc79845.png">


**After**
<img width="1557" alt="capture d ecran 2017-05-05 a 11 47 21" src="https://cloud.githubusercontent.com/assets/6251463/25751801/8385b372-31b6-11e7-805b-133c9b23705b.png">

```
func calculateLegendOffsets 
offsetTop += xAxis.labelRotatedHeight`
```
and i resume
```
func calculateOffsets()
 let xlabelheight = xAxis.labelRotatedHeight + xAxis.yOffset
 offsetTop += xlabelheight
```




