### PR TITLE
fix #2099, avoid crash when some chart only allow 1 data set

### DIFF
--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -44,7 +44,7 @@ open class LegendRenderer: Renderer
             // loop for building up the colors and labels used in the legend
             for i in 0..<data.dataSetCount
             {
-                let dataSet = data.getDataSetByIndex(i)!
+                guard let dataSet = data.getDataSetByIndex(i) else { continue }
                 
                 var clrs: [NSUIColor] = dataSet.colors
                 let entryCount = dataSet.entryCount


### PR DESCRIPTION
fix #2099, avoid crash when some chart only allow 1 data set but people will set more than that