### PR TITLE
remove an argument not necessarily required (from #2439)

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -869,17 +869,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     ///
     /// - returns: `true` if the image was saved successfully
     open func save(to path: String, format: ImageFormat) -> Bool
-    {
-        let saveUrl = URL(fileURLWithPath: path)
-        if #available(iOS 9.0, *)
-        {
-            if saveUrl.hasDirectoryPath
-            {
-                // the path represents a directory. not include filename.
-                return false
-            }
-        }
-        
+    {   
         var imageData: Data?
         switch (format)
         {
@@ -896,7 +886,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         {
             do
             {
-                try imageData.write(to: saveUrl, options: .atomic)
+                try imageData.write(to: URL(fileURLWithPath: path), options: .atomic)
             }
             catch
             {

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -871,10 +871,13 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     open func save(to path: String, format: ImageFormat) -> Bool
     {
         let saveUrl = URL(fileURLWithPath: path)
-        if saveUrl.hasDirectoryPath
+        if #available(iOS 9.0, *)
         {
-            // the path represents a directory. not include filename.
-            return false
+            if saveUrl.hasDirectoryPath
+            {
+                // the path represents a directory. not include filename.
+                return false
+            }
         }
         
         var imageData: Data?

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -855,7 +855,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     
     public enum ImageFormat
     {
-        case jpeg
+        /// - parameter quality: compression quality for lossless formats (JPEG)
+        case jpeg(quality: Double)
         case png
     }
     
@@ -866,24 +867,20 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     ///
     /// - parameter to: path to the image to save
     /// - parameter format: the format to save
-    /// - parameter compressionQuality: compression quality for lossless formats (JPEG)
     ///
     /// - returns: `true` if the image was saved successfully
-    open func save(to path: String, format: ImageFormat, compressionQuality: Double) -> Bool
+    open func save(to path: String, format: ImageFormat) -> Bool
     {
-		guard let image = getChartImage(transparent: format != .jpeg)
-            else { return false }
-        
         var imageData: Data!
         switch (format)
         {
         case .png:
+            guard let image = getChartImage(transparent: true) else { return false }
             imageData = NSUIImagePNGRepresentation(image)
-            break
             
-        case .jpeg:
+        case .jpeg(let compressionQuality):
+            guard let image = getChartImage(transparent: false) else { return false }
             imageData = NSUIImageJPEGRepresentation(image, CGFloat(compressionQuality))
-            break
         }
         
         do
@@ -895,7 +892,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             return false
         }
         
-		return true
+        return true
     }
     
     internal var _viewportJobs = [ViewPortJob]()

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -860,10 +860,9 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         case png
     }
     
-    /// Saves the current chart state with the given name to the given path on
-    /// the sdcard leaving the path empty "" will put the saved file directly on
-    /// the SD card chart is saved as a PNG image, example:
-    /// saveToPath("myfilename", "foldername1/foldername2")
+    /// Saves the current chart state with the given name to the given path, examples:
+    /// save(to: "./out/filename.jpg", format: .jpeg(quality: 90.0))
+    /// save(to: "./out/filename.png", format: .png)
     ///
     /// - parameter to: path to the image to save
     /// - parameter format: the format to save
@@ -871,7 +870,14 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - returns: `true` if the image was saved successfully
     open func save(to path: String, format: ImageFormat) -> Bool
     {
-        var imageData: Data!
+        let saveUrl = URL(fileURLWithPath: path)
+        if saveUrl.hasDirectoryPath
+        {
+            // the path represents a directory. not include filename.
+            return false
+        }
+        
+        var imageData: Data?
         switch (format)
         {
         case .png:
@@ -883,16 +889,22 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             imageData = NSUIImageJPEGRepresentation(image, CGFloat(compressionQuality))
         }
         
-        do
+        if let imageData = imageData
         {
-            try imageData.write(to: URL(fileURLWithPath: path), options: .atomic)
+            do
+            {
+                try imageData.write(to: saveUrl, options: .atomic)
+            }
+            catch
+            {
+                return false
+            }
+            return true
         }
-        catch
+        else
         {
             return false
         }
-        
-        return true
     }
     
     internal var _viewportJobs = [ViewPortJob]()


### PR DESCRIPTION
```ChartViewBase.swift
open func save(to path: String, format: ImageFormat, compressionQuality: Double) -> Bool
```

`compressionQuality` is not used for .png Format.
I think it is better to use Associated Value.

(this is from #2439)