### PR TITLE
Pie chart with value line : add an image view to be visible beside Label

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
@@ -46,7 +46,7 @@ open class PieChartDataEntry: ChartDataEntry
     /// - parameter label: The label for the x-axis
     /// - parameter icon: icon image
     /// - parameter data: Spot for additional data this Entry represents
-    public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?, imageView: UIImageView? = nil)
+    public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?, imageView: NSUIImageView? = nil)
     {
         super.init(x: 0.0, y: value, icon: icon, data: data)
         
@@ -85,7 +85,7 @@ open class PieChartDataEntry: ChartDataEntry
     // MARK: Data property accessors
     
     open var label: String?
-    open var image: UIImageView?
+    open var image: NSUIImageView?
 
     open var value: Double
     {

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
@@ -46,11 +46,12 @@ open class PieChartDataEntry: ChartDataEntry
     /// - parameter label: The label for the x-axis
     /// - parameter icon: icon image
     /// - parameter data: Spot for additional data this Entry represents
-    public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
+    public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?, imageView: UIImageView? = nil)
     {
         super.init(x: 0.0, y: value, icon: icon, data: data)
         
         self.label = label
+        self.image = imageView
     }
     
     /// - parameter value: The value on the y-axis
@@ -84,7 +85,8 @@ open class PieChartDataEntry: ChartDataEntry
     // MARK: Data property accessors
     
     open var label: String?
-    
+    open var image: UIImageView?
+
     open var value: Double
     {
         get { return y }

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -464,13 +464,26 @@ open class PieChartRenderer: DataRenderer
                     }
                     else if drawYOutside
                     {
-                        ChartUtils.drawText(
-                            context: context,
-                            text: valueText,
-                            point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight / 2.0),
-                            align: align,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
-                        )
+                        if let image = pe?.image {
+                            ChartUtils.drawText(
+                                context: context,
+                                text: valueText,
+                                point: CGPoint(x: labelPoint.x + (sliceXBase * 10), y: (labelPoint.y + lineHeight / 2.0) + (sliceYBase * 10)),
+                                align: align,
+                                attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            )
+                            
+                            image.frame = CGRect(x: pt1.x  - 10, y: pt1.y - 10 , width: 20, height: 20)
+                            self.chart?.addSubview(image)
+                        } else {
+                            ChartUtils.drawText(
+                                context: context,
+                                text: valueText,
+                                point: CGPoint(x: labelPoint.x , y: labelPoint.y + lineHeight / 2.0),
+                                align: align,
+                                attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            )
+                        }
                     }
                 }
                 

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -11,7 +11,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 	public typealias NSUIEvent = UIEvent
 	public typealias NSUITouch = UITouch
 	public typealias NSUIImage = UIImage
-    public typealias NSUIImageView = NSImageView
+    public typealias NSUIImageView = UIImageView
 	public typealias NSUIScrollView = UIScrollView
 	public typealias NSUIGestureRecognizer = UIGestureRecognizer
 	public typealias NSUIGestureRecognizerState = UIGestureRecognizerState

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -11,6 +11,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 	public typealias NSUIEvent = UIEvent
 	public typealias NSUITouch = UITouch
 	public typealias NSUIImage = UIImage
+    public typealias NSUIImageView = NSImageView
 	public typealias NSUIScrollView = UIScrollView
 	public typealias NSUIGestureRecognizer = UIGestureRecognizer
 	public typealias NSUIGestureRecognizerState = UIGestureRecognizerState
@@ -220,6 +221,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 	public typealias NSUIEvent = NSEvent
 	public typealias NSUITouch = NSTouch
 	public typealias NSUIImage = NSImage
+    public typealias NSUIImageView = NSImageView
 	public typealias NSUIScrollView = NSScrollView
 	public typealias NSUIGestureRecognizer = NSGestureRecognizer
 	public typealias NSUIGestureRecognizerState = NSGestureRecognizerState


### PR DESCRIPTION
According to issue [PieChart, adding an imageView beside values #2318](https://github.com/danielgindi/Charts/issues/2318#issuecomment-301737890) :

to achieve the pie chart with value lines like below : 
![screen shot 2017-04-05 at 3 15 38 pm](https://cloud.githubusercontent.com/assets/13133764/24702149/c268270c-1a12-11e7-966e-0b45f3a18a54.png)

**Added feature** : adding image in pie chart with value lines: 
 which the image will be shown beside the chart value. you can set the data chart with UIImageViews, and they will be shown in just pie chart with value beside the label value. 
