### PR TITLE
Changes for Swift 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9
 matrix:
   include:
-    - osx_image: xcode8.3
-      env: PLATFORM="iOS"
-    - osx_image: xcode8.3
-      env: PLATFORM="tvOS"
-    - osx_image: xcode8.3
-      env: PLATFORM="macOS"
     - osx_image: xcode9
       env: PLATFORM="iOS"
     - osx_image: xcode9

--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -1125,32 +1125,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
-		06165F391D8110E700722320 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				COMBINE_HIDPI_IMAGES = YES;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.dcg.Charts;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};

--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -720,6 +720,14 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					A58A4ED274A941CA248EA921 = {
+						LastSwiftMigration = 0900;
+					};
+					F2749BD5443C1CB5FE2080C2 = {
+						LastSwiftMigration = 0900;
+					};
+				};
 			};
 			buildConfigurationList = 493FF4FB1D40FC7C51DDDA6B /* Build configuration list for PBXProject "Charts" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -979,7 +987,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1012,7 +1020,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator appletvos appletvsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -1146,7 +1154,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1178,7 +1186,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;

--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -1125,6 +1125,32 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		06165F391D8110E700722320 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.dcg.Charts;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};

--- a/Charts.xcodeproj/xcshareddata/xcschemes/Charts.xcscheme
+++ b/Charts.xcodeproj/xcshareddata/xcschemes/Charts.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Charts.xcodeproj/xcshareddata/xcschemes/ChartsTests.xcscheme
+++ b/Charts.xcodeproj/xcshareddata/xcschemes/ChartsTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ChartsDemo-OSX/ChartsDemo-OSX.xcodeproj/project.pbxproj
+++ b/ChartsDemo-OSX/ChartsDemo-OSX.xcodeproj/project.pbxproj
@@ -33,25 +33,11 @@
 			remoteGlobalIDString = 06165F2E1D8110E600722320;
 			remoteInfo = ChartsTests;
 		};
-		0630AE741D812840008859B0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0630AE691D812840008859B0 /* Charts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 06B120D51D811E6200D14B02;
-			remoteInfo = ChartsRealm;
-		};
-		0630AE761D812840008859B0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0630AE691D812840008859B0 /* Charts.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 06B120FF1D811F1600D14B02;
-			remoteInfo = ChartsRealmTests;
-		};
 		0630AE8E1D8128A5008859B0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0630AE691D812840008859B0 /* Charts.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 06165F231D8110E600722320;
+			remoteGlobalIDString = A58A4ED274A941CA248EA921;
 			remoteInfo = Charts;
 		};
 /* End PBXContainerItemProxy section */
@@ -100,8 +86,6 @@
 			children = (
 				0630AE711D812840008859B0 /* Charts.framework */,
 				0630AE731D812840008859B0 /* ChartsTests.xctest */,
-				0630AE751D812840008859B0 /* ChartsRealm.framework */,
-				0630AE771D812840008859B0 /* ChartsRealmTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -175,12 +159,13 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = dcg;
 				TargetAttributes = {
 					65B3F63D1C73B4F5000983D0 = {
 						CreatedOnToolsVersion = 7.2.1;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -221,20 +206,6 @@
 			fileType = wrapper.cfbundle;
 			path = ChartsTests.xctest;
 			remoteRef = 0630AE721D812840008859B0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0630AE751D812840008859B0 /* ChartsRealm.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = ChartsRealm.framework;
-			remoteRef = 0630AE741D812840008859B0 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		0630AE771D812840008859B0 /* ChartsRealmTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = ChartsRealmTests.xctest;
-			remoteRef = 0630AE761D812840008859B0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -294,14 +265,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -340,14 +317,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -376,12 +359,16 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "ChartsDemo-OSX/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.ChartsDemo-OSX";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -390,12 +377,16 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "ChartsDemo-OSX/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.ChartsDemo-OSX";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/ChartsDemo-OSX/ChartsDemo-OSX/Demos/BarDemoViewController.swift
+++ b/ChartsDemo-OSX/ChartsDemo-OSX/Demos/BarDemoViewController.swift
@@ -47,7 +47,7 @@ open class BarDemoViewController: NSViewController
         let panel = NSSavePanel()
         panel.allowedFileTypes = ["png"]
         panel.beginSheetModal(for: self.view.window!) { (result) -> Void in
-            if result == NSFileHandlingPanelOKButton
+            if result.rawValue == NSFileHandlingPanelOKButton
             {
                 if let path = panel.url?.path
                 {

--- a/ChartsDemo-OSX/ChartsDemo-OSX/Demos/PieDemoViewController.swift
+++ b/ChartsDemo-OSX/ChartsDemo-OSX/Demos/PieDemoViewController.swift
@@ -32,13 +32,13 @@ open class PieDemoViewController: NSViewController
         
         data.addDataSet(ds1)
         
-        let paragraphStyle: NSMutableParagraphStyle = NSParagraphStyle.default().mutableCopy() as! NSMutableParagraphStyle
+        let paragraphStyle: NSMutableParagraphStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
         paragraphStyle.lineBreakMode = .byTruncatingTail
         paragraphStyle.alignment = .center
         let centerText: NSMutableAttributedString = NSMutableAttributedString(string: "Charts\nby Daniel Cohen Gindi")
-        centerText.setAttributes([NSFontAttributeName: NSFont(name: "HelveticaNeue-Light", size: 15.0)!, NSParagraphStyleAttributeName: paragraphStyle], range: NSMakeRange(0, centerText.length))
-        centerText.addAttributes([NSFontAttributeName: NSFont(name: "HelveticaNeue-Light", size: 13.0)!, NSForegroundColorAttributeName: NSColor.gray], range: NSMakeRange(10, centerText.length - 10))
-        centerText.addAttributes([NSFontAttributeName: NSFont(name: "HelveticaNeue-LightItalic", size: 13.0)!, NSForegroundColorAttributeName: NSColor(red: 51 / 255.0, green: 181 / 255.0, blue: 229 / 255.0, alpha: 1.0)], range: NSMakeRange(centerText.length - 19, 19))
+        centerText.setAttributes([NSAttributedStringKey.font: NSFont(name: "HelveticaNeue-Light", size: 15.0)!, NSAttributedStringKey.paragraphStyle: paragraphStyle], range: NSMakeRange(0, centerText.length))
+        centerText.addAttributes([NSAttributedStringKey.font: NSFont(name: "HelveticaNeue-Light", size: 13.0)!, NSAttributedStringKey.foregroundColor: NSColor.gray], range: NSMakeRange(10, centerText.length - 10))
+        centerText.addAttributes([NSAttributedStringKey.font: NSFont(name: "HelveticaNeue-LightItalic", size: 13.0)!, NSAttributedStringKey.foregroundColor: NSColor(red: 51 / 255.0, green: 181 / 255.0, blue: 229 / 255.0, alpha: 1.0)], range: NSMakeRange(centerText.length - 19, 19))
         
         self.pieChartView.centerAttributedText = centerText
         

--- a/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
+++ b/ChartsDemo/ChartsDemo.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 0630AE391D8126C0008859B0 /* Charts.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = 06165F231D8110E600722320;
+			remoteGlobalIDString = A58A4ED274A941CA248EA921;
 			remoteInfo = Charts;
 		};
 /* End PBXContainerItemProxy section */
@@ -129,7 +129,6 @@
 		0439A3521C9FF95F00496F83 /* PiePolylineChartViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PiePolylineChartViewController.m; sourceTree = "<group>"; };
 		0471CBFB1CA1090A00E52DBC /* PiePolylineChartViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PiePolylineChartViewController.xib; sourceTree = "<group>"; };
 		0630AE391D8126C0008859B0 /* Charts.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Charts.xcodeproj; path = ../Charts.xcodeproj; sourceTree = "<group>"; };
-		066750AC1E2DB68D00E22DC6 /* Carthage.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Carthage.xcconfig; path = ../Carthage.xcconfig; sourceTree = "<group>"; };
 		55E3564D1ADC638F00A57971 /* BubbleChartViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BubbleChartViewController.xib; sourceTree = "<group>"; };
 		55E3564E1ADC638F00A57971 /* BubbleChartViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BubbleChartViewController.h; sourceTree = "<group>"; };
 		55E3564F1ADC638F00A57971 /* BubbleChartViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BubbleChartViewController.m; sourceTree = "<group>"; };
@@ -287,7 +286,6 @@
 		5B57BBA61A9B26AA0036A6CC = {
 			isa = PBXGroup;
 			children = (
-				066750AC1E2DB68D00E22DC6 /* Carthage.xcconfig */,
 				5B57BBB11A9B26AA0036A6CC /* Classes */,
 				5B8EAF2E1AB32E15009697AA /* Resources */,
 				5B57BBB21A9B26AA0036A6CC /* Supporting Files */,
@@ -484,12 +482,13 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = dcg;
 				TargetAttributes = {
 					5B57BBAE1A9B26AA0036A6CC = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -640,25 +639,29 @@
 /* Begin XCBuildConfiguration section */
 		5B57BBD01A9B26AA0036A6CC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 066750AC1E2DB68D00E22DC6 /* Carthage.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -686,25 +689,29 @@
 		};
 		5B57BBD11A9B26AA0036A6CC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 066750AC1E2DB68D00E22DC6 /* Carthage.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -726,40 +733,46 @@
 		};
 		5B57BBD31A9B26AA0036A6CC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 066750AC1E2DB68D00E22DC6 /* Carthage.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(SOURCE_ROOT)/../Carthage/Build/iOS";
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ChartsDemo;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Supporting Files/ChartsDemo-Bridging-Header.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
 		5B57BBD41A9B26AA0036A6CC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 066750AC1E2DB68D00E22DC6 /* Carthage.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(SOURCE_ROOT)/../Carthage/Build/iOS";
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dcg.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = ChartsDemo;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				SWIFT_OBJC_BRIDGING_HEADER = "Supporting Files/ChartsDemo-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift.h";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/ChartsDemo/Classes/Components/BalloonMarker.swift
+++ b/ChartsDemo/Classes/Components/BalloonMarker.swift
@@ -15,19 +15,19 @@ import Charts
 
 open class BalloonMarker: MarkerImage
 {
-    open var color: UIColor?
-    open var arrowSize = CGSize(width: 15, height: 11)
-    open var font: UIFont?
-    open var textColor: UIColor?
-    open var insets = UIEdgeInsets()
-    open var minimumSize = CGSize()
+    @objc open var color: UIColor?
+    @objc open var arrowSize = CGSize(width: 15, height: 11)
+    @objc open var font: UIFont?
+    @objc open var textColor: UIColor?
+    @objc open var insets = UIEdgeInsets()
+    @objc open var minimumSize = CGSize()
     
     fileprivate var label: String?
     fileprivate var _labelSize: CGSize = CGSize()
     fileprivate var _paragraphStyle: NSMutableParagraphStyle?
-    fileprivate var _drawAttributes = [String : AnyObject]()
+    fileprivate var _drawAttributes = [NSAttributedStringKey : Any]()
     
-    public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets)
+    @objc public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets)
     {
         super.init()
         
@@ -114,16 +114,16 @@ open class BalloonMarker: MarkerImage
         setLabel(String(entry.y))
     }
     
-    open func setLabel(_ newLabel: String)
+    @objc open func setLabel(_ newLabel: String)
     {
         label = newLabel
         
         _drawAttributes.removeAll()
-        _drawAttributes[NSFontAttributeName] = self.font
-        _drawAttributes[NSParagraphStyleAttributeName] = _paragraphStyle
-        _drawAttributes[NSForegroundColorAttributeName] = self.textColor
+        _drawAttributes[NSAttributedStringKey.font] = self.font
+        _drawAttributes[NSAttributedStringKey.paragraphStyle] = _paragraphStyle
+        _drawAttributes[NSAttributedStringKey.foregroundColor] = self.textColor
         
-        _labelSize = label?.size(attributes: _drawAttributes) ?? CGSize.zero
+        _labelSize = label?.size(withAttributes: _drawAttributes) ?? CGSize.zero
         
         var size = CGSize()
         size.width = _labelSize.width + self.insets.left + self.insets.right

--- a/ChartsDemo/Classes/Components/XYMarkerView.swift
+++ b/ChartsDemo/Classes/Components/XYMarkerView.swift
@@ -9,10 +9,10 @@ import Charts
 
 open class XYMarkerView: BalloonMarker
 {
-    open var xAxisValueFormatter: IAxisValueFormatter?
+    @objc open var xAxisValueFormatter: IAxisValueFormatter?
     fileprivate var yFormatter = NumberFormatter()
     
-    public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets,
+    @objc public init(color: UIColor, font: UIFont, textColor: UIColor, insets: UIEdgeInsets,
                 xAxisValueFormatter: IAxisValueFormatter)
     {
         super.init(color: color, font: font, textColor: textColor, insets: insets)

--- a/ChartsDemo/Classes/Formatters/LargeValueFormatter.swift
+++ b/ChartsDemo/Classes/Formatters/LargeValueFormatter.swift
@@ -14,17 +14,17 @@ open class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
     /// Suffix to be appended after the values.
     ///
     /// **default**: suffix: ["", "k", "m", "b", "t"]
-    open var suffix = ["", "k", "m", "b", "t"]
+    @objc open var suffix = ["", "k", "m", "b", "t"]
     
     /// An appendix text to be added at the end of the formatted value.
-    open var appendix: String?
+    @objc open var appendix: String?
     
     public override init()
     {
         
     }
     
-    public init(appendix: String?)
+    @objc public init(appendix: String?)
     {
         self.appendix = appendix
     }

--- a/Source/Charts/Animation/Animator.swift
+++ b/Source/Charts/Animation/Animator.swift
@@ -29,15 +29,15 @@ public protocol AnimatorDelegate
 @objc(ChartAnimator)
 open class Animator: NSObject
 {
-    open weak var delegate: AnimatorDelegate?
-    open var updateBlock: (() -> Void)?
-    open var stopBlock: (() -> Void)?
+    @objc open weak var delegate: AnimatorDelegate?
+    @objc open var updateBlock: (() -> Void)?
+    @objc open var stopBlock: (() -> Void)?
     
     /// the phase that is animated and influences the drawn values on the x-axis
-    open var phaseX: Double = 1.0
+    @objc open var phaseX: Double = 1.0
     
     /// the phase that is animated and influences the drawn values on the y-axis
-    open var phaseY: Double = 1.0
+    @objc open var phaseY: Double = 1.0
     
     fileprivate var _startTimeX: TimeInterval = 0.0
     fileprivate var _startTimeY: TimeInterval = 0.0
@@ -66,7 +66,7 @@ open class Animator: NSObject
         stop()
     }
     
-    open func stop()
+    @objc open func stop()
     {
         if _displayLink != nil
         {
@@ -173,7 +173,7 @@ open class Animator: NSObject
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingX: an easing function for the animation on the x axis
     /// - parameter easingY: an easing function for the animation on the y axis
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
     {
         stop()
         
@@ -206,7 +206,7 @@ open class Animator: NSObject
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOptionX: the easing function for the animation on the x axis
     /// - parameter easingOptionY: the easing function for the animation on the y axis
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easingFunctionFromOption(easingOptionX), easingY: easingFunctionFromOption(easingOptionY))
     }
@@ -216,7 +216,7 @@ open class Animator: NSObject
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easing, easingY: easing)
     }
@@ -226,7 +226,7 @@ open class Animator: NSObject
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
@@ -235,7 +235,7 @@ open class Animator: NSObject
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval)
     {
         animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOption: .easeInOutSine)
     }
@@ -244,7 +244,7 @@ open class Animator: NSObject
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easing: an easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
+    @objc open func animate(xAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _startTimeX = CACurrentMediaTime()
         _durationX = xAxisDuration
@@ -271,7 +271,7 @@ open class Animator: NSObject
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easingOption: the easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, easingOption: ChartEasingOption)
+    @objc open func animate(xAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         animate(xAxisDuration: xAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
@@ -279,7 +279,7 @@ open class Animator: NSObject
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
-    open func animate(xAxisDuration: TimeInterval)
+    @objc open func animate(xAxisDuration: TimeInterval)
     {
         animate(xAxisDuration: xAxisDuration, easingOption: .easeInOutSine)
     }
@@ -288,7 +288,7 @@ open class Animator: NSObject
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
-    open func animate(yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
+    @objc open func animate(yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _startTimeY = CACurrentMediaTime()
         _durationY = yAxisDuration
@@ -315,7 +315,7 @@ open class Animator: NSObject
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
-    open func animate(yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
+    @objc open func animate(yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         animate(yAxisDuration: yAxisDuration, easing: easingFunctionFromOption(easingOption))
     }
@@ -323,7 +323,7 @@ open class Animator: NSObject
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
-    open func animate(yAxisDuration: TimeInterval)
+    @objc open func animate(yAxisDuration: TimeInterval)
     {
         animate(yAxisDuration: yAxisDuration, easingOption: .easeInOutSine)
     }

--- a/Source/Charts/Charts/BarChartView.swift
+++ b/Source/Charts/Charts/BarChartView.swift
@@ -83,7 +83,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     }
         
     /// - returns: The bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
-    open func getBarBounds(entry e: BarChartDataEntry) -> CGRect
+    @objc open func getBarBounds(entry e: BarChartDataEntry) -> CGRect
     {
         guard let
             data = _data as? BarChartData,
@@ -114,7 +114,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     /// - parameter fromX: the starting point on the x-axis where the grouping should begin
     /// - parameter groupSpace: the space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
     /// - parameter barSpace: the space between individual bars in values (not pixels) e.g. 0.1f for bar width 1f
-    open func groupBars(fromX: Double, groupSpace: Double, barSpace: Double)
+    @objc open func groupBars(fromX: Double, groupSpace: Double, barSpace: Double)
     {
         guard let barData = self.barData
             else
@@ -131,7 +131,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     /// - parameter x:
     /// - parameter dataSetIndex:
     /// - parameter stackIndex: the index inside the stack - only relevant for stacked entries
-    open func highlightValue(x: Double, dataSetIndex: Int, stackIndex: Int)
+    @objc open func highlightValue(x: Double, dataSetIndex: Int, stackIndex: Int)
     {
         highlightValue(Highlight(x: x, dataSetIndex: dataSetIndex, stackIndex: stackIndex))
     }
@@ -139,7 +139,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     // MARK: Accessors
     
     /// if set to true, all values are drawn above their bars, instead of below their top
-    open var drawValueAboveBarEnabled: Bool
+    @objc open var drawValueAboveBarEnabled: Bool
     {
         get { return _drawValueAboveBarEnabled }
         set
@@ -150,7 +150,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     }
     
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
-    open var drawBarShadowEnabled: Bool
+    @objc open var drawBarShadowEnabled: Bool
     {
         get { return _drawBarShadowEnabled }
         set
@@ -162,11 +162,11 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     
     /// Adds half of the bar width to each side of the x-axis range in order to allow the bars of the barchart to be fully displayed.
     /// **default**: false
-    open var fitBars = false
+    @objc open var fitBars = false
     
     /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values (relevant only for stacked).
     /// If enabled, highlighting operations will highlight the whole bar, even if only a single stack entry was tapped.
-    open var highlightFullBarEnabled: Bool = false
+    @objc open var highlightFullBarEnabled: Bool = false
     
     /// - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
     open var isHighlightFullBarEnabled: Bool { return highlightFullBarEnabled }

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -21,7 +21,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 {
     /// the maximum number of entries to which values will be drawn
     /// (entry numbers greater than this value will cause value-labels to disappear)
-    internal var _maxVisibleCount = 100
+    @objc internal var _maxVisibleCount = 100
     
     /// flag that indicates if auto scaling on the y axis is enabled
     fileprivate var _autoScaleMinMaxEnabled = false
@@ -34,48 +34,48 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     fileprivate var _scaleYEnabled = true
     
     /// the color for the background of the chart-drawing area (everything behind the grid lines).
-    open var gridBackgroundColor = NSUIColor(red: 240/255.0, green: 240/255.0, blue: 240/255.0, alpha: 1.0)
+    @objc open var gridBackgroundColor = NSUIColor(red: 240/255.0, green: 240/255.0, blue: 240/255.0, alpha: 1.0)
     
-    open var borderColor = NSUIColor.black
-    open var borderLineWidth: CGFloat = 1.0
+    @objc open var borderColor = NSUIColor.black
+    @objc open var borderLineWidth: CGFloat = 1.0
     
     /// flag indicating if the grid background should be drawn or not
-    open var drawGridBackgroundEnabled = false
+    @objc open var drawGridBackgroundEnabled = false
     
     /// When enabled, the borders rectangle will be rendered.
     /// If this is enabled, there is no point drawing the axis-lines of x- and y-axis.
-    open var drawBordersEnabled = false
+    @objc open var drawBordersEnabled = false
     
     /// When enabled, the values will be clipped to contentRect, otherwise they can bleed outside the content rect.
-    open var clipValuesToContentEnabled: Bool = false
+    @objc open var clipValuesToContentEnabled: Bool = false
 
     /// Sets the minimum offset (padding) around the chart, defaults to 10
-    open var minOffset = CGFloat(10.0)
+    @objc open var minOffset = CGFloat(10.0)
     
     /// Sets whether the chart should keep its position (zoom / scroll) after a rotation (orientation change)
     /// **default**: false
-    open var keepPositionOnRotation: Bool = false
+    @objc open var keepPositionOnRotation: Bool = false
     
     /// the object representing the left y-axis
-    internal var _leftAxis: YAxis!
+    @objc internal var _leftAxis: YAxis!
     
     /// the object representing the right y-axis
-    internal var _rightAxis: YAxis!
+    @objc internal var _rightAxis: YAxis!
 
-    internal var _leftYAxisRenderer: YAxisRenderer!
-    internal var _rightYAxisRenderer: YAxisRenderer!
+    @objc internal var _leftYAxisRenderer: YAxisRenderer!
+    @objc internal var _rightYAxisRenderer: YAxisRenderer!
     
-    internal var _leftAxisTransformer: Transformer!
-    internal var _rightAxisTransformer: Transformer!
+    @objc internal var _leftAxisTransformer: Transformer!
+    @objc internal var _rightAxisTransformer: Transformer!
     
-    internal var _xAxisRenderer: XAxisRenderer!
+    @objc internal var _xAxisRenderer: XAxisRenderer!
     
-    internal var _tapGestureRecognizer: NSUITapGestureRecognizer!
-    internal var _doubleTapGestureRecognizer: NSUITapGestureRecognizer!
+    @objc internal var _tapGestureRecognizer: NSUITapGestureRecognizer!
+    @objc internal var _doubleTapGestureRecognizer: NSUITapGestureRecognizer!
     #if !os(tvOS)
-    internal var _pinchGestureRecognizer: NSUIPinchGestureRecognizer!
+    @objc internal var _pinchGestureRecognizer: NSUIPinchGestureRecognizer!
     #endif
-    internal var _panGestureRecognizer: NSUIPanGestureRecognizer!
+    @objc internal var _panGestureRecognizer: NSUIPanGestureRecognizer!
     
     /// flag that indicates if a custom viewport offset has been set
     fileprivate var _customViewPortEnabled = false
@@ -278,7 +278,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     fileprivate var _autoScaleLastHighestVisibleX: Double?
     
     /// Performs auto scaling of the axis by recalculating the minimum and maximum y-values based on the entries currently in view.
-    internal func autoScale()
+    @objc internal func autoScale()
     {
         guard let data = _data
             else { return }
@@ -302,13 +302,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         calculateOffsets()
     }
     
-    internal func prepareValuePxMatrix()
+    @objc internal func prepareValuePxMatrix()
     {
         _rightAxisTransformer.prepareMatrixValuePx(chartXMin: _xAxis._axisMinimum, deltaX: CGFloat(xAxis.axisRange), deltaY: CGFloat(_rightAxis.axisRange), chartYMin: _rightAxis._axisMinimum)
         _leftAxisTransformer.prepareMatrixValuePx(chartXMin: xAxis._axisMinimum, deltaX: CGFloat(xAxis.axisRange), deltaY: CGFloat(_leftAxis.axisRange), chartYMin: _leftAxis._axisMinimum)
     }
     
-    internal func prepareOffsetMatrix()
+    @objc internal func prepareOffsetMatrix()
     {
         _rightAxisTransformer.prepareMatrixOffset(inverted: _rightAxis.isInverted)
         _leftAxisTransformer.prepareMatrixOffset(inverted: _leftAxis.isInverted)
@@ -470,7 +470,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// draws the grid background
-    internal func drawGridBackground(context: CGContext)
+    @objc internal func drawGridBackground(context: CGContext)
     {
         if drawGridBackgroundEnabled || drawBordersEnabled
         {
@@ -807,7 +807,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             getAxis(_closestDataSetToTouch.axisDependency).isInverted
     }
     
-    open func stopDeceleration()
+    @objc open func stopDeceleration()
     {
         if _decelerationDisplayLink !== nil
         {
@@ -960,7 +960,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// MARK: Viewport modifiers
     
     /// Zooms in by 1.4, into the charts center.
-    open func zoomIn()
+    @objc open func zoomIn()
     {
         let center = _viewPortHandler.contentCenter
         
@@ -973,7 +973,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// Zooms out by 0.7, from the charts center.
-    open func zoomOut()
+    @objc open func zoomOut()
     {
         let center = _viewPortHandler.contentCenter
         
@@ -986,7 +986,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// Zooms out to original size.
-    open func resetZoom()
+    @objc open func resetZoom()
     {
         let matrix = _viewPortHandler.resetZoom()
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
@@ -1003,7 +1003,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter scaleY: if < 1 --> zoom out, if > 1 --> zoom in
     /// - parameter x:
     /// - parameter y:
-    open func zoom(
+    @objc open func zoom(
         scaleX: CGFloat,
                scaleY: CGFloat,
                x: CGFloat,
@@ -1025,7 +1025,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter xValue:
     /// - parameter yValue:
     /// - parameter axis:
-    open func zoom(
+    @objc open func zoom(
         scaleX: CGFloat,
                scaleY: CGFloat,
                xValue: Double,
@@ -1051,7 +1051,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter xValue:
     /// - parameter yValue:
     /// - parameter axis:
-    open func zoomToCenter(
+    @objc open func zoomToCenter(
         scaleX: CGFloat,
                scaleY: CGFloat)
     {
@@ -1073,7 +1073,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func zoomAndCenterViewAnimated(
+    @objc open func zoomAndCenterViewAnimated(
         scaleX: CGFloat,
         scaleY: CGFloat,
         xValue: Double,
@@ -1115,7 +1115,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func zoomAndCenterViewAnimated(
+    @objc open func zoomAndCenterViewAnimated(
         scaleX: CGFloat,
         scaleY: CGFloat,
         xValue: Double,
@@ -1136,7 +1136,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func zoomAndCenterViewAnimated(
+    @objc open func zoomAndCenterViewAnimated(
         scaleX: CGFloat,
         scaleY: CGFloat,
         xValue: Double,
@@ -1148,7 +1148,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// Resets all zooming and dragging and makes the chart fit exactly it's bounds.
-    open func fitScreen()
+    @objc open func fitScreen()
     {
         let matrix = _viewPortHandler.fitScreen()
         let _ = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: false)
@@ -1158,13 +1158,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// Sets the minimum scale value to which can be zoomed out. 1 = fitScreen
-    open func setScaleMinima(_ scaleX: CGFloat, scaleY: CGFloat)
+    @objc open func setScaleMinima(_ scaleX: CGFloat, scaleY: CGFloat)
     {
         _viewPortHandler.setMinimumScaleX(scaleX)
         _viewPortHandler.setMinimumScaleY(scaleY)
     }
     
-    open var visibleXRange: Double
+    @objc open var visibleXRange: Double
     {
         return abs(highestVisibleX - lowestVisibleX)
     }
@@ -1174,7 +1174,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// If this is e.g. set to 10, no more than a range of 10 values on the x-axis can be viewed at once without scrolling.
     ///
     /// If you call this method, chart must have data or it has no effect.
-    open func setVisibleXRangeMaximum(_ maxXRange: Double)
+    @objc open func setVisibleXRangeMaximum(_ maxXRange: Double)
     {
         let xScale = _xAxis.axisRange / maxXRange
         _viewPortHandler.setMinimumScaleX(CGFloat(xScale))
@@ -1185,7 +1185,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// If this is e.g. set to 10, no less than a range of 10 values on the x-axis can be viewed at once without scrolling.
     ///
     /// If you call this method, chart must have data or it has no effect.
-    open func setVisibleXRangeMinimum(_ minXRange: Double)
+    @objc open func setVisibleXRangeMinimum(_ minXRange: Double)
     {
         let xScale = _xAxis.axisRange / minXRange
         _viewPortHandler.setMaximumScaleX(CGFloat(xScale))
@@ -1197,7 +1197,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// at once without scrolling.
     ///
     /// If you call this method, chart must have data or it has no effect.
-    open func setVisibleXRange(minXRange: Double, maxXRange: Double)
+    @objc open func setVisibleXRange(minXRange: Double, maxXRange: Double)
     {
         let minScale = _xAxis.axisRange / maxXRange
         let maxScale = _xAxis.axisRange / minXRange
@@ -1210,7 +1210,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     ///
     /// - parameter yRange:
     /// - parameter axis: - the axis for which this limit should apply
-    open func setVisibleYRangeMaximum(_ maxYRange: Double, axis: YAxis.AxisDependency)
+    @objc open func setVisibleYRangeMaximum(_ maxYRange: Double, axis: YAxis.AxisDependency)
     {
         let yScale = getAxisRange(axis: axis) / maxYRange
         _viewPortHandler.setMinimumScaleY(CGFloat(yScale))
@@ -1220,7 +1220,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     ///
     /// - parameter yRange:
     /// - parameter axis: - the axis for which this limit should apply
-    open func setVisibleYRangeMinimum(_ minYRange: Double, axis: YAxis.AxisDependency)
+    @objc open func setVisibleYRangeMinimum(_ minYRange: Double, axis: YAxis.AxisDependency)
     {
         let yScale = getAxisRange(axis: axis) / minYRange
         _viewPortHandler.setMaximumScaleY(CGFloat(yScale))
@@ -1231,7 +1231,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter minYRange:
     /// - parameter maxYRange:
     /// - parameter axis:
-    open func setVisibleYRange(minYRange: Double, maxYRange: Double, axis: YAxis.AxisDependency)
+    @objc open func setVisibleYRange(minYRange: Double, maxYRange: Double, axis: YAxis.AxisDependency)
     {
         let minScale = getAxisRange(axis: axis) / minYRange
         let maxScale = getAxisRange(axis: axis) / maxYRange
@@ -1240,7 +1240,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     
     /// Moves the left side of the current viewport to the specified x-value.
     /// This also refreshes the chart by calling setNeedsDisplay().
-    open func moveViewToX(_ xValue: Double)
+    @objc open func moveViewToX(_ xValue: Double)
     {
         let job = MoveViewJob(
             viewPortHandler: viewPortHandler,
@@ -1257,7 +1257,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// 
     /// - parameter yValue:
     /// - parameter axis: - which axis should be used as a reference for the y-axis
-    open func moveViewToY(_ yValue: Double, axis: YAxis.AxisDependency)
+    @objc open func moveViewToY(_ yValue: Double, axis: YAxis.AxisDependency)
     {
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
         
@@ -1277,7 +1277,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter xValue:
     /// - parameter yValue:
     /// - parameter axis: - which axis should be used as a reference for the y-axis
-    open func moveViewTo(xValue: Double, yValue: Double, axis: YAxis.AxisDependency)
+    @objc open func moveViewTo(xValue: Double, yValue: Double, axis: YAxis.AxisDependency)
     {
         let yInView = getAxisRange(axis: axis) / Double(_viewPortHandler.scaleY)
         
@@ -1299,7 +1299,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func moveViewToAnimated(
+    @objc open func moveViewToAnimated(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency,
@@ -1334,7 +1334,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func moveViewToAnimated(
+    @objc open func moveViewToAnimated(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency,
@@ -1352,7 +1352,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func moveViewToAnimated(
+    @objc open func moveViewToAnimated(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency,
@@ -1367,7 +1367,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter xValue:
     /// - parameter yValue:
     /// - parameter axis: - which axis should be used as a reference for the y-axis
-    open func centerViewTo(
+    @objc open func centerViewTo(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency)
@@ -1392,7 +1392,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func centerViewToAnimated(
+    @objc open func centerViewToAnimated(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency,
@@ -1427,7 +1427,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func centerViewToAnimated(
+    @objc open func centerViewToAnimated(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency,
@@ -1444,7 +1444,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// - parameter axis: which axis should be used as a reference for the y-axis
     /// - parameter duration: the duration of the animation in seconds
     /// - parameter easing:
-    open func centerViewToAnimated(
+    @objc open func centerViewToAnimated(
         xValue: Double,
         yValue: Double,
         axis: YAxis.AxisDependency,
@@ -1455,7 +1455,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 
     /// Sets custom offsets for the current `ChartViewPort` (the offsets on the sides of the actual chart window). Setting this will prevent the chart from automatically calculating it's offsets. Use `resetViewPortOffsets()` to undo this.
     /// ONLY USE THIS WHEN YOU KNOW WHAT YOU ARE DOING, else use `setExtraOffsets(...)`.
-    open func setViewPortOffsets(left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
+    @objc open func setViewPortOffsets(left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         _customViewPortEnabled = true
         
@@ -1474,7 +1474,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// Resets all custom offsets set via `setViewPortOffsets(...)` method. Allows the chart to again calculate all offsets automatically.
-    open func resetViewPortOffsets()
+    @objc open func resetViewPortOffsets()
     {
         _customViewPortEnabled = false
         calculateOffsets()
@@ -1483,7 +1483,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     // MARK: - Accessors
     
     /// - returns: The range of the specified axis.
-    open func getAxisRange(axis: YAxis.AxisDependency) -> Double
+    @objc open func getAxisRange(axis: YAxis.AxisDependency) -> Double
     {
         if axis == .left
         {
@@ -1496,7 +1496,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// - returns: The position (in pixels) the provided Entry has inside the chart view
-    open func getPosition(entry e: ChartDataEntry, axis: YAxis.AxisDependency) -> CGPoint
+    @objc open func getPosition(entry e: ChartDataEntry, axis: YAxis.AxisDependency) -> CGPoint
     {
         var vals = CGPoint(x: CGFloat(e.x), y: CGFloat(e.y))
 
@@ -1506,7 +1506,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// is dragging enabled? (moving the chart with the finger) for the chart (this does not affect scaling).
-    open var dragEnabled: Bool
+    @objc open var dragEnabled: Bool
     {
         get
         {
@@ -1522,13 +1522,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// is dragging enabled? (moving the chart with the finger) for the chart (this does not affect scaling).
-    open var isDragEnabled: Bool
+    @objc open var isDragEnabled: Bool
     {
         return dragEnabled
     }
     
     /// is scaling enabled? (zooming in and out by gesture) for the chart (this does not affect dragging).
-    open func setScaleEnabled(_ enabled: Bool)
+    @objc open func setScaleEnabled(_ enabled: Bool)
     {
         if _scaleXEnabled != enabled || _scaleYEnabled != enabled
         {
@@ -1540,7 +1540,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    open var scaleXEnabled: Bool
+    @objc open var scaleXEnabled: Bool
     {
         get
         {
@@ -1558,7 +1558,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    open var scaleYEnabled: Bool
+    @objc open var scaleYEnabled: Bool
     {
         get
         {
@@ -1576,11 +1576,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    open var isScaleXEnabled: Bool { return scaleXEnabled }
-    open var isScaleYEnabled: Bool { return scaleYEnabled }
+    @objc open var isScaleXEnabled: Bool { return scaleXEnabled }
+    @objc open var isScaleYEnabled: Bool { return scaleYEnabled }
     
     /// flag that indicates if double tap zoom is enabled or not
-    open var doubleTapToZoomEnabled: Bool
+    @objc open var doubleTapToZoomEnabled: Bool
     {
         get
         {
@@ -1598,33 +1598,33 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     
     /// **default**: true
     /// - returns: `true` if zooming via double-tap is enabled `false` ifnot.
-    open var isDoubleTapToZoomEnabled: Bool
+    @objc open var isDoubleTapToZoomEnabled: Bool
     {
         return doubleTapToZoomEnabled
     }
     
     /// flag that indicates if highlighting per dragging over a fully zoomed out chart is enabled
-    open var highlightPerDragEnabled = true
+    @objc open var highlightPerDragEnabled = true
     
     /// If set to true, highlighting per dragging over a fully zoomed out chart is enabled
     /// You might want to disable this when using inside a `NSUIScrollView`
     /// 
     /// **default**: true
-    open var isHighlightPerDragEnabled: Bool
+    @objc open var isHighlightPerDragEnabled: Bool
     {
         return highlightPerDragEnabled
     }
     
     /// **default**: true
     /// - returns: `true` if drawing the grid background is enabled, `false` ifnot.
-    open var isDrawGridBackgroundEnabled: Bool
+    @objc open var isDrawGridBackgroundEnabled: Bool
     {
         return drawGridBackgroundEnabled
     }
     
     /// **default**: false
     /// - returns: `true` if drawing the borders rectangle is enabled, `false` ifnot.
-    open var isDrawBordersEnabled: Bool
+    @objc open var isDrawBordersEnabled: Bool
     {
         return drawBordersEnabled
     }
@@ -1633,20 +1633,20 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// (encapsulated in a `CGPoint`). This method transforms pixel coordinates to
     /// coordinates / values in the chart. This is the opposite method to
     /// `getPixelsForValues(...)`.
-    open func valueForTouchPoint(point pt: CGPoint, axis: YAxis.AxisDependency) -> CGPoint
+    @objc open func valueForTouchPoint(point pt: CGPoint, axis: YAxis.AxisDependency) -> CGPoint
     {
         return getTransformer(forAxis: axis).valueForTouchPoint(pt)
     }
 
     /// Transforms the given chart values into pixels. This is the opposite
     /// method to `valueForTouchPoint(...)`.
-    open func pixelForValues(x: Double, y: Double, axis: YAxis.AxisDependency) -> CGPoint
+    @objc open func pixelForValues(x: Double, y: Double, axis: YAxis.AxisDependency) -> CGPoint
     {
         return getTransformer(forAxis: axis).pixelForValues(x: x, y: y)
     }
     
     /// - returns: The Entry object displayed at the touched position of the chart
-    open func getEntryByTouchPoint(point pt: CGPoint) -> ChartDataEntry!
+    @objc open func getEntryByTouchPoint(point pt: CGPoint) -> ChartDataEntry!
     {
         if let h = getHighlightByTouchPoint(pt)
         {
@@ -1656,7 +1656,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// - returns: The DataSet object displayed at the touched position of the chart
-    open func getDataSetByTouchPoint(point pt: CGPoint) -> IBarLineScatterCandleBubbleChartDataSet!
+    @objc open func getDataSetByTouchPoint(point pt: CGPoint) -> IBarLineScatterCandleBubbleChartDataSet!
     {
         let h = getHighlightByTouchPoint(pt)
         if h !== nil
@@ -1667,7 +1667,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// - returns: The current x-scale factor
-    open var scaleX: CGFloat
+    @objc open var scaleX: CGFloat
     {
         if _viewPortHandler === nil
         {
@@ -1677,7 +1677,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// - returns: The current y-scale factor
-    open var scaleY: CGFloat
+    @objc open var scaleY: CGFloat
     {
         if _viewPortHandler === nil
         {
@@ -1687,22 +1687,22 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// if the chart is fully zoomed out, return true
-    open var isFullyZoomedOut: Bool { return _viewPortHandler.isFullyZoomedOut }
+    @objc open var isFullyZoomedOut: Bool { return _viewPortHandler.isFullyZoomedOut }
 
     /// - returns: The left y-axis object. In the horizontal bar-chart, this is the
     /// top axis.
-    open var leftAxis: YAxis
+    @objc open var leftAxis: YAxis
     {
         return _leftAxis
     }
 
     /// - returns: The right y-axis object. In the horizontal bar-chart, this is the
     /// bottom axis.
-    open var rightAxis: YAxis { return _rightAxis }
+    @objc open var rightAxis: YAxis { return _rightAxis }
 
     /// - returns: The y-axis object to the corresponding AxisDependency. In the
     /// horizontal bar-chart, LEFT == top, RIGHT == BOTTOM
-    open func getAxis(_ axis: YAxis.AxisDependency) -> YAxis
+    @objc open func getAxis(_ axis: YAxis.AxisDependency) -> YAxis
     {
         if axis == .left
         {
@@ -1715,7 +1715,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// flag that indicates if pinch-zoom is enabled. if true, both x and y axis can be scaled simultaneously with 2 fingers, if false, x and y axis can be scaled separately
-    open var pinchZoomEnabled: Bool
+    @objc open var pinchZoomEnabled: Bool
     {
         get
         {
@@ -1735,29 +1735,29 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 
     /// **default**: false
     /// - returns: `true` if pinch-zoom is enabled, `false` ifnot
-    open var isPinchZoomEnabled: Bool { return pinchZoomEnabled }
+    @objc open var isPinchZoomEnabled: Bool { return pinchZoomEnabled }
 
     /// Set an offset in dp that allows the user to drag the chart over it's
     /// bounds on the x-axis.
-    open func setDragOffsetX(_ offset: CGFloat)
+    @objc open func setDragOffsetX(_ offset: CGFloat)
     {
         _viewPortHandler.setDragOffsetX(offset)
     }
 
     /// Set an offset in dp that allows the user to drag the chart over it's
     /// bounds on the y-axis.
-    open func setDragOffsetY(_ offset: CGFloat)
+    @objc open func setDragOffsetY(_ offset: CGFloat)
     {
         _viewPortHandler.setDragOffsetY(offset)
     }
 
     /// - returns: `true` if both drag offsets (x and y) are zero or smaller.
-    open var hasNoDragOffset: Bool { return _viewPortHandler.hasNoDragOffset }
+    @objc open var hasNoDragOffset: Bool { return _viewPortHandler.hasNoDragOffset }
 
     /// The X axis renderer. This is a read-write property so you can set your own custom renderer here.
     /// **default**: An instance of XAxisRenderer
     /// - returns: The current set X axis renderer
-    open var xAxisRenderer: XAxisRenderer
+    @objc open var xAxisRenderer: XAxisRenderer
     {
         get { return _xAxisRenderer }
         set { _xAxisRenderer = newValue }
@@ -1766,7 +1766,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// The left Y axis renderer. This is a read-write property so you can set your own custom renderer here.
     /// **default**: An instance of YAxisRenderer
     /// - returns: The current set left Y axis renderer
-    open var leftYAxisRenderer: YAxisRenderer
+    @objc open var leftYAxisRenderer: YAxisRenderer
     {
         get { return _leftYAxisRenderer }
         set { _leftYAxisRenderer = newValue }
@@ -1775,7 +1775,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// The right Y axis renderer. This is a read-write property so you can set your own custom renderer here.
     /// **default**: An instance of YAxisRenderer
     /// - returns: The current set right Y axis renderer
-    open var rightYAxisRenderer: YAxisRenderer
+    @objc open var rightYAxisRenderer: YAxisRenderer
     {
         get { return _rightYAxisRenderer }
         set { _rightYAxisRenderer = newValue }
@@ -1792,14 +1792,14 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// - returns: `true` if either the left or the right or both axes are inverted.
-    open var isAnyAxisInverted: Bool
+    @objc open var isAnyAxisInverted: Bool
     {
         return _leftAxis.isInverted || _rightAxis.isInverted
     }
     
     /// flag that indicates if auto scaling on the y axis is enabled.
     /// if yes, the y axis automatically adjusts to the min and max y values of the current x axis range whenever the viewport changes
-    open var autoScaleMinMaxEnabled: Bool
+    @objc open var autoScaleMinMaxEnabled: Bool
     {
         get { return _autoScaleMinMaxEnabled }
         set { _autoScaleMinMaxEnabled = newValue }
@@ -1807,10 +1807,10 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     
     /// **default**: false
     /// - returns: `true` if auto scaling on the y axis is enabled.
-    open var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled }
+    @objc open var isAutoScaleMinMaxEnabled : Bool { return autoScaleMinMaxEnabled }
     
     /// Sets a minimum width to the specified y axis.
-    open func setYAxisMinWidth(_ axis: YAxis.AxisDependency, width: CGFloat)
+    @objc open func setYAxisMinWidth(_ axis: YAxis.AxisDependency, width: CGFloat)
     {
         if axis == .left
         {
@@ -1824,7 +1824,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     
     /// **default**: 0.0
     /// - returns: The (custom) minimum width of the specified Y axis.
-    open func getYAxisMinWidth(_ axis: YAxis.AxisDependency) -> CGFloat
+    @objc open func getYAxisMinWidth(_ axis: YAxis.AxisDependency) -> CGFloat
     {
         if axis == .left
         {
@@ -1837,7 +1837,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     /// Sets a maximum width to the specified y axis.
     /// Zero (0.0) means there's no maximum width
-    open func setYAxisMaxWidth(_ axis: YAxis.AxisDependency, width: CGFloat)
+    @objc open func setYAxisMaxWidth(_ axis: YAxis.AxisDependency, width: CGFloat)
     {
         if axis == .left
         {
@@ -1853,7 +1853,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     ///
     /// **default**: 0.0 (no maximum specified)
     /// - returns: The (custom) maximum width of the specified Y axis.
-    open func getYAxisMaxWidth(_ axis: YAxis.AxisDependency) -> CGFloat
+    @objc open func getYAxisMaxWidth(_ axis: YAxis.AxisDependency) -> CGFloat
     {
         if axis == .left
         {
@@ -1866,7 +1866,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
 
     /// - returns the width of the specified y axis.
-    open func getYAxisWidth(_ axis: YAxis.AxisDependency) -> CGFloat
+    @objc open func getYAxisWidth(_ axis: YAxis.AxisDependency) -> CGFloat
     {
         if axis == .left
         {

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -42,39 +42,39 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - returns: The object representing all x-labels, this method can be used to
     /// acquire the XAxis object and modify it (e.g. change the position of the
     /// labels)
-    open var xAxis: XAxis
+    @objc open var xAxis: XAxis
     {
         return _xAxis
     }
     
     /// The default IValueFormatter that has been determined by the chart considering the provided minimum and maximum values.
-    internal var _defaultValueFormatter: IValueFormatter? = DefaultValueFormatter(decimals: 0)
+    @objc internal var _defaultValueFormatter: IValueFormatter? = DefaultValueFormatter(decimals: 0)
     
     /// object that holds all data that was originally set for the chart, before it was modified or any filtering algorithms had been applied
-    internal var _data: ChartData?
+    @objc internal var _data: ChartData?
     
     /// Flag that indicates if highlighting per tap (touch) is enabled
     fileprivate var _highlightPerTapEnabled = true
     
     /// If set to true, chart continues to scroll after touch up
-    open var dragDecelerationEnabled = true
+    @objc open var dragDecelerationEnabled = true
     
     /// Deceleration friction coefficient in [0 ; 1] interval, higher values indicate that speed will decrease slowly, for example if it set to 0, it will stop immediately.
     /// 1 is an invalid value, and will be converted to 0.999 automatically.
     fileprivate var _dragDecelerationFrictionCoef: CGFloat = 0.9
     
     /// if true, units are drawn next to the values in the chart
-    internal var _drawUnitInChart = false
+    @objc internal var _drawUnitInChart = false
     
     /// The object representing the labels on the x-axis
-    internal var _xAxis: XAxis!
+    @objc internal var _xAxis: XAxis!
     
     /// The `Description` object of the chart.
     /// This should have been called just "description", but
-    open var chartDescription: Description?
+    @objc open var chartDescription: Description?
     
     /// This property is deprecated - Use `chartDescription.text` instead.
-    @available(*, deprecated: 1.0, message: "Use `chartDescription.text` instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use `chartDescription.text` instead.")
     open var descriptionText: String
     {
         get { return chartDescription?.text ?? "" }
@@ -82,7 +82,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// This property is deprecated - Use `chartDescription.font` instead.
-    @available(*, deprecated: 1.0, message: "Use `chartDescription.font` instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use `chartDescription.font` instead.")
     open var descriptionFont: NSUIFont?
     {
         get { return chartDescription?.font }
@@ -96,7 +96,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// This property is deprecated - Use `chartDescription.textColor` instead.
-    @available(*, deprecated: 1.0, message: "Use `chartDescription.textColor` instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use `chartDescription.textColor` instead.")
     open var descriptionTextColor: NSUIColor?
     {
         get { return chartDescription?.textColor }
@@ -110,7 +110,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// This property is deprecated - Use `chartDescription.textAlign` instead.
-    @available(*, deprecated: 1.0, message: "Use `chartDescription.textAlign` instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use `chartDescription.textAlign` instead.")
     open var descriptionTextAlign: NSTextAlignment
     {
         get { return chartDescription?.textAlign ?? NSTextAlignment.right }
@@ -126,65 +126,65 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// The legend object containing all data associated with the legend
-    internal var _legend: Legend!
+    @objc internal var _legend: Legend!
     
     /// delegate to receive chart events
-    open weak var delegate: ChartViewDelegate?
+    @objc open weak var delegate: ChartViewDelegate?
     
     /// text that is displayed when the chart is empty
-    open var noDataText = "No chart data available."
+    @objc open var noDataText = "No chart data available."
     
     /// Font to be used for the no data text.
-    open var noDataFont: NSUIFont! = NSUIFont(name: "HelveticaNeue", size: 12.0)
+    @objc open var noDataFont: NSUIFont! = NSUIFont(name: "HelveticaNeue", size: 12.0)
     
     /// color of the no data text
-    open var noDataTextColor: NSUIColor = NSUIColor.black
+    @objc open var noDataTextColor: NSUIColor = NSUIColor.black
     
-    internal var _legendRenderer: LegendRenderer!
+    @objc internal var _legendRenderer: LegendRenderer!
     
     /// object responsible for rendering the data
-    open var renderer: DataRenderer?
+    @objc open var renderer: DataRenderer?
     
-    open var highlighter: IHighlighter?
+    @objc open var highlighter: IHighlighter?
     
     /// object that manages the bounds and drawing constraints of the chart
-    internal var _viewPortHandler: ViewPortHandler!
+    @objc internal var _viewPortHandler: ViewPortHandler!
     
     /// object responsible for animations
-    internal var _animator: Animator!
+    @objc internal var _animator: Animator!
     
     /// flag that indicates if offsets calculation has already been done or not
     fileprivate var _offsetsCalculated = false
 	
     /// array of Highlight objects that reference the highlighted slices in the chart
-    internal var _indicesToHighlight = [Highlight]()
+    @objc internal var _indicesToHighlight = [Highlight]()
     
     /// `true` if drawing the marker is enabled when tapping on values
     /// (use the `marker` property to specify a marker)
-    open var drawMarkers = true
+    @objc open var drawMarkers = true
     
     /// - returns: `true` if drawing the marker is enabled when tapping on values
     /// (use the `marker` property to specify a marker)
-    open var isDrawMarkersEnabled: Bool { return drawMarkers }
+    @objc open var isDrawMarkersEnabled: Bool { return drawMarkers }
     
     /// The marker that is displayed when a value is clicked on the chart
-    open var marker: IMarker?
+    @objc open var marker: IMarker?
     
     fileprivate var _interceptTouchEvents = false
     
     /// An extra offset to be appended to the viewport's top
-    open var extraTopOffset: CGFloat = 0.0
+    @objc open var extraTopOffset: CGFloat = 0.0
     
     /// An extra offset to be appended to the viewport's right
-    open var extraRightOffset: CGFloat = 0.0
+    @objc open var extraRightOffset: CGFloat = 0.0
     
     /// An extra offset to be appended to the viewport's bottom
-    open var extraBottomOffset: CGFloat = 0.0
+    @objc open var extraBottomOffset: CGFloat = 0.0
     
     /// An extra offset to be appended to the viewport's left
-    open var extraLeftOffset: CGFloat = 0.0
+    @objc open var extraLeftOffset: CGFloat = 0.0
     
-    open func setExtraOffsets(left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
+    @objc open func setExtraOffsets(left: CGFloat, top: CGFloat, right: CGFloat, bottom: CGFloat)
     {
         extraLeftOffset = left
         extraTopOffset = top
@@ -212,7 +212,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         self.removeObserver(self, forKeyPath: "frame")
     }
     
-    internal func initialize()
+    @objc internal func initialize()
     {
         #if os(iOS)
             self.backgroundColor = NSUIColor.clear
@@ -271,7 +271,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// Clears the chart from all data (sets it to null) and refreshes it (by calling setNeedsDisplay()).
-    open func clear()
+    @objc open func clear()
     {
         _data = nil
         _offsetsCalculated = false
@@ -282,14 +282,14 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// Removes all DataSets (and thereby Entries) from the chart. Does not set the data object to nil. Also refreshes the chart by calling setNeedsDisplay().
-    open func clearValues()
+    @objc open func clearValues()
     {
         _data?.clearValues()
         setNeedsDisplay()
     }
 
     /// - returns: `true` if the chart is empty (meaning it's data object is either null or contains no entries).
-    open func isEmpty() -> Bool
+    @objc open func isEmpty() -> Bool
     {
         guard let data = _data else { return true }
 
@@ -305,25 +305,25 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     
     /// Lets the chart know its underlying data has changed and should perform all necessary recalculations.
     /// It is crucial that this method is called everytime data is changed dynamically. Not calling this method can lead to crashes or unexpected behaviour.
-    open func notifyDataSetChanged()
+    @objc open func notifyDataSetChanged()
     {
         fatalError("notifyDataSetChanged() cannot be called on ChartViewBase")
     }
     
     /// Calculates the offsets of the chart to the border depending on the position of an eventual legend or depending on the length of the y-axis and x-axis labels and their position
-    internal func calculateOffsets()
+    @objc internal func calculateOffsets()
     {
         fatalError("calculateOffsets() cannot be called on ChartViewBase")
     }
     
     /// calcualtes the y-min and y-max value and the y-delta and x-delta value
-    internal func calcMinMax()
+    @objc internal func calcMinMax()
     {
         fatalError("calcMinMax() cannot be called on ChartViewBase")
     }
     
     /// calculates the required number of digits for the values that might be drawn in the chart (if enabled), and creates the default value formatter
-    internal func setupDefaultFormatter(min: Double, max: Double)
+    @objc internal func setupDefaultFormatter(min: Double, max: Double)
     {
         // check if a custom formatter is set or not
         var reference = Double(0.0)
@@ -367,8 +367,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 text: noDataText,
                 point: CGPoint(x: frame.width / 2.0, y: frame.height / 2.0),
                 attributes:
-                [NSFontAttributeName: noDataFont,
-                 NSForegroundColorAttributeName: noDataTextColor],
+                [NSAttributedStringKey.font.rawValue: noDataFont,
+                 NSAttributedStringKey.foregroundColor.rawValue: noDataTextColor],
                 constrainedToSize: self.bounds.size,
                 anchor: CGPoint(x: 0.5, y: 0.5),
                 angleRadians: 0.0)
@@ -384,7 +384,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// Draws the description text in the bottom right corner of the chart (per default)
-    internal func drawDescription(context: CGContext)
+    @objc internal func drawDescription(context: CGContext)
     {
         // check if description should be drawn
         guard
@@ -407,8 +407,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         
         var attrs = [String : AnyObject]()
         
-        attrs[NSFontAttributeName] = description.font
-        attrs[NSForegroundColorAttributeName] = description.textColor
+        attrs[NSAttributedStringKey.font] = description.font
+        attrs[NSAttributedStringKey.foregroundColor] = description.textColor
 
         ChartUtils.drawText(
             context: context,
@@ -421,7 +421,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     // MARK: - Highlighting
     
     /// - returns: The array of currently highlighted values. This might an empty if nothing is highlighted.
-    open var highlighted: [Highlight]
+    @objc open var highlighted: [Highlight]
     {
         return _indicesToHighlight
     }
@@ -429,21 +429,21 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// Set this to false to prevent values from being highlighted by tap gesture.
     /// Values can still be highlighted via drag or programmatically.
     /// **default**: true
-    open var highlightPerTapEnabled: Bool
+    @objc open var highlightPerTapEnabled: Bool
     {
         get { return _highlightPerTapEnabled }
         set { _highlightPerTapEnabled = newValue }
     }
     
     /// - returns: `true` if values can be highlighted via tap gesture, `false` ifnot.
-    open var isHighLightPerTapEnabled: Bool
+    @objc open var isHighLightPerTapEnabled: Bool
     {
         return highlightPerTapEnabled
     }
     
     /// Checks if the highlight array is null, has a length of zero or if the first object is null.
     /// - returns: `true` if there are values to highlight, `false` ifthere are no values to highlight.
-    open func valuesToHighlight() -> Bool
+    @objc open func valuesToHighlight() -> Bool
     {
         return _indicesToHighlight.count > 0
     }
@@ -452,7 +452,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// null or an empty array to undo all highlighting. 
     /// This should be used to programmatically highlight values.
     /// This method *will not* call the delegate.
-    open func highlightValues(_ highs: [Highlight]?)
+    @objc open func highlightValues(_ highs: [Highlight]?)
     {
         // set the indices to highlight
         _indicesToHighlight = highs ?? [Highlight]()
@@ -475,7 +475,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// This method will call the delegate.
     /// - parameter x: The x-value to highlight
     /// - parameter dataSetIndex: The dataset index to search in
-    open func highlightValue(x: Double, dataSetIndex: Int)
+    @objc open func highlightValue(x: Double, dataSetIndex: Int)
     {
         highlightValue(x: x, dataSetIndex: dataSetIndex, callDelegate: true)
     }
@@ -486,7 +486,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter x: The x-value to highlight
     /// - parameter y: The y-value to highlight. Supply `NaN` for "any"
     /// - parameter dataSetIndex: The dataset index to search in
-    open func highlightValue(x: Double, y: Double, dataSetIndex: Int)
+    @objc open func highlightValue(x: Double, y: Double, dataSetIndex: Int)
     {
         highlightValue(x: x, y: y, dataSetIndex: dataSetIndex, callDelegate: true)
     }
@@ -496,7 +496,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter x: The x-value to highlight
     /// - parameter dataSetIndex: The dataset index to search in
     /// - parameter callDelegate: Should the delegate be called for this change
-    open func highlightValue(x: Double, dataSetIndex: Int, callDelegate: Bool)
+    @objc open func highlightValue(x: Double, dataSetIndex: Int, callDelegate: Bool)
     {
         highlightValue(x: x, y: Double.nan, dataSetIndex: dataSetIndex, callDelegate: callDelegate)
     }
@@ -507,7 +507,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter y: The y-value to highlight. Supply `NaN` for "any"
     /// - parameter dataSetIndex: The dataset index to search in
     /// - parameter callDelegate: Should the delegate be called for this change
-    open func highlightValue(x: Double, y: Double, dataSetIndex: Int, callDelegate: Bool)
+    @objc open func highlightValue(x: Double, y: Double, dataSetIndex: Int, callDelegate: Bool)
     {
         guard let data = _data else
         {
@@ -528,13 +528,13 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// Highlights the values represented by the provided Highlight object
     /// This method *will not* call the delegate.
     /// - parameter highlight: contains information about which entry should be highlighted
-    open func highlightValue(_ highlight: Highlight?)
+    @objc open func highlightValue(_ highlight: Highlight?)
     {
         highlightValue(highlight, callDelegate: false)
     }
 
     /// Highlights the value selected by touch gesture.
-    open func highlightValue(_ highlight: Highlight?, callDelegate: Bool)
+    @objc open func highlightValue(_ highlight: Highlight?, callDelegate: Bool)
     {
         var entry: ChartDataEntry?
         var h = highlight
@@ -578,7 +578,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - returns: The Highlight object (contains x-index and DataSet index) of the
     /// selected value at the given touch point inside the Line-, Scatter-, or
     /// CandleStick-Chart.
-    open func getHighlightByTouchPoint(_ pt: CGPoint) -> Highlight?
+    @objc open func getHighlightByTouchPoint(_ pt: CGPoint) -> Highlight?
     {
         if _data === nil
         {
@@ -590,12 +590,12 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
 
     /// The last value that was highlighted via touch.
-    open var lastHighlighted: Highlight?
+    @objc open var lastHighlighted: Highlight?
   
     // MARK: - Markers
 
     /// draws all MarkerViews on the highlighted positions
-    internal func drawMarkers(context: CGContext)
+    @objc internal func drawMarkers(context: CGContext)
     {
         // if there is no marker view or drawing marker is disabled
         guard
@@ -636,7 +636,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// - returns: The actual position in pixels of the MarkerView for the given Entry in the given DataSet.
-    open func getMarkerPosition(highlight: Highlight) -> CGPoint
+    @objc open func getMarkerPosition(highlight: Highlight) -> CGPoint
     {
         return CGPoint(x: highlight.drawX, y: highlight.drawY)
     }
@@ -644,7 +644,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     // MARK: - Animation
     
     /// - returns: The animator responsible for animating chart values.
-    open var chartAnimator: Animator!
+    @objc open var chartAnimator: Animator!
     {
         return _animator
     }
@@ -655,7 +655,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingX: an easing function for the animation on the x axis
     /// - parameter easingY: an easing function for the animation on the y axis
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingX: ChartEasingFunctionBlock?, easingY: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingX: easingX, easingY: easingY)
     }
@@ -666,7 +666,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOptionX: the easing function for the animation on the x axis
     /// - parameter easingOptionY: the easing function for the animation on the y axis
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOptionX: ChartEasingOption, easingOptionY: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOptionX: easingOptionX, easingOptionY: easingOptionY)
     }
@@ -676,7 +676,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easing: easing)
     }
@@ -686,7 +686,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration, easingOption: easingOption)
     }
@@ -695,7 +695,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter yAxisDuration: duration for animating the y axis
-    open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval)
+    @objc open func animate(xAxisDuration: TimeInterval, yAxisDuration: TimeInterval)
     {
         _animator.animate(xAxisDuration: xAxisDuration, yAxisDuration: yAxisDuration)
     }
@@ -704,7 +704,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easing: an easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
+    @objc open func animate(xAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(xAxisDuration: xAxisDuration, easing: easing)
     }
@@ -713,7 +713,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
     /// - parameter easingOption: the easing function for the animation
-    open func animate(xAxisDuration: TimeInterval, easingOption: ChartEasingOption)
+    @objc open func animate(xAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(xAxisDuration: xAxisDuration, easingOption: easingOption)
     }
@@ -721,7 +721,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// Animates the drawing / rendering of the chart the x-axis with the specified animation time.
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter xAxisDuration: duration for animating the x axis
-    open func animate(xAxisDuration: TimeInterval)
+    @objc open func animate(xAxisDuration: TimeInterval)
     {
         _animator.animate(xAxisDuration: xAxisDuration)
     }
@@ -730,7 +730,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easing: an easing function for the animation
-    open func animate(yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
+    @objc open func animate(yAxisDuration: TimeInterval, easing: ChartEasingFunctionBlock?)
     {
         _animator.animate(yAxisDuration: yAxisDuration, easing: easing)
     }
@@ -739,7 +739,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
     /// - parameter easingOption: the easing function for the animation
-    open func animate(yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
+    @objc open func animate(yAxisDuration: TimeInterval, easingOption: ChartEasingOption)
     {
         _animator.animate(yAxisDuration: yAxisDuration, easingOption: easingOption)
     }
@@ -747,7 +747,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// Animates the drawing / rendering of the chart the y-axis with the specified animation time.
     /// If `animate(...)` is called, no further calling of `invalidate()` is necessary to refresh the chart.
     /// - parameter yAxisDuration: duration for animating the y axis
-    open func animate(yAxisDuration: TimeInterval)
+    @objc open func animate(yAxisDuration: TimeInterval)
     {
         _animator.animate(yAxisDuration: yAxisDuration)
     }
@@ -784,7 +784,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// *
     /// - note: (Equivalent of getCenter() in MPAndroidChart, as center is already a standard in iOS that returns the center point relative to superview, and MPAndroidChart returns relative to self)*
     /// - returns: The center point of the chart (the whole View) in pixels.
-    open var midPoint: CGPoint
+    @objc open var midPoint: CGPoint
     {
         let bounds = self.bounds
         return CGPoint(x: bounds.origin.x + bounds.size.width / 2.0, y: bounds.origin.y + bounds.size.height / 2.0)
@@ -797,32 +797,32 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// - returns: The Legend object of the chart. This method can be used to get an instance of the legend in order to customize the automatically generated Legend.
-    open var legend: Legend
+    @objc open var legend: Legend
     {
         return _legend
     }
     
     /// - returns: The renderer object responsible for rendering / drawing the Legend.
-    open var legendRenderer: LegendRenderer!
+    @objc open var legendRenderer: LegendRenderer!
     {
         return _legendRenderer
     }
     
     /// - returns: The rectangle that defines the borders of the chart-value surface (into which the actual values are drawn).
-    open var contentRect: CGRect
+    @objc open var contentRect: CGRect
     {
         return _viewPortHandler.contentRect
     }
     
     /// - returns: The ViewPortHandler of the chart that is responsible for the
     /// content area of the chart and its offsets and dimensions.
-    open var viewPortHandler: ViewPortHandler!
+    @objc open var viewPortHandler: ViewPortHandler!
     {
         return _viewPortHandler
     }
     
     /// - returns: The bitmap that represents the chart.
-    open func getChartImage(transparent: Bool) -> NSUIImage?
+    @objc open func getChartImage(transparent: Bool) -> NSUIImage?
     {
         NSUIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque || !transparent, NSUIMainScreen()?.nsuiScale ?? 1.0)
         
@@ -898,7 +898,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
 		return true
     }
     
-    internal var _viewportJobs = [ViewPortJob]()
+    @objc internal var _viewportJobs = [ViewPortJob]()
     
     open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?)
     {
@@ -926,7 +926,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         }
     }
     
-    open func removeViewportJob(_ job: ViewPortJob)
+    @objc open func removeViewportJob(_ job: ViewPortJob)
     {
         if let index = _viewportJobs.index(where: { $0 === job })
         {
@@ -934,12 +934,12 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         }
     }
     
-    open func clearAllViewportJobs()
+    @objc open func clearAllViewportJobs()
     {
         _viewportJobs.removeAll(keepingCapacity: false)
     }
     
-    open func addViewportJob(_ job: ViewPortJob)
+    @objc open func addViewportJob(_ job: ViewPortJob)
     {
         if _viewPortHandler.hasChartDimens
         {
@@ -953,7 +953,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     
     /// **default**: true
     /// - returns: `true` if chart continues to scroll after touch up, `false` ifnot.
-    open var isDragDecelerationEnabled: Bool
+    @objc open var isDragDecelerationEnabled: Bool
         {
             return dragDecelerationEnabled
     }
@@ -962,7 +962,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// 1 is an invalid value, and will be converted to 0.999 automatically.
     /// 
     /// **default**: true
-    open var dragDecelerationFrictionCoef: CGFloat
+    @objc open var dragDecelerationFrictionCoef: CGFloat
     {
         get
         {

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -367,8 +367,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 text: noDataText,
                 point: CGPoint(x: frame.width / 2.0, y: frame.height / 2.0),
                 attributes:
-                [NSAttributedStringKey.font.rawValue: noDataFont,
-                 NSAttributedStringKey.foregroundColor.rawValue: noDataTextColor],
+                [NSAttributedStringKey.font: noDataFont,
+                 NSAttributedStringKey.foregroundColor: noDataTextColor],
                 constrainedToSize: self.bounds.size,
                 anchor: CGPoint(x: 0.5, y: 0.5),
                 angleRadians: 0.0)
@@ -405,7 +405,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 y: frame.height - _viewPortHandler.offsetBottom - description.yOffset - description.font.lineHeight)
         }
         
-        var attrs = [String : AnyObject]()
+        var attrs = [NSAttributedStringKey : Any]()
         
         attrs[NSAttributedStringKey.font] = description.font
         attrs[NSAttributedStringKey.foregroundColor] = description.textColor

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -16,7 +16,7 @@ import CoreGraphics
 open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
 {
     /// the fill-formatter used for determining the position of the fill-line
-    internal var _fillFormatter: IFillFormatter!
+    @objc internal var _fillFormatter: IFillFormatter!
     
     /// enum that allows to specify the order in which the different data objects for the combined-chart are drawn
     @objc(CombinedChartDrawOrder)
@@ -60,7 +60,7 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
         }
     }
     
-    open var fillFormatter: IFillFormatter
+    @objc open var fillFormatter: IFillFormatter
     {
         get
         {
@@ -183,14 +183,14 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
     // MARK: - Accessors
     
     /// if set to true, all values are drawn above their bars, instead of below their top
-    open var drawValueAboveBarEnabled: Bool
+    @objc open var drawValueAboveBarEnabled: Bool
         {
         get { return (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled }
         set { (renderer as! CombinedChartRenderer!).drawValueAboveBarEnabled = newValue }
     }
     
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
-    open var drawBarShadowEnabled: Bool
+    @objc open var drawBarShadowEnabled: Bool
     {
         get { return (renderer as! CombinedChartRenderer!).drawBarShadowEnabled }
         set { (renderer as! CombinedChartRenderer!).drawBarShadowEnabled = newValue }
@@ -205,7 +205,7 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
     /// the order in which the provided data objects should be drawn.
     /// The earlier you place them in the provided array, the further they will be in the background. 
     /// e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
-    open var drawOrder: [Int]
+    @objc open var drawOrder: [Int]
     {
         get
         {
@@ -218,7 +218,7 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
     }
     
     /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values
-    open var highlightFullBarEnabled: Bool = false
+    @objc open var highlightFullBarEnabled: Bool = false
     
     /// - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
     open var isHighlightFullBarEnabled: Bool { return highlightFullBarEnabled }

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -223,7 +223,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// Checks if the given index is set to be highlighted.
-    open func needsHighlight(index: Int) -> Bool
+    @objc open func needsHighlight(index: Int) -> Bool
     {
         // no highlight
         if !valuesToHighlight()
@@ -277,7 +277,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: The index of the DataSet this x-index belongs to.
-    open func dataSetIndexForIndex(_ xValue: Double) -> Int
+    @objc open func dataSetIndexForIndex(_ xValue: Double) -> Int
     {
         var dataSets = _data?.dataSets ?? []
         
@@ -295,14 +295,14 @@ open class PieChartView: PieRadarChartViewBase
     /// - returns: An integer array of all the different angles the chart slices
     /// have the angles in the returned array determine how much space (of 360°)
     /// each slice takes
-    open var drawAngles: [CGFloat]
+    @objc open var drawAngles: [CGFloat]
     {
         return _drawAngles
     }
 
     /// - returns: The absolute angles of the different chart slices (where the
     /// slices end)
-    open var absoluteAngles: [CGFloat]
+    @objc open var absoluteAngles: [CGFloat]
     {
         return _absoluteAngles
     }
@@ -310,7 +310,7 @@ open class PieChartView: PieRadarChartViewBase
     /// The color for the hole that is drawn in the center of the PieChart (if enabled).
     /// 
     /// - note: Use holeTransparent with holeColor = nil to make the hole transparent.*
-    open var holeColor: NSUIColor?
+    @objc open var holeColor: NSUIColor?
     {
         get
         {
@@ -326,7 +326,7 @@ open class PieChartView: PieRadarChartViewBase
     /// if true, the hole will see-through to the inner tips of the slices
     ///
     /// **default**: `false`
-    open var drawSlicesUnderHoleEnabled: Bool
+    @objc open var drawSlicesUnderHoleEnabled: Bool
     {
         get
         {
@@ -340,13 +340,13 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: `true` if the inner tips of the slices are visible behind the hole, `false` if not.
-    open var isDrawSlicesUnderHoleEnabled: Bool
+    @objc open var isDrawSlicesUnderHoleEnabled: Bool
     {
         return drawSlicesUnderHoleEnabled
     }
     
     /// `true` if the hole in the center of the pie-chart is set to be visible, `false` ifnot
-    open var drawHoleEnabled: Bool
+    @objc open var drawHoleEnabled: Bool
     {
         get
         {
@@ -360,7 +360,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: `true` if the hole in the center of the pie-chart is set to be visible, `false` ifnot
-    open var isDrawHoleEnabled: Bool
+    @objc open var isDrawHoleEnabled: Bool
     {
         get
         {
@@ -369,7 +369,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// the text that is displayed in the center of the pie-chart
-    open var centerText: String?
+    @objc open var centerText: String?
     {
         get
         {
@@ -394,9 +394,9 @@ open class PieChartView: PieRadarChartViewBase
                 
                 attrString = NSMutableAttributedString(string: newValue!)
                 attrString?.setAttributes([
-                    NSForegroundColorAttributeName: NSUIColor.black,
-                    NSFontAttributeName: NSUIFont.systemFont(ofSize: 12.0),
-                    NSParagraphStyleAttributeName: paragraphStyle
+                    NSAttributedStringKey.foregroundColor: NSUIColor.black,
+                    NSAttributedStringKey.font: NSUIFont.systemFont(ofSize: 12.0),
+                    NSAttributedStringKey.paragraphStyle: paragraphStyle
                     ], range: NSMakeRange(0, attrString!.length))
             }
             self.centerAttributedText = attrString
@@ -404,7 +404,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// the text that is displayed in the center of the pie-chart
-    open var centerAttributedText: NSAttributedString?
+    @objc open var centerAttributedText: NSAttributedString?
     {
         get
         {
@@ -418,7 +418,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// Sets the offset the center text should have from it's original position in dp. Default x = 0, y = 0
-    open var centerTextOffset: CGPoint
+    @objc open var centerTextOffset: CGPoint
     {
         get
         {
@@ -432,7 +432,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// `true` if drawing the center text is enabled
-    open var drawCenterTextEnabled: Bool
+    @objc open var drawCenterTextEnabled: Bool
     {
         get
         {
@@ -446,7 +446,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: `true` if drawing the center text is enabled
-    open var isDrawCenterTextEnabled: Bool
+    @objc open var isDrawCenterTextEnabled: Bool
     {
         get
         {
@@ -470,13 +470,13 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: The circlebox, the boundingbox of the pie-chart slices
-    open var circleBox: CGRect
+    @objc open var circleBox: CGRect
     {
         return _circleBox
     }
     
     /// - returns: The center of the circlebox
-    open var centerCircleBox: CGPoint
+    @objc open var centerCircleBox: CGPoint
     {
         return CGPoint(x: _circleBox.midX, y: _circleBox.midY)
     }
@@ -484,7 +484,7 @@ open class PieChartView: PieRadarChartViewBase
     /// the radius of the hole in the center of the piechart in percent of the maximum radius (max = the radius of the whole chart)
     /// 
     /// **default**: 0.5 (50%) (half the pie)
-    open var holeRadiusPercent: CGFloat
+    @objc open var holeRadiusPercent: CGFloat
     {
         get
         {
@@ -500,7 +500,7 @@ open class PieChartView: PieRadarChartViewBase
     /// The color that the transparent-circle should have.
     ///
     /// **default**: `nil`
-    open var transparentCircleColor: NSUIColor?
+    @objc open var transparentCircleColor: NSUIColor?
     {
         get
         {
@@ -516,7 +516,7 @@ open class PieChartView: PieRadarChartViewBase
     /// the radius of the transparent circle that is drawn next to the hole in the piechart in percent of the maximum radius (max = the radius of the whole chart)
     /// 
     /// **default**: 0.55 (55%) -> means 5% larger than the center-hole by default
-    open var transparentCircleRadiusPercent: CGFloat
+    @objc open var transparentCircleRadiusPercent: CGFloat
     {
         get
         {
@@ -530,7 +530,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// set this to true to draw the enrty labels into the pie slices
-    @available(*, deprecated: 1.0, message: "Use `drawEntryLabelsEnabled` instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use `drawEntryLabelsEnabled` instead.")
     open var drawSliceTextEnabled: Bool
     {
         get
@@ -544,7 +544,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: `true` if drawing entry labels is enabled, `false` ifnot
-    @available(*, deprecated: 1.0, message: "Use `isDrawEntryLabelsEnabled` instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use `isDrawEntryLabelsEnabled` instead.")
     open var isDrawSliceTextEnabled: Bool
     {
         get
@@ -554,7 +554,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// The color the entry labels are drawn with.
-    open var entryLabelColor: NSUIColor?
+    @objc open var entryLabelColor: NSUIColor?
     {
         get { return _entryLabelColor }
         set
@@ -565,7 +565,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// The font the entry labels are drawn with.
-    open var entryLabelFont: NSUIFont?
+    @objc open var entryLabelFont: NSUIFont?
     {
         get { return _entryLabelFont }
         set
@@ -576,7 +576,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// Set this to true to draw the enrty labels into the pie slices
-    open var drawEntryLabelsEnabled: Bool
+    @objc open var drawEntryLabelsEnabled: Bool
     {
         get
         {
@@ -590,7 +590,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: `true` if drawing entry labels is enabled, `false` ifnot
-    open var isDrawEntryLabelsEnabled: Bool
+    @objc open var isDrawEntryLabelsEnabled: Bool
     {
         get
         {
@@ -599,7 +599,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// If this is enabled, values inside the PieChart are drawn in percent and not with their original value. Values provided for the ValueFormatter to format are then provided in percent.
-    open var usePercentValuesEnabled: Bool
+    @objc open var usePercentValuesEnabled: Bool
     {
         get
         {
@@ -613,7 +613,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// - returns: `true` if drawing x-values is enabled, `false` ifnot
-    open var isUsePercentValuesEnabled: Bool
+    @objc open var isUsePercentValuesEnabled: Bool
     {
         get
         {
@@ -622,7 +622,7 @@ open class PieChartView: PieRadarChartViewBase
     }
     
     /// the rectangular radius of the bounding box for the center text, as a percentage of the pie hole
-    open var centerTextRadiusPercent: CGFloat
+    @objc open var centerTextRadiusPercent: CGFloat
     {
         get
         {
@@ -638,7 +638,7 @@ open class PieChartView: PieRadarChartViewBase
     /// The max angle that is used for calculating the pie-circle.
     /// 360 means it's a full pie-chart, 180 results in a half-pie-chart.
     /// **default**: 360.0
-    open var maxAngle: CGFloat
+    @objc open var maxAngle: CGFloat
     {
         get
         {

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -385,11 +385,12 @@ open class PieChartView: PieRadarChartViewBase
             else
             {
                 #if os(OSX)
-                    let paragraphStyle = NSParagraphStyle.default().mutableCopy() as! NSMutableParagraphStyle
+                    let paragraphStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
+                    paragraphStyle.lineBreakMode = NSParagraphStyle.LineBreakMode.byTruncatingTail
                 #else
                     let paragraphStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
+                    paragraphStyle.lineBreakMode = NSLineBreakMode.byTruncatingTail
                 #endif
-                paragraphStyle.lineBreakMode = NSLineBreakMode.byTruncatingTail
                 paragraphStyle.alignment = .center
                 
                 attrString = NSMutableAttributedString(string: newValue!)

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -26,10 +26,10 @@ open class PieRadarChartViewBase: ChartViewBase
     fileprivate var _rawRotationAngle = CGFloat(270.0)
     
     /// flag that indicates if rotation is enabled or not
-    open var rotationEnabled = true
+    @objc open var rotationEnabled = true
     
     /// Sets the minimum offset (padding) around the chart, defaults to 0.0
-    open var minOffset = CGFloat(0.0)
+    @objc open var minOffset = CGFloat(0.0)
 
     /// iOS && OSX only: Enabled multi-touch rotation using two fingers.
     fileprivate var _rotationWithTwoFingers = false
@@ -246,7 +246,7 @@ open class PieRadarChartViewBase: ChartViewBase
 
     /// - returns: The angle relative to the chart center for the given point on the chart in degrees.
     /// The angle is always between 0 and 360°, 0° is NORTH, 90° is EAST, ...
-    open func angleForPoint(x: CGFloat, y: CGFloat) -> CGFloat
+    @objc open func angleForPoint(x: CGFloat, y: CGFloat) -> CGFloat
     {
         let c = centerOffsets
         
@@ -276,14 +276,14 @@ open class PieRadarChartViewBase: ChartViewBase
     
     /// Calculates the position around a center point, depending on the distance
     /// from the center, and the angle of the position around the center.
-    open func getPosition(center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
+    @objc open func getPosition(center: CGPoint, dist: CGFloat, angle: CGFloat) -> CGPoint
     {
         return CGPoint(x: center.x + dist * cos(angle * ChartUtils.Math.FDEG2RAD),
                 y: center.y + dist * sin(angle * ChartUtils.Math.FDEG2RAD))
     }
 
     /// - returns: The distance of a certain point on the chart to the center of the chart.
-    open func distanceToCenter(x: CGFloat, y: CGFloat) -> CGFloat
+    @objc open func distanceToCenter(x: CGFloat, y: CGFloat) -> CGFloat
     {
         let c = self.centerOffsets
 
@@ -318,7 +318,7 @@ open class PieRadarChartViewBase: ChartViewBase
 
     /// - returns: The xIndex for the given angle around the center of the chart.
     /// -1 if not found / outofbounds.
-    open func indexForAngle(_ angle: CGFloat) -> Int
+    @objc open func indexForAngle(_ angle: CGFloat) -> Int
     {
         fatalError("indexForAngle() cannot be called on PieRadarChartViewBase")
     }
@@ -327,7 +327,7 @@ open class PieRadarChartViewBase: ChartViewBase
     ///
     /// **default**: 270 --> top (NORTH)
     /// - returns: Will always return a normalized value, which will be between 0.0 < 360.0
-    open var rotationAngle: CGFloat
+    @objc open var rotationAngle: CGFloat
     {
         get
         {
@@ -343,13 +343,13 @@ open class PieRadarChartViewBase: ChartViewBase
     
     /// gets the raw version of the current rotation angle of the pie chart the returned value could be any value, negative or positive, outside of the 360 degrees. 
     /// this is used when working with rotation direction, mainly by gestures and animations.
-    open var rawRotationAngle: CGFloat
+    @objc open var rawRotationAngle: CGFloat
     {
         return _rawRotationAngle
     }
 
     /// - returns: The diameter of the pie- or radar-chart
-    open var diameter: CGFloat
+    @objc open var diameter: CGFloat
     {
         var content = _viewPortHandler.contentRect
         content.origin.x += extraLeftOffset
@@ -360,20 +360,20 @@ open class PieRadarChartViewBase: ChartViewBase
     }
 
     /// - returns: The radius of the chart in pixels.
-    open var radius: CGFloat
+    @objc open var radius: CGFloat
     {
         fatalError("radius cannot be called on PieRadarChartViewBase")
     }
 
     /// - returns: The required offset for the chart legend.
-    internal var requiredLegendOffset: CGFloat
+    @objc internal var requiredLegendOffset: CGFloat
     {
         fatalError("requiredLegendOffset cannot be called on PieRadarChartViewBase")
     }
 
     /// - returns: The base offset needed for the chart without calculating the
     /// legend size.
-    internal var requiredBaseOffset: CGFloat
+    @objc internal var requiredBaseOffset: CGFloat
     {
         fatalError("requiredBaseOffset cannot be called on PieRadarChartViewBase")
     }
@@ -388,7 +388,7 @@ open class PieRadarChartViewBase: ChartViewBase
         return 0.0
     }
     
-    open var isRotationEnabled: Bool { return rotationEnabled }
+    @objc open var isRotationEnabled: Bool { return rotationEnabled }
     
     /// flag that indicates if rotation is done with two fingers or one.
     /// when the chart is inside a scrollview, you need a two-finger rotation because a one-finger rotation eats up all touch events.
@@ -397,7 +397,7 @@ open class PieRadarChartViewBase: ChartViewBase
     /// On OSX this will keep two-finger multitouch rotation, and one-pointer mouse rotation.
     /// 
     /// **default**: false
-    open var rotationWithTwoFingers: Bool
+    @objc open var rotationWithTwoFingers: Bool
     {
         get
         {
@@ -419,7 +419,7 @@ open class PieRadarChartViewBase: ChartViewBase
     /// On OSX this will keep two-finger multitouch rotation, and one-pointer mouse rotation.
     ///
     /// **default**: false
-    open var isRotationWithTwoFingers: Bool
+    @objc open var isRotationWithTwoFingers: Bool
     {
         return _rotationWithTwoFingers
     }
@@ -429,7 +429,7 @@ open class PieRadarChartViewBase: ChartViewBase
     fileprivate var _spinAnimator: Animator!
     
     /// Applys a spin animation to the Chart.
-    open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easing: ChartEasingFunctionBlock?)
+    @objc open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easing: ChartEasingFunctionBlock?)
     {
         if _spinAnimator != nil
         {
@@ -445,17 +445,17 @@ open class PieRadarChartViewBase: ChartViewBase
         _spinAnimator.animate(xAxisDuration: duration, easing: easing)
     }
     
-    open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easingOption: ChartEasingOption)
+    @objc open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat, easingOption: ChartEasingOption)
     {
         spin(duration: duration, fromAngle: fromAngle, toAngle: toAngle, easing: easingFunctionFromOption(easingOption))
     }
     
-    open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat)
+    @objc open func spin(duration: TimeInterval, fromAngle: CGFloat, toAngle: CGFloat)
     {
         spin(duration: duration, fromAngle: fromAngle, toAngle: toAngle, easing: nil)
     }
     
-    open func stopSpinAnimation()
+    @objc open func stopSpinAnimation()
     {
         if _spinAnimator != nil
         {
@@ -481,7 +481,7 @@ open class PieRadarChartViewBase: ChartViewBase
     fileprivate var _decelerationDisplayLink: NSUIDisplayLink!
     fileprivate var _decelerationAngularVelocity: CGFloat = 0.0
     
-    internal final func processRotationGestureBegan(location: CGPoint)
+    @objc internal final func processRotationGestureBegan(location: CGPoint)
     {
         self.resetVelocity()
         
@@ -495,7 +495,7 @@ open class PieRadarChartViewBase: ChartViewBase
         _rotationGestureStartPoint = location
     }
     
-    internal final func processRotationGestureMoved(location: CGPoint)
+    @objc internal final func processRotationGestureMoved(location: CGPoint)
     {
         if isDragDecelerationEnabled
         {
@@ -518,7 +518,7 @@ open class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    internal final func processRotationGestureEnded(location: CGPoint)
+    @objc internal final func processRotationGestureEnded(location: CGPoint)
     {
         if isDragDecelerationEnabled
         {
@@ -537,7 +537,7 @@ open class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    internal final func processRotationGestureCancelled()
+    @objc internal final func processRotationGestureCancelled()
     {
         if _isRotating
         {
@@ -774,7 +774,7 @@ open class PieRadarChartViewBase: ChartViewBase
         self.rotationAngle = angleForPoint(x: x, y: y) - _startAngle
     }
     
-    open func stopDeceleration()
+    @objc open func stopDeceleration()
     {
         if _decelerationDisplayLink !== nil
         {

--- a/Source/Charts/Charts/RadarChartView.swift
+++ b/Source/Charts/Charts/RadarChartView.swift
@@ -18,22 +18,22 @@ import CoreGraphics
 open class RadarChartView: PieRadarChartViewBase
 {
     /// width of the web lines that come from the center.
-    open var webLineWidth = CGFloat(1.5)
+    @objc open var webLineWidth = CGFloat(1.5)
     
     /// width of the web lines that are in between the lines coming from the center
-    open var innerWebLineWidth = CGFloat(0.75)
+    @objc open var innerWebLineWidth = CGFloat(0.75)
     
     /// color for the web lines that come from the center
-    open var webColor = NSUIColor(red: 122/255.0, green: 122/255.0, blue: 122.0/255.0, alpha: 1.0)
+    @objc open var webColor = NSUIColor(red: 122/255.0, green: 122/255.0, blue: 122.0/255.0, alpha: 1.0)
     
     /// color for the web lines in between the lines that come from the center.
-    open var innerWebColor = NSUIColor(red: 122/255.0, green: 122/255.0, blue: 122.0/255.0, alpha: 1.0)
+    @objc open var innerWebColor = NSUIColor(red: 122/255.0, green: 122/255.0, blue: 122.0/255.0, alpha: 1.0)
     
     /// transparency the grid is drawn with (0.0 - 1.0)
-    open var webAlpha: CGFloat = 150.0 / 255.0
+    @objc open var webAlpha: CGFloat = 150.0 / 255.0
     
     /// flag indicating if the web lines should be drawn or not
-    open var drawWeb = true
+    @objc open var drawWeb = true
     
     /// modulus that determines how many labels and web-lines are skipped before the next is drawn
     fileprivate var _skipWebLineCount = 0
@@ -41,8 +41,8 @@ open class RadarChartView: PieRadarChartViewBase
     /// the object reprsenting the y-axis labels
     fileprivate var _yAxis: YAxis!
     
-    internal var _yAxisRenderer: YAxisRendererRadarChart!
-    internal var _xAxisRenderer: XAxisRendererRadarChart!
+    @objc internal var _yAxisRenderer: YAxisRendererRadarChart!
+    @objc internal var _xAxisRenderer: XAxisRendererRadarChart!
     
     public override init(frame: CGRect)
     {
@@ -150,7 +150,7 @@ open class RadarChartView: PieRadarChartViewBase
     }
 
     /// - returns: The factor that is needed to transform values into pixels.
-    open var factor: CGFloat
+    @objc open var factor: CGFloat
     {
         let content = _viewPortHandler.contentRect
         return min(content.width / 2.0, content.height / 2.0)
@@ -158,7 +158,7 @@ open class RadarChartView: PieRadarChartViewBase
     }
 
     /// - returns: The angle that each slice in the radar chart occupies.
-    open var sliceAngle: CGFloat
+    @objc open var sliceAngle: CGFloat
     {
         return 360.0 / CGFloat(_data?.maxEntryCountSet?.entryCount ?? 0)
     }
@@ -189,14 +189,14 @@ open class RadarChartView: PieRadarChartViewBase
     }
 
     /// - returns: The object that represents all y-labels of the RadarChart.
-    open var yAxis: YAxis
+    @objc open var yAxis: YAxis
     {
         return _yAxis
     }
 
     /// Sets the number of web-lines that should be skipped on chart web before the next one is drawn. This targets the lines that come from the center of the RadarChart.
     /// if count = 1 -> 1 line is skipped in between
-    open var skipWebLineCount: Int
+    @objc open var skipWebLineCount: Int
     {
         get
         {
@@ -231,5 +231,5 @@ open class RadarChartView: PieRadarChartViewBase
     open override var chartYMin: Double { return _yAxis._axisMinimum }
     
     /// - returns: The range of y-values this chart can display.
-    open var yRange: Double { return _yAxis.axisRange }
+    @objc open var yRange: Double { return _yAxis.axisRange }
 }

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -24,37 +24,37 @@ open class AxisBase: ComponentBase
     /// Custom formatter that is used instead of the auto-formatter if set
     fileprivate var _axisValueFormatter: IAxisValueFormatter?
     
-    open var labelFont = NSUIFont.systemFont(ofSize: 10.0)
-    open var labelTextColor = NSUIColor.black
+    @objc open var labelFont = NSUIFont.systemFont(ofSize: 10.0)
+    @objc open var labelTextColor = NSUIColor.black
     
-    open var axisLineColor = NSUIColor.gray
-    open var axisLineWidth = CGFloat(0.5)
-    open var axisLineDashPhase = CGFloat(0.0)
-    open var axisLineDashLengths: [CGFloat]!
+    @objc open var axisLineColor = NSUIColor.gray
+    @objc open var axisLineWidth = CGFloat(0.5)
+    @objc open var axisLineDashPhase = CGFloat(0.0)
+    @objc open var axisLineDashLengths: [CGFloat]!
     
-    open var gridColor = NSUIColor.gray.withAlphaComponent(0.9)
-    open var gridLineWidth = CGFloat(0.5)
-    open var gridLineDashPhase = CGFloat(0.0)
-    open var gridLineDashLengths: [CGFloat]!
-    open var gridLineCap = CGLineCap.butt
+    @objc open var gridColor = NSUIColor.gray.withAlphaComponent(0.9)
+    @objc open var gridLineWidth = CGFloat(0.5)
+    @objc open var gridLineDashPhase = CGFloat(0.0)
+    @objc open var gridLineDashLengths: [CGFloat]!
+    @objc open var gridLineCap = CGLineCap.butt
     
-    open var drawGridLinesEnabled = true
-    open var drawAxisLineEnabled = true
+    @objc open var drawGridLinesEnabled = true
+    @objc open var drawAxisLineEnabled = true
     
     /// flag that indicates of the labels of this axis should be drawn or not
-    open var drawLabelsEnabled = true
+    @objc open var drawLabelsEnabled = true
     
     fileprivate var _centerAxisLabelsEnabled = false
 
     /// Centers the axis labels instead of drawing them at their original position.
     /// This is useful especially for grouped BarChart.
-    open var centerAxisLabelsEnabled: Bool
+    @objc open var centerAxisLabelsEnabled: Bool
     {
         get { return _centerAxisLabelsEnabled && entryCount > 0 }
         set { _centerAxisLabelsEnabled = newValue }
     }
     
-    open var isCenterAxisLabelsEnabled: Bool
+    @objc open var isCenterAxisLabelsEnabled: Bool
     {
         get { return centerAxisLabelsEnabled }
     }
@@ -65,19 +65,19 @@ open class AxisBase: ComponentBase
     /// Are the LimitLines drawn behind the data or in front of the data?
     /// 
     /// **default**: false
-    open var drawLimitLinesBehindDataEnabled = false
+    @objc open var drawLimitLinesBehindDataEnabled = false
 
     /// the flag can be used to turn off the antialias for grid lines
-    open var gridAntialiasEnabled = true
+    @objc open var gridAntialiasEnabled = true
     
     /// the actual array of entries
-    open var entries = [Double]()
+    @objc open var entries = [Double]()
     
     /// axis label entries only used for centered labels
-    open var centeredEntries = [Double]()
+    @objc open var centeredEntries = [Double]()
     
     /// the number of entries the legend contains
-    open var entryCount: Int { return entries.count }
+    @objc open var entryCount: Int { return entries.count }
     
     /// the number of label entries the axis should have
     ///
@@ -85,13 +85,13 @@ open class AxisBase: ComponentBase
     fileprivate var _labelCount = Int(6)
     
     /// the number of decimal digits to use (for the default formatter
-    open var decimals: Int = 0
+    @objc open var decimals: Int = 0
     
     /// When true, axis labels are controlled by the `granularity` property.
     /// When false, axis values could possibly be repeated.
     /// This could happen if two adjacent axis values are rounded to same value.
     /// If using granularity this could be avoided by having fewer axis values visible.
-    open var granularityEnabled = false
+    @objc open var granularityEnabled = false
     
     fileprivate var _granularity = Double(1.0)
     
@@ -99,7 +99,7 @@ open class AxisBase: ComponentBase
     /// This can be used to avoid label duplicating when zooming in.
     ///
     /// **default**: 1.0
-    open var granularity: Double
+    @objc open var granularity: Double
     {
         get
         {
@@ -115,7 +115,7 @@ open class AxisBase: ComponentBase
     }
     
     /// The minimum interval between axis values.
-    open var isGranularityEnabled: Bool
+    @objc open var isGranularityEnabled: Bool
     {
         get
         {
@@ -124,9 +124,9 @@ open class AxisBase: ComponentBase
     }
     
     /// if true, the set number of y-labels will be forced
-    open var forceLabelsEnabled = false
+    @objc open var forceLabelsEnabled = false
     
-    open func getLongestLabel() -> String
+    @objc open func getLongestLabel() -> String
     {
         var longest = ""
         
@@ -144,7 +144,7 @@ open class AxisBase: ComponentBase
     }
     
     /// - returns: The formatted label at the specified index. This will either use the auto-formatter or the custom formatter (if one is set).
-    open func getFormattedLabel(_ index: Int) -> String
+    @objc open func getFormattedLabel(_ index: Int) -> String
     {
         if index < 0 || index >= entries.count
         {
@@ -157,7 +157,7 @@ open class AxisBase: ComponentBase
     /// Sets the formatter to be used for formatting the axis labels.
     /// If no formatter is set, the chart will automatically determine a reasonable formatting (concerning decimals) for all the values that are drawn inside the chart.
     /// Use `nil` to use the formatter calculated by the chart.
-    open var valueFormatter: IAxisValueFormatter?
+    @objc open var valueFormatter: IAxisValueFormatter?
     {
         get
         {
@@ -177,48 +177,48 @@ open class AxisBase: ComponentBase
         }
     }
     
-    open var isDrawGridLinesEnabled: Bool { return drawGridLinesEnabled }
+    @objc open var isDrawGridLinesEnabled: Bool { return drawGridLinesEnabled }
     
-    open var isDrawAxisLineEnabled: Bool { return drawAxisLineEnabled }
+    @objc open var isDrawAxisLineEnabled: Bool { return drawAxisLineEnabled }
     
-    open var isDrawLabelsEnabled: Bool { return drawLabelsEnabled }
+    @objc open var isDrawLabelsEnabled: Bool { return drawLabelsEnabled }
     
     /// Are the LimitLines drawn behind the data or in front of the data?
     /// 
     /// **default**: false
-    open var isDrawLimitLinesBehindDataEnabled: Bool { return drawLimitLinesBehindDataEnabled }
+    @objc open var isDrawLimitLinesBehindDataEnabled: Bool { return drawLimitLinesBehindDataEnabled }
     
     /// Extra spacing for `axisMinimum` to be added to automatically calculated `axisMinimum`
-    open var spaceMin: Double = 0.0
+    @objc open var spaceMin: Double = 0.0
     
     /// Extra spacing for `axisMaximum` to be added to automatically calculated `axisMaximum`
-    open var spaceMax: Double = 0.0
+    @objc open var spaceMax: Double = 0.0
     
     /// Flag indicating that the axis-min value has been customized
-    internal var _customAxisMin: Bool = false
+    @objc internal var _customAxisMin: Bool = false
     
     /// Flag indicating that the axis-max value has been customized
-    internal var _customAxisMax: Bool = false
+    @objc internal var _customAxisMax: Bool = false
     
     /// Do not touch this directly, instead, use axisMinimum.
     /// This is automatically calculated to represent the real min value,
     /// and is used when calculating the effective minimum.
-    internal var _axisMinimum = Double(0)
+    @objc internal var _axisMinimum = Double(0)
     
     /// Do not touch this directly, instead, use axisMaximum.
     /// This is automatically calculated to represent the real max value,
     /// and is used when calculating the effective maximum.
-    internal var _axisMaximum = Double(0)
+    @objc internal var _axisMaximum = Double(0)
     
     /// the total range of values this axis covers
-    open var axisRange = Double(0)
+    @objc open var axisRange = Double(0)
     
     /// the number of label entries the axis should have
     /// max = 25,
     /// min = 2,
     /// default = 6,
     /// be aware that this number is not fixed and can only be approximated
-    open var labelCount: Int
+    @objc open var labelCount: Int
     {
         get
         {
@@ -241,23 +241,23 @@ open class AxisBase: ComponentBase
         }
     }
     
-    open func setLabelCount(_ count: Int, force: Bool)
+    @objc open func setLabelCount(_ count: Int, force: Bool)
     {
         self.labelCount = count
         forceLabelsEnabled = force
     }
     
     /// - returns: `true` if focing the y-label count is enabled. Default: false
-    open var isForceLabelsEnabled: Bool { return forceLabelsEnabled }
+    @objc open var isForceLabelsEnabled: Bool { return forceLabelsEnabled }
     
     /// Adds a new ChartLimitLine to this axis.
-    open func addLimitLine(_ line: ChartLimitLine)
+    @objc open func addLimitLine(_ line: ChartLimitLine)
     {
         _limitLines.append(line)
     }
     
     /// Removes the specified ChartLimitLine from the axis.
-    open func removeLimitLine(_ line: ChartLimitLine)
+    @objc open func removeLimitLine(_ line: ChartLimitLine)
     {
         for i in 0 ..< _limitLines.count
         {
@@ -270,13 +270,13 @@ open class AxisBase: ComponentBase
     }
     
     /// Removes all LimitLines from the axis.
-    open func removeAllLimitLines()
+    @objc open func removeAllLimitLines()
     {
         _limitLines.removeAll(keepingCapacity: false)
     }
     
     /// - returns: The LimitLines of this axis.
-    open var limitLines : [ChartLimitLine]
+    @objc open var limitLines : [ChartLimitLine]
     {
         return _limitLines
     }
@@ -284,23 +284,23 @@ open class AxisBase: ComponentBase
     // MARK: Custom axis ranges
     
     /// By calling this method, any custom minimum value that has been previously set is reseted, and the calculation is done automatically.
-    open func resetCustomAxisMin()
+    @objc open func resetCustomAxisMin()
     {
         _customAxisMin = false
     }
     
-    open var isAxisMinCustom: Bool { return _customAxisMin }
+    @objc open var isAxisMinCustom: Bool { return _customAxisMin }
     
     /// By calling this method, any custom maximum value that has been previously set is reseted, and the calculation is done automatically.
-    open func resetCustomAxisMax()
+    @objc open func resetCustomAxisMax()
     {
         _customAxisMax = false
     }
     
-    open var isAxisMaxCustom: Bool { return _customAxisMax }
+    @objc open var isAxisMaxCustom: Bool { return _customAxisMax }
     
     /// This property is deprecated - Use `axisMinimum` instead.
-    @available(*, deprecated: 1.0, message: "Use axisMinimum instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use axisMinimum instead.")
     open var axisMinValue: Double
     {
         get { return axisMinimum }
@@ -308,7 +308,7 @@ open class AxisBase: ComponentBase
     }
     
     /// This property is deprecated - Use `axisMaximum` instead.
-    @available(*, deprecated: 1.0, message: "Use axisMaximum instead.")
+    @objc @available(*, deprecated: 1.0, message: "Use axisMaximum instead.")
     open var axisMaxValue: Double
     {
         get { return axisMaximum }
@@ -318,7 +318,7 @@ open class AxisBase: ComponentBase
     /// The minimum value for this axis.
     /// If set, this value will not be calculated automatically depending on the provided data.
     /// Use `resetCustomAxisMin()` to undo this.
-    open var axisMinimum: Double
+    @objc open var axisMinimum: Double
     {
         get
         {
@@ -335,7 +335,7 @@ open class AxisBase: ComponentBase
     /// The maximum value for this axis.
     /// If set, this value will not be calculated automatically depending on the provided data.
     /// Use `resetCustomAxisMax()` to undo this.
-    open var axisMaximum: Double
+    @objc open var axisMaximum: Double
     {
         get
         {
@@ -352,7 +352,7 @@ open class AxisBase: ComponentBase
     /// Calculates the minimum, maximum and range values of the YAxis with the given minimum and maximum values from the chart data.
     /// - parameter dataMin: the y-min value according to chart data
     /// - parameter dataMax: the y-max value according to chart
-    open func calculate(min dataMin: Double, max dataMax: Double)
+    @objc open func calculate(min dataMin: Double, max dataMax: Double)
     {
         // if custom, use value as is, else use data value
         var min = _customAxisMin ? _axisMinimum : (dataMin - spaceMin)

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -27,32 +27,32 @@ open class ChartLimitLine: ComponentBase
     }
     
     /// limit / maximum (the y-value or xIndex)
-    open var limit = Double(0.0)
+    @objc open var limit = Double(0.0)
     
     fileprivate var _lineWidth = CGFloat(2.0)
-    open var lineColor = NSUIColor(red: 237.0/255.0, green: 91.0/255.0, blue: 91.0/255.0, alpha: 1.0)
-    open var lineDashPhase = CGFloat(0.0)
-    open var lineDashLengths: [CGFloat]?
+    @objc open var lineColor = NSUIColor(red: 237.0/255.0, green: 91.0/255.0, blue: 91.0/255.0, alpha: 1.0)
+    @objc open var lineDashPhase = CGFloat(0.0)
+    @objc open var lineDashLengths: [CGFloat]?
     
-    open var valueTextColor = NSUIColor.black
-    open var valueFont = NSUIFont.systemFont(ofSize: 13.0)
+    @objc open var valueTextColor = NSUIColor.black
+    @objc open var valueFont = NSUIFont.systemFont(ofSize: 13.0)
     
-    open var drawLabelEnabled = true
-    open var label = ""
-    open var labelPosition = LabelPosition.rightTop
+    @objc open var drawLabelEnabled = true
+    @objc open var label = ""
+    @objc open var labelPosition = LabelPosition.rightTop
     
     public override init()
     {
         super.init()
     }
     
-    public init(limit: Double)
+    @objc public init(limit: Double)
     {
         super.init()
         self.limit = limit
     }
     
-    public init(limit: Double, label: String)
+    @objc public init(limit: Double, label: String)
     {
         super.init()
         self.limit = limit
@@ -60,7 +60,7 @@ open class ChartLimitLine: ComponentBase
     }
     
     /// set the line width of the chart (min = 0.2, max = 12); default 2
-    open var lineWidth: CGFloat
+    @objc open var lineWidth: CGFloat
     {
         get
         {

--- a/Source/Charts/Components/ComponentBase.swift
+++ b/Source/Charts/Components/ComponentBase.swift
@@ -18,20 +18,20 @@ import CoreGraphics
 open class ComponentBase: NSObject
 {
     /// flag that indicates if this component is enabled or not
-    open var enabled = true
+    @objc open var enabled = true
     
     /// The offset this component has on the x-axis
     /// **default**: 5.0
-    open var xOffset = CGFloat(5.0)
+    @objc open var xOffset = CGFloat(5.0)
     
     /// The offset this component has on the x-axis
     /// **default**: 5.0 (or 0.0 on ChartYAxis)
-    open var yOffset = CGFloat(5.0)
+    @objc open var yOffset = CGFloat(5.0)
     
     public override init()
     {
         super.init()
     }
 
-    open var isEnabled: Bool { return enabled }
+    @objc open var isEnabled: Bool { return enabled }
 }

--- a/Source/Charts/Components/Description.swift
+++ b/Source/Charts/Components/Description.swift
@@ -21,7 +21,7 @@ open class Description: ComponentBase
             // 23 is the smallest recommended font size on the TV
             font = NSUIFont.systemFont(ofSize: 23)
         #elseif os(OSX)
-            font = NSUIFont.systemFont(ofSize: NSUIFont.systemFontSize())
+            font = NSUIFont.systemFont(ofSize: NSUIFont.systemFontSize)
         #else
             font = NSUIFont.systemFont(ofSize: 8.0)
         #endif

--- a/Source/Charts/Components/Description.swift
+++ b/Source/Charts/Components/Description.swift
@@ -30,17 +30,17 @@ open class Description: ComponentBase
     }
     
     /// The text to be shown as the description.
-    open var text: String? = "Description Label"
+    @objc open var text: String? = "Description Label"
     
     /// Custom position for the description text in pixels on the screen.
     open var position: CGPoint? = nil
     
     /// The text alignment of the description text. Default RIGHT.
-    open var textAlign: NSTextAlignment = NSTextAlignment.right
+    @objc open var textAlign: NSTextAlignment = NSTextAlignment.right
     
     /// Font object used for drawing the description text.
-    open var font: NSUIFont
+    @objc open var font: NSUIFont
     
     /// Text color used for drawing the description text
-    open var textColor = NSUIColor.black
+    @objc open var textColor = NSUIColor.black
 }

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -92,11 +92,11 @@ open class Legend: ComponentBase
     }
     
     /// The legend entries array
-    open var entries = [LegendEntry]()
+    @objc open var entries = [LegendEntry]()
     
     /// Entries that will be appended to the end of the auto calculated entries after calculating the legend.
     /// (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
-    open var extraEntries = [LegendEntry]()
+    @objc open var extraEntries = [LegendEntry]()
     
     /// Are the legend labels/colors a custom value or auto calculated? If false, then it's auto, if true, then custom.
     /// 
@@ -104,7 +104,7 @@ open class Legend: ComponentBase
     fileprivate var _isLegendCustom = false
     
     /// This property is deprecated - Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.
-    @available(*, deprecated: 1.0, message: "Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.")
+    @objc @available(*, deprecated: 1.0, message: "Use `horizontalAlignment`, `verticalAlignment`, `orientation`, `drawInside`, `direction`.")
     open var position: Position
     {
         get
@@ -179,55 +179,55 @@ open class Legend: ComponentBase
     }
     
     /// The horizontal alignment of the legend
-    open var horizontalAlignment: HorizontalAlignment = HorizontalAlignment.left
+    @objc open var horizontalAlignment: HorizontalAlignment = HorizontalAlignment.left
     
     /// The vertical alignment of the legend
-    open var verticalAlignment: VerticalAlignment = VerticalAlignment.bottom
+    @objc open var verticalAlignment: VerticalAlignment = VerticalAlignment.bottom
     
     /// The orientation of the legend
-    open var orientation: Orientation = Orientation.horizontal
+    @objc open var orientation: Orientation = Orientation.horizontal
     
     /// Flag indicating whether the legend will draw inside the chart or outside
-    open var drawInside: Bool = false
+    @objc open var drawInside: Bool = false
     
     /// Flag indicating whether the legend will draw inside the chart or outside
-    open var isDrawInsideEnabled: Bool { return drawInside }
+    @objc open var isDrawInsideEnabled: Bool { return drawInside }
     
     /// The text direction of the legend
-    open var direction: Direction = Direction.leftToRight
+    @objc open var direction: Direction = Direction.leftToRight
 
-    open var font: NSUIFont = NSUIFont.systemFont(ofSize: 10.0)
-    open var textColor = NSUIColor.black
+    @objc open var font: NSUIFont = NSUIFont.systemFont(ofSize: 10.0)
+    @objc open var textColor = NSUIColor.black
 
     /// The form/shape of the legend forms
-    open var form = Form.square
+    @objc open var form = Form.square
     
     /// The size of the legend forms
-    open var formSize = CGFloat(8.0)
+    @objc open var formSize = CGFloat(8.0)
     
     /// The line width for forms that consist of lines
-    open var formLineWidth = CGFloat(3.0)
+    @objc open var formLineWidth = CGFloat(3.0)
     
     /// Line dash configuration for shapes that consist of lines.
     ///
     /// This is how much (in pixels) into the dash pattern are we starting from.
-    open var formLineDashPhase: CGFloat = 0.0
+    @objc open var formLineDashPhase: CGFloat = 0.0
     
     /// Line dash configuration for shapes that consist of lines.
     ///
     /// This is the actual dash pattern.
     /// I.e. [2, 3] will paint [--   --   ]
     /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
-    open var formLineDashLengths: [CGFloat]?
+    @objc open var formLineDashLengths: [CGFloat]?
     
-    open var xEntrySpace = CGFloat(6.0)
-    open var yEntrySpace = CGFloat(0.0)
-    open var formToTextSpace = CGFloat(5.0)
-    open var stackSpace = CGFloat(3.0)
+    @objc open var xEntrySpace = CGFloat(6.0)
+    @objc open var yEntrySpace = CGFloat(0.0)
+    @objc open var formToTextSpace = CGFloat(5.0)
+    @objc open var stackSpace = CGFloat(3.0)
     
-    open var calculatedLabelSizes = [CGSize]()
-    open var calculatedLabelBreakPoints = [Bool]()
-    open var calculatedLineSizes = [CGSize]()
+    @objc open var calculatedLabelSizes = [CGSize]()
+    @objc open var calculatedLabelBreakPoints = [Bool]()
+    @objc open var calculatedLineSizes = [CGSize]()
     
     public override init()
     {
@@ -237,14 +237,14 @@ open class Legend: ComponentBase
         self.yOffset = 3.0
     }
     
-    public init(entries: [LegendEntry])
+    @objc public init(entries: [LegendEntry])
     {
         super.init()
         
         self.entries = entries
     }
     
-    open func getMaximumEntrySize(withFont font: NSUIFont) -> CGSize
+    @objc open func getMaximumEntrySize(withFont font: NSUIFont) -> CGSize
     {
         var maxW = CGFloat(0.0)
         var maxH = CGFloat(0.0)
@@ -262,7 +262,7 @@ open class Legend: ComponentBase
             guard let label = entry.label
                 else { continue }
             
-            let size = (label as NSString!).size(attributes: [NSFontAttributeName: font])
+            let size = (label as NSString!).size(withAttributes: [NSAttributedStringKey.font: font])
             
             if size.width > maxW
             {
@@ -280,29 +280,29 @@ open class Legend: ComponentBase
         )
     }
 
-    open var neededWidth = CGFloat(0.0)
-    open var neededHeight = CGFloat(0.0)
-    open var textWidthMax = CGFloat(0.0)
-    open var textHeightMax = CGFloat(0.0)
+    @objc open var neededWidth = CGFloat(0.0)
+    @objc open var neededHeight = CGFloat(0.0)
+    @objc open var textWidthMax = CGFloat(0.0)
+    @objc open var textHeightMax = CGFloat(0.0)
     
     /// flag that indicates if word wrapping is enabled
     /// this is currently supported only for `orientation == Horizontal`.
     /// you may want to set maxSizePercent when word wrapping, to set the point where the text wraps.
     /// 
     /// **default**: true
-    open var wordWrapEnabled = true
+    @objc open var wordWrapEnabled = true
     
     /// if this is set, then word wrapping the legend is enabled.
-    open var isWordWrapEnabled: Bool { return wordWrapEnabled }
+    @objc open var isWordWrapEnabled: Bool { return wordWrapEnabled }
 
     /// The maximum relative size out of the whole chart view in percent.
     /// If the legend is to the right/left of the chart, then this affects the width of the legend.
     /// If the legend is to the top/bottom of the chart, then this affects the height of the legend.
     /// 
     /// **default**: 0.95 (95%)
-    open var maxSizePercent: CGFloat = 0.95
+    @objc open var maxSizePercent: CGFloat = 0.95
     
-    open func calculateDimensions(labelFont: NSUIFont, viewPortHandler: ViewPortHandler)
+    @objc open func calculateDimensions(labelFont: NSUIFont, viewPortHandler: ViewPortHandler)
     {
         let maxEntrySize = getMaximumEntrySize(withFont: labelFont)
         let defaultFormSize = self.formSize
@@ -351,7 +351,7 @@ open class Legend: ComponentBase
                 
                 if label != nil
                 {
-                    let size = (label as NSString!).size(attributes: [NSFontAttributeName: labelFont])
+                    let size = (label as NSString!).size(withAttributes: [NSAttributedStringKey.font: labelFont])
                     
                     if drawingForm && !wasStacked
                     {
@@ -410,7 +410,7 @@ open class Legend: ComponentBase
             
             // Start calculating layout
             
-            let labelAttrs = [NSFontAttributeName: labelFont]
+            let labelAttrs = [NSAttributedStringKey.font: labelFont]
             var maxLineWidth: CGFloat = 0.0
             var currentLineWidth: CGFloat = 0.0
             var requiredWidth: CGFloat = 0.0
@@ -438,7 +438,7 @@ open class Legend: ComponentBase
                 // grouped forms have null labels
                 if label != nil
                 {
-                    calculatedLabelSizes[i] = (label as NSString!).size(attributes: labelAttrs)
+                    calculatedLabelSizes[i] = (label as NSString!).size(withAttributes: labelAttrs)
                     requiredWidth += drawingForm ? formToTextSpace + formSize : 0.0
                     requiredWidth += calculatedLabelSizes[i].width
                 }
@@ -502,21 +502,21 @@ open class Legend: ComponentBase
     /// * A nil label will start a group.
     /// This will disable the feature that automatically calculates the legend entries from the datasets.
     /// Call `resetCustom(...)` to re-enable automatic calculation (and then `notifyDataSetChanged()` is needed).
-    open func setCustom(entries: [LegendEntry])
+    @objc open func setCustom(entries: [LegendEntry])
     {
         self.entries = entries
         _isLegendCustom = true
     }
     
     /// Calling this will disable the custom legend entries (set by `setLegend(...)`). Instead, the entries will again be calculated automatically (after `notifyDataSetChanged()` is called).
-    open func resetCustom()
+    @objc open func resetCustom()
     {
         _isLegendCustom = false
     }
     
     /// **default**: false (automatic legend)
     /// - returns: `true` if a custom legend entries has been set
-    open var isLegendCustom: Bool
+    @objc open var isLegendCustom: Bool
     {
         return _isLegendCustom
     }
@@ -684,7 +684,7 @@ open class Legend: ComponentBase
     }
     
     /// This constructor is deprecated - Use `init(entries:)`
-    @available(*, deprecated: 1.0, message: "Use `init(entries:)`")
+    @objc @available(*, deprecated: 1.0, message: "Use `init(entries:)`")
     public init(colors: [NSObject], labels: [NSObject])
     {
         super.init()
@@ -713,21 +713,21 @@ open class Legend: ComponentBase
     }
     
     /// This property is deprecated - Use `extraEntries`
-    @available(*, deprecated: 1.0, message: "Use `extraEntries`")
+    @objc @available(*, deprecated: 1.0, message: "Use `extraEntries`")
     open var extraColorsObjc: [NSObject]
     {
         return ChartUtils.bridgedObjCGetNSUIColorArray(swift: extraColors)
     }
     
     /// This property is deprecated - Use `extraLabels`
-    @available(*, deprecated: 1.0, message: "Use `extraLabels`")
+    @objc @available(*, deprecated: 1.0, message: "Use `extraLabels`")
     open var extraLabelsObjc: [NSObject]
     {
         return ChartUtils.bridgedObjCGetStringArray(swift: extraLabels)
     }
     
     /// This property is deprecated - Use `colors`
-    @available(*, deprecated: 1.0, message: "Use `colors`")
+    @objc @available(*, deprecated: 1.0, message: "Use `colors`")
     open var colorsObjc: [NSObject]
     {
         get { return ChartUtils.bridgedObjCGetNSUIColorArray(swift: colors) }
@@ -735,7 +735,7 @@ open class Legend: ComponentBase
     }
     
     /// This property is deprecated - Use `labels`
-    @available(*, deprecated: 1.0, message: "Use `labels`")
+    @objc @available(*, deprecated: 1.0, message: "Use `labels`")
     open var labelsObjc: [NSObject]
     {
         get { return ChartUtils.bridgedObjCGetStringArray(swift: labels) }
@@ -743,7 +743,7 @@ open class Legend: ComponentBase
     }
     
     /// This function is deprecated - Use `entries`
-    @available(*, deprecated: 1.0, message: "Use `entries`")
+    @objc @available(*, deprecated: 1.0, message: "Use `entries`")
     open func getLabel(_ index: Int) -> String?
     {
         return entries[index].label
@@ -777,7 +777,7 @@ open class Legend: ComponentBase
     }
     
     /// This function is deprecated - Use `Use `extra(entries:)`
-    @available(*, deprecated: 1.0, message: "Use `extra(entries:)`")
+    @objc @available(*, deprecated: 1.0, message: "Use `extra(entries:)`")
     open func setExtra(colors: [NSObject], labels: [NSObject])
     {
         var entries = [LegendEntry]()
@@ -831,7 +831,7 @@ open class Legend: ComponentBase
     }
     
     /// This function is deprecated - Use `Use `setCustom(entries:)`
-    @available(*, deprecated: 1.0, message: "Use `setCustom(entries:)`")
+    @objc @available(*, deprecated: 1.0, message: "Use `setCustom(entries:)`")
     open func setCustom(colors: [NSObject], labels: [NSObject])
     {
         var entries = [LegendEntry]()

--- a/Source/Charts/Components/LegendEntry.swift
+++ b/Source/Charts/Components/LegendEntry.swift
@@ -32,7 +32,7 @@ open class LegendEntry: NSObject
     /// - parameter formLineDashPhase:      Line dash configuration.
     /// - parameter formLineDashLengths:    Line dash configurationas NaN to use the legend's default.
     /// - parameter formColor:              The color for drawing the form.
-    public init(label: String?,
+    @objc public init(label: String?,
                 form: Legend.Form,
                 formSize: CGFloat,
                 formLineWidth: CGFloat,
@@ -51,31 +51,31 @@ open class LegendEntry: NSObject
     
     /// The legend entry text.
     /// A `nil` label will start a group.
-    open var label: String?
+    @objc open var label: String?
     
     /// The form to draw for this entry.
     ///
     /// `None` will avoid drawing a form, and any related space.
     /// `Empty` will avoid drawing a form, but keep its space.
     /// `Default` will use the Legend's default.
-    open var form: Legend.Form = .default
+    @objc open var form: Legend.Form = .default
     
     /// Form size will be considered except for when .None is used
     ///
     /// Set as NaN to use the legend's default
-    open var formSize: CGFloat = CGFloat.nan
+    @objc open var formSize: CGFloat = CGFloat.nan
     
     /// Line width used for shapes that consist of lines.
     ///
     /// Set to NaN to use the legend's default.
-    open var formLineWidth: CGFloat = CGFloat.nan
+    @objc open var formLineWidth: CGFloat = CGFloat.nan
     
     /// Line dash configuration for shapes that consist of lines.
     ///
     /// This is how much (in pixels) into the dash pattern are we starting from.
     ///
     /// Set to NaN to use the legend's default.
-    open var formLineDashPhase: CGFloat = 0.0
+    @objc open var formLineDashPhase: CGFloat = 0.0
     
     /// Line dash configuration for shapes that consist of lines.
     ///
@@ -84,8 +84,8 @@ open class LegendEntry: NSObject
     /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
     ///
     /// Set to nil to use the legend's default.
-    open var formLineDashLengths: [CGFloat]?
+    @objc open var formLineDashLengths: [CGFloat]?
     
     /// The color for drawing the form
-    open var formColor: NSUIColor?
+    @objc open var formColor: NSUIColor?
 }

--- a/Source/Charts/Components/MarkerImage.swift
+++ b/Source/Charts/Components/MarkerImage.swift
@@ -20,14 +20,14 @@ import CoreGraphics
 open class MarkerImage: NSObject, IMarker
 {
     /// The marker image to render
-    open var image: NSUIImage?
+    @objc open var image: NSUIImage?
     
     open var offset: CGPoint = CGPoint()
     
-    open weak var chartView: ChartViewBase?
+    @objc open weak var chartView: ChartViewBase?
     
     /// As long as size is 0.0/0.0 - it will default to the image's size
-    open var size: CGSize = CGSize()
+    @objc open var size: CGSize = CGSize()
     
     public override init()
     {

--- a/Source/Charts/Components/MarkerView.swift
+++ b/Source/Charts/Components/MarkerView.swift
@@ -21,7 +21,7 @@ open class MarkerView: NSUIView, IMarker
 {
     open var offset: CGPoint = CGPoint()
     
-    open weak var chartView: ChartViewBase?
+    @objc open weak var chartView: ChartViewBase?
     
     open func offsetForDrawing(atPoint point: CGPoint) -> CGPoint
     {

--- a/Source/Charts/Components/MarkerView.swift
+++ b/Source/Charts/Components/MarkerView.swift
@@ -82,10 +82,10 @@ open class MarkerView: NSUIView, IMarker
         #else
             
             var loadedObjects = NSArray()
-            let loadedObjectsPointer = AutoreleasingUnsafeMutablePointer<NSArray>(&loadedObjects)
+            let loadedObjectsPointer = AutoreleasingUnsafeMutablePointer<NSArray?>(&loadedObjects)
             
             if Bundle.main.loadNibNamed(
-                String(describing: self),
+                NSNib.Name(String(describing: self)),
                 owner: nil,
                 topLevelObjects: loadedObjectsPointer)
             {

--- a/Source/Charts/Components/XAxis.swift
+++ b/Source/Charts/Components/XAxis.swift
@@ -26,40 +26,40 @@ open class XAxis: AxisBase
     }
     
     /// width of the x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
-    open var labelWidth = CGFloat(1.0)
+    @objc open var labelWidth = CGFloat(1.0)
     
     /// height of the x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
-    open var labelHeight = CGFloat(1.0)
+    @objc open var labelHeight = CGFloat(1.0)
     
     /// width of the (rotated) x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
-    open var labelRotatedWidth = CGFloat(1.0)
+    @objc open var labelRotatedWidth = CGFloat(1.0)
     
     /// height of the (rotated) x-axis labels in pixels - this is automatically calculated by the `computeSize()` methods in the renderers
-    open var labelRotatedHeight = CGFloat(1.0)
+    @objc open var labelRotatedHeight = CGFloat(1.0)
     
     /// This is the angle for drawing the X axis labels (in degrees)
-    open var labelRotationAngle = CGFloat(0.0)
+    @objc open var labelRotationAngle = CGFloat(0.0)
 
     /// if set to true, the chart will avoid that the first and last label entry in the chart "clip" off the edge of the chart
-    open var avoidFirstLastClippingEnabled = false
+    @objc open var avoidFirstLastClippingEnabled = false
     
     /// the position of the x-labels relative to the chart
-    open var labelPosition = LabelPosition.top
+    @objc open var labelPosition = LabelPosition.top
     
     /// if set to true, word wrapping the labels will be enabled.
     /// word wrapping is done using `(value width * labelRotatedWidth)`
     ///
     /// - note: currently supports all charts except pie/radar/horizontal-bar*
-    open var wordWrapEnabled = false
+    @objc open var wordWrapEnabled = false
     
     /// - returns: `true` if word wrapping the labels is enabled
-    open var isWordWrapEnabled: Bool { return wordWrapEnabled }
+    @objc open var isWordWrapEnabled: Bool { return wordWrapEnabled }
     
     /// the width for wrapping the labels, as percentage out of one value width.
     /// used only when isWordWrapEnabled = true.
     /// 
     /// **default**: 1.0
-    open var wordWrapWidthPercent: CGFloat = 1.0
+    @objc open var wordWrapWidthPercent: CGFloat = 1.0
     
     public override init()
     {
@@ -68,7 +68,7 @@ open class XAxis: AxisBase
         self.yOffset = 4.0
     }
     
-    open var isAvoidFirstLastClippingEnabled: Bool
+    @objc open var isAvoidFirstLastClippingEnabled: Bool
     {
         return avoidFirstLastClippingEnabled
     }

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -39,39 +39,39 @@ open class YAxis: AxisBase
     }
     
     /// indicates if the bottom y-label entry is drawn or not
-    open var drawBottomYLabelEntryEnabled = true
+    @objc open var drawBottomYLabelEntryEnabled = true
     
     /// indicates if the top y-label entry is drawn or not
-    open var drawTopYLabelEntryEnabled = true
+    @objc open var drawTopYLabelEntryEnabled = true
     
     /// flag that indicates if the axis is inverted or not
-    open var inverted = false
+    @objc open var inverted = false
     
     /// flag that indicates if the zero-line should be drawn regardless of other grid lines
-    open var drawZeroLineEnabled = false
+    @objc open var drawZeroLineEnabled = false
     
     /// Color of the zero line
-    open var zeroLineColor: NSUIColor? = NSUIColor.gray
+    @objc open var zeroLineColor: NSUIColor? = NSUIColor.gray
     
     /// Width of the zero line
-    open var zeroLineWidth: CGFloat = 1.0
+    @objc open var zeroLineWidth: CGFloat = 1.0
     
     /// This is how much (in pixels) into the dash pattern are we starting from.
-    open var zeroLineDashPhase = CGFloat(0.0)
+    @objc open var zeroLineDashPhase = CGFloat(0.0)
     
     /// This is the actual dash pattern.
     /// I.e. [2, 3] will paint [--   --   ]
     /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
-    open var zeroLineDashLengths: [CGFloat]?
+    @objc open var zeroLineDashLengths: [CGFloat]?
 
     /// axis space from the largest value to the top in percent of the total axis range
-    open var spaceTop = CGFloat(0.1)
+    @objc open var spaceTop = CGFloat(0.1)
 
     /// axis space from the smallest value to the bottom in percent of the total axis range
-    open var spaceBottom = CGFloat(0.1)
+    @objc open var spaceBottom = CGFloat(0.1)
     
     /// the position of the y-labels relative to the chart
-    open var labelPosition = LabelPosition.outsideChart
+    @objc open var labelPosition = LabelPosition.outsideChart
     
     /// the side this axis object represents
     fileprivate var _axisDependency = AxisDependency.left
@@ -79,13 +79,13 @@ open class YAxis: AxisBase
     /// the minimum width that the axis should take
     /// 
     /// **default**: 0.0
-    open var minWidth = CGFloat(0)
+    @objc open var minWidth = CGFloat(0)
     
     /// the maximum width that the axis can take.
     /// use Infinity for disabling the maximum.
     /// 
     /// **default**: CGFloat.infinity
-    open var maxWidth = CGFloat(CGFloat.infinity)
+    @objc open var maxWidth = CGFloat(CGFloat.infinity)
     
     public override init()
     {
@@ -94,7 +94,7 @@ open class YAxis: AxisBase
         self.yOffset = 0.0
     }
     
-    public init(position: AxisDependency)
+    @objc public init(position: AxisDependency)
     {
         super.init()
         
@@ -103,28 +103,28 @@ open class YAxis: AxisBase
         self.yOffset = 0.0
     }
     
-    open var axisDependency: AxisDependency
+    @objc open var axisDependency: AxisDependency
     {
         return _axisDependency
     }
     
-    open func requiredSize() -> CGSize
+    @objc open func requiredSize() -> CGSize
     {
         let label = getLongestLabel() as NSString
-        var size = label.size(attributes: [NSFontAttributeName: labelFont])
+        var size = label.size(withAttributes: [NSAttributedStringKey.font: labelFont])
         size.width += xOffset * 2.0
         size.height += yOffset * 2.0
         size.width = max(minWidth, min(size.width, maxWidth > 0.0 ? maxWidth : size.width))
         return size
     }
     
-    open func getRequiredHeightSpace() -> CGFloat
+    @objc open func getRequiredHeightSpace() -> CGFloat
     {
         return requiredSize().height
     }
     
     /// - returns: `true` if this axis needs horizontal offset, `false` ifno offset is needed.
-    open var needsOffset: Bool
+    @objc open var needsOffset: Bool
     {
         if isEnabled && isDrawLabelsEnabled && labelPosition == .outsideChart
         {
@@ -136,7 +136,7 @@ open class YAxis: AxisBase
         }
     }
     
-    open var isInverted: Bool { return inverted }
+    @objc open var isInverted: Bool { return inverted }
     
     open override func calculate(min dataMin: Double, max dataMax: Double)
     {
@@ -172,8 +172,8 @@ open class YAxis: AxisBase
         axisRange = abs(_axisMaximum - _axisMinimum)
     }
     
-    open var isDrawBottomYLabelEntryEnabled: Bool { return drawBottomYLabelEntryEnabled }
+    @objc open var isDrawBottomYLabelEntryEnabled: Bool { return drawBottomYLabelEntryEnabled }
     
-    open var isDrawTopYLabelEntryEnabled: Bool { return drawTopYLabelEntryEnabled }
+    @objc open var isDrawTopYLabelEntryEnabled: Bool { return drawTopYLabelEntryEnabled }
 
 }

--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -24,7 +24,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
         valueColors.append(NSUIColor.black)
     }
     
-    public init(label: String?)
+    @objc public init(label: String?)
     {
         super.init()
         
@@ -235,7 +235,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     /// Sets colors to a single color a specific alpha value.
     /// - parameter color: the color to set
     /// - parameter alpha: alpha to apply to the set `color`
-    open func setColor(_ color: NSUIColor, alpha: CGFloat)
+    @objc open func setColor(_ color: NSUIColor, alpha: CGFloat)
     {
         setColor(color.withAlphaComponent(alpha))
     }
@@ -243,7 +243,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     /// Sets colors with a specific alpha value.
     /// - parameter colors: the colors to set
     /// - parameter alpha: alpha to apply to the set `colors`
-    open func setColors(_ colors: [NSUIColor], alpha: CGFloat)
+    @objc open func setColors(_ colors: [NSUIColor], alpha: CGFloat)
     {
         var colorsWithAlpha = colors
         
@@ -270,7 +270,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     open var isHighlightEnabled: Bool { return highlightEnabled }
     
     /// Custom formatter that is used instead of the auto-formatter if set
-    internal var _valueFormatter: IValueFormatter?
+    @objc internal var _valueFormatter: IValueFormatter?
     
     /// Custom formatter that is used instead of the auto-formatter if set
     open var valueFormatter: IValueFormatter?
@@ -411,7 +411,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     
     // MARK: - NSCopying
     
-    open func copyWithZone(_ zone: NSZone?) -> AnyObject
+    @objc open func copyWithZone(_ zone: NSZone?) -> AnyObject
     {
         let copy = type(of: self).init()
         

--- a/Source/Charts/Data/Implementations/Standard/BarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartData.swift
@@ -27,7 +27,7 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
     /// The width of the bars on the x-axis, in values (not pixels)
     ///
     /// **default**: 0.85
-    open var barWidth = Double(0.85)
+    @objc open var barWidth = Double(0.85)
     
     /// Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
     /// Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
@@ -36,7 +36,7 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
     /// - parameter the starting point on the x-axis where the grouping should begin
     /// - parameter groupSpace: The space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
     /// - parameter barSpace: The space between individual bars in values (not pixels) e.g. 0.1f for bar width 1f
-    open func groupBars(fromX: Double, groupSpace: Double, barSpace: Double)
+    @objc open func groupBars(fromX: Double, groupSpace: Double, barSpace: Double)
     {
         let setCount = _dataSets.count
         if setCount <= 1
@@ -98,7 +98,7 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
     ///
     /// - parameter groupSpace:
     /// - parameter barSpace:
-    open func groupWidth(groupSpace: Double, barSpace: Double) -> Double
+    @objc open func groupWidth(groupSpace: Double, barSpace: Double) -> Double
     {
         return Double(_dataSets.count) * (self.barWidth + barSpace) + groupSpace
     }

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -55,7 +55,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for stacked bar entries.
-    public init(x: Double, yValues: [Double])
+    @objc public init(x: Double, yValues: [Double])
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues))
         self._yVals = yValues
@@ -64,7 +64,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// This constructor is misleading, please use the `data` argument instead of `label`.
-    @available(*, deprecated: 1.0, message: "Use `data` argument instead of `label`.")
+    @objc @available(*, deprecated: 1.0, message: "Use `data` argument instead of `label`.")
     public init(x: Double, yValues: [Double], label: String)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), data: label as AnyObject?)
@@ -74,7 +74,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for stacked bar entries. One data object for whole stack
-    public init(x: Double, yValues: [Double], data: AnyObject?)
+    @objc public init(x: Double, yValues: [Double], data: AnyObject?)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), data: data)
         self._yVals = yValues
@@ -83,7 +83,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for stacked bar entries. One data object for whole stack
-    public init(x: Double, yValues: [Double], icon: NSUIImage?, data: AnyObject?)
+    @objc public init(x: Double, yValues: [Double], icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), icon: icon, data: data)
         self._yVals = yValues
@@ -92,7 +92,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for stacked bar entries. One data object for whole stack
-    public init(x: Double, yValues: [Double], icon: NSUIImage?)
+    @objc public init(x: Double, yValues: [Double], icon: NSUIImage?)
     {
         super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), icon: icon)
         self._yVals = yValues
@@ -100,7 +100,7 @@ open class BarChartDataEntry: ChartDataEntry
         calcRanges()
     }
     
-    open func sumBelow(stackIndex :Int) -> Double
+    @objc open func sumBelow(stackIndex :Int) -> Double
     {
         if _yVals == nil
         {
@@ -120,18 +120,18 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// - returns: The sum of all negative values this entry (if stacked) contains. (this is a positive number)
-    open var negativeSum: Double
+    @objc open var negativeSum: Double
     {
         return _negativeSum
     }
     
     /// - returns: The sum of all positive values this entry (if stacked) contains.
-    open var positiveSum: Double
+    @objc open var positiveSum: Double
     {
         return _positiveSum
     }
 
-    open func calcPosNegSum()
+    @objc open func calcPosNegSum()
     {
         if _yVals == nil
         {
@@ -162,7 +162,7 @@ open class BarChartDataEntry: ChartDataEntry
     /// Splits up the stack-values of the given bar-entry into Range objects.
     /// - parameter entry:
     /// - returns:
-    open func calcRanges()
+    @objc open func calcRanges()
     {
         let values = yValues
         if values?.isEmpty != false
@@ -204,10 +204,10 @@ open class BarChartDataEntry: ChartDataEntry
     // MARK: Accessors
     
     /// the values the stacked barchart holds
-    open var isStacked: Bool { return _yVals != nil }
+    @objc open var isStacked: Bool { return _yVals != nil }
     
     /// the values the stacked barchart holds
-    open var yValues: [Double]?
+    @objc open var yValues: [Double]?
     {
         get { return self._yVals }
         set
@@ -220,7 +220,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// - returns: The ranges of the individual stack-entries. Will return null if this entry is not stacked.
-    open var ranges: [Range]?
+    @objc open var ranges: [Range]?
     {
         return _ranges
     }

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -127,7 +127,7 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
     }
     
     /// - returns: The overall entry count, including counting each stack-value individually
-    open var entryCountStacks: Int
+    @objc open var entryCountStacks: Int
     {
         return _entryCountStacks
     }

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartData.swift
@@ -25,7 +25,7 @@ open class BubbleChartData: BarLineScatterCandleBubbleChartData
     }
     
     /// Sets the width of the circle that surrounds the bubble when highlighted for all DataSet objects this data object contains
-    open func setHighlightCircleWidth(_ width: CGFloat)
+    @objc open func setHighlightCircleWidth(_ width: CGFloat)
     {
         for set in (_dataSets as? [IBubbleChartDataSet])!
         {

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
@@ -15,7 +15,7 @@ import CoreGraphics
 open class BubbleChartDataEntry: ChartDataEntry
 {
     /// The size of the bubble.
-    open var size = CGFloat(0.0)
+    @objc open var size = CGFloat(0.0)
     
     public required init()
     {
@@ -25,7 +25,7 @@ open class BubbleChartDataEntry: ChartDataEntry
     /// - parameter x: The index on the x-axis.
     /// - parameter y: The value on the y-axis.
     /// - parameter size: The size of the bubble.
-    public init(x: Double, y: Double, size: CGFloat)
+    @objc public init(x: Double, y: Double, size: CGFloat)
     {
         super.init(x: x, y: y)
         
@@ -36,7 +36,7 @@ open class BubbleChartDataEntry: ChartDataEntry
     /// - parameter y: The value on the y-axis.
     /// - parameter size: The size of the bubble.
     /// - parameter data: Spot for additional data this Entry represents.
-    public init(x: Double, y: Double, size: CGFloat, data: AnyObject?)
+    @objc public init(x: Double, y: Double, size: CGFloat, data: AnyObject?)
     {
         super.init(x: x, y: y, data: data)
         
@@ -47,7 +47,7 @@ open class BubbleChartDataEntry: ChartDataEntry
     /// - parameter y: The value on the y-axis.
     /// - parameter size: The size of the bubble.
     /// - parameter icon: icon image
-    public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?)
+    @objc public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?)
     {
         super.init(x: x, y: y, icon: icon)
         
@@ -59,7 +59,7 @@ open class BubbleChartDataEntry: ChartDataEntry
     /// - parameter size: The size of the bubble.
     /// - parameter icon: icon image
     /// - parameter data: Spot for additional data this Entry represents.
-    public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: AnyObject?)
+    @objc public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: x, y: y, icon: icon, data: data)
         

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataSet.swift
@@ -17,10 +17,10 @@ open class BubbleChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBubbleCh
 {
     // MARK: - Data functions and accessors
     
-    internal var _maxSize = CGFloat(0.0)
+    @objc internal var _maxSize = CGFloat(0.0)
     
     open var maxSize: CGFloat { return _maxSize }
-    open var normalizeSizeEnabled: Bool = true
+    @objc open var normalizeSizeEnabled: Bool = true
     open var isNormalizeSizeEnabled: Bool { return normalizeSizeEnabled }
     
     open override func calcMinMax(entry e: ChartDataEntry)

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
@@ -14,23 +14,23 @@ import Foundation
 open class CandleChartDataEntry: ChartDataEntry
 {
     /// shadow-high value
-    open var high = Double(0.0)
+    @objc open var high = Double(0.0)
     
     /// shadow-low value
-    open var low = Double(0.0)
+    @objc open var low = Double(0.0)
     
     /// close value
-    open var close = Double(0.0)
+    @objc open var close = Double(0.0)
     
     /// open value
-    open var open = Double(0.0)
+    @objc open var open = Double(0.0)
     
     public required init()
     {
         super.init()
     }
     
-    public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double)
+    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double)
     {
         super.init(x: x, y: (shadowH + shadowL) / 2.0)
         
@@ -40,7 +40,7 @@ open class CandleChartDataEntry: ChartDataEntry
         self.close = close
     }
     
-    public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, data: AnyObject?)
+    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, data: AnyObject?)
     {
         super.init(x: x, y: (shadowH + shadowL) / 2.0, data: data)
         
@@ -50,7 +50,7 @@ open class CandleChartDataEntry: ChartDataEntry
         self.close = close
     }
     
-    public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?)
+    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?)
     {
         super.init(x: x, y: (shadowH + shadowL) / 2.0, icon: icon)
         
@@ -60,7 +60,7 @@ open class CandleChartDataEntry: ChartDataEntry
         self.close = close
     }
     
-    public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: x, y: (shadowH + shadowL) / 2.0, icon: icon, data: data)
         
@@ -71,13 +71,13 @@ open class CandleChartDataEntry: ChartDataEntry
     }
     
     /// - returns: The overall range (difference) between shadow-high and shadow-low.
-    open var shadowRange: Double
+    @objc open var shadowRange: Double
     {
         return abs(high - low)
     }
     
     /// - returns: The body size (difference between open and close).
-    open var bodyRange: Double
+    @objc open var bodyRange: Double
     {
         return abs(open - close)
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -13,16 +13,16 @@ import Foundation
 
 open class ChartData: NSObject
 {
-    internal var _yMax: Double = -Double.greatestFiniteMagnitude
-    internal var _yMin: Double = Double.greatestFiniteMagnitude
-    internal var _xMax: Double = -Double.greatestFiniteMagnitude
-    internal var _xMin: Double = Double.greatestFiniteMagnitude
-    internal var _leftAxisMax: Double = -Double.greatestFiniteMagnitude
-    internal var _leftAxisMin: Double = Double.greatestFiniteMagnitude
-    internal var _rightAxisMax: Double = -Double.greatestFiniteMagnitude
-    internal var _rightAxisMin: Double = Double.greatestFiniteMagnitude
+    @objc internal var _yMax: Double = -Double.greatestFiniteMagnitude
+    @objc internal var _yMin: Double = Double.greatestFiniteMagnitude
+    @objc internal var _xMax: Double = -Double.greatestFiniteMagnitude
+    @objc internal var _xMin: Double = Double.greatestFiniteMagnitude
+    @objc internal var _leftAxisMax: Double = -Double.greatestFiniteMagnitude
+    @objc internal var _leftAxisMin: Double = Double.greatestFiniteMagnitude
+    @objc internal var _rightAxisMax: Double = -Double.greatestFiniteMagnitude
+    @objc internal var _rightAxisMin: Double = Double.greatestFiniteMagnitude
     
-    internal var _dataSets = [IChartDataSet]()
+    @objc internal var _dataSets = [IChartDataSet]()
     
     public override init()
     {
@@ -31,7 +31,7 @@ open class ChartData: NSObject
         _dataSets = [IChartDataSet]()
     }
     
-    public init(dataSets: [IChartDataSet]?)
+    @objc public init(dataSets: [IChartDataSet]?)
     {
         super.init()
         
@@ -40,24 +40,24 @@ open class ChartData: NSObject
         self.initialize(dataSets: _dataSets)
     }
     
-    public convenience init(dataSet: IChartDataSet?)
+    @objc public convenience init(dataSet: IChartDataSet?)
     {
         self.init(dataSets: dataSet === nil ? nil : [dataSet!])
     }
     
-    internal func initialize(dataSets: [IChartDataSet])
+    @objc internal func initialize(dataSets: [IChartDataSet])
     {
         notifyDataChanged()
     }
     
     /// Call this method to let the ChartData know that the underlying data has changed.
     /// Calling this performs all necessary recalculations needed when the contained data has changed.
-    open func notifyDataChanged()
+    @objc open func notifyDataChanged()
     {
         calcMinMax()
     }
     
-    open func calcMinMaxY(fromX: Double, toX: Double)
+    @objc open func calcMinMaxY(fromX: Double, toX: Double)
     {
         for set in _dataSets
         {
@@ -69,7 +69,7 @@ open class ChartData: NSObject
     }
     
     /// calc minimum and maximum y value over all datasets
-    open func calcMinMax()
+    @objc open func calcMinMax()
     {
         _yMax = -Double.greatestFiniteMagnitude
         _yMin = Double.greatestFiniteMagnitude
@@ -138,7 +138,7 @@ open class ChartData: NSObject
     }
     
     /// Adjusts the current minimum and maximum values based on the provided Entry object.
-    open func calcMinMax(entry e: ChartDataEntry, axis: YAxis.AxisDependency)
+    @objc open func calcMinMax(entry e: ChartDataEntry, axis: YAxis.AxisDependency)
     {
         if _yMax < e.y
         {
@@ -187,7 +187,7 @@ open class ChartData: NSObject
     }
     
     /// Adjusts the minimum and maximum values based on the given DataSet.
-    open func calcMinMax(dataSet d: IChartDataSet)
+    @objc open func calcMinMax(dataSet d: IChartDataSet)
     {
         if _yMax < d.yMax
         {
@@ -236,13 +236,13 @@ open class ChartData: NSObject
     }
     
     /// - returns: The number of LineDataSets this object contains
-    open var dataSetCount: Int
+    @objc open var dataSetCount: Int
     {
         return _dataSets.count
     }
     
     /// - returns: The smallest y-value the data object contains.
-    open var yMin: Double
+    @objc open var yMin: Double
     {
         return _yMin
     }
@@ -253,7 +253,7 @@ open class ChartData: NSObject
         return _yMin
     }
     
-    open func getYMin(axis: YAxis.AxisDependency) -> Double
+    @objc open func getYMin(axis: YAxis.AxisDependency) -> Double
     {
         if axis == .left
         {
@@ -280,7 +280,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The greatest y-value the data object contains.
-    open var yMax: Double
+    @objc open var yMax: Double
     {
         return _yMax
     }
@@ -291,7 +291,7 @@ open class ChartData: NSObject
         return _yMax
     }
     
-    open func getYMax(axis: YAxis.AxisDependency) -> Double
+    @objc open func getYMax(axis: YAxis.AxisDependency) -> Double
     {
         if axis == .left
         {
@@ -318,18 +318,18 @@ open class ChartData: NSObject
     }
     
     /// - returns: The minimum x-value the data object contains.
-    open var xMin: Double
+    @objc open var xMin: Double
     {
         return _xMin
     }
     /// - returns: The maximum x-value the data object contains.
-    open var xMax: Double
+    @objc open var xMax: Double
     {
         return _xMax
     }
     
     /// - returns: All DataSet objects this ChartData object holds.
-    open var dataSets: [IChartDataSet]
+    @objc open var dataSets: [IChartDataSet]
     {
         get
         {
@@ -350,7 +350,7 @@ open class ChartData: NSObject
     /// - parameter type:
     /// - parameter ignorecase: if true, the search is not case-sensitive
     /// - returns: The index of the DataSet Object with the given label. Sensitive or not.
-    internal func getDataSetIndexByLabel(_ label: String, ignorecase: Bool) -> Int
+    @objc internal func getDataSetIndexByLabel(_ label: String, ignorecase: Bool) -> Int
     {
         if ignorecase
         {
@@ -381,7 +381,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The labels of all DataSets as a string array.
-    internal func dataSetLabels() -> [String]
+    @objc internal func dataSetLabels() -> [String]
     {
         var types = [String]()
         
@@ -402,7 +402,7 @@ open class ChartData: NSObject
     ///
     /// - parameter highlight:
     /// - returns: The entry that is highlighted
-    open func entryForHighlight(_ highlight: Highlight) -> ChartDataEntry?
+    @objc open func entryForHighlight(_ highlight: Highlight) -> ChartDataEntry?
     {
         if highlight.dataSetIndex >= dataSets.count
         {
@@ -419,7 +419,7 @@ open class ChartData: NSObject
     /// - parameter label:
     /// - parameter ignorecase:
     /// - returns: The DataSet Object with the given label. Sensitive or not.
-    open func getDataSetByLabel(_ label: String, ignorecase: Bool) -> IChartDataSet?
+    @objc open func getDataSetByLabel(_ label: String, ignorecase: Bool) -> IChartDataSet?
     {
         let index = getDataSetIndexByLabel(label, ignorecase: ignorecase)
         
@@ -433,7 +433,7 @@ open class ChartData: NSObject
         }
     }
     
-    open func getDataSetByIndex(_ index: Int) -> IChartDataSet!
+    @objc open func getDataSetByIndex(_ index: Int) -> IChartDataSet!
     {
         if index < 0 || index >= _dataSets.count
         {
@@ -443,7 +443,7 @@ open class ChartData: NSObject
         return _dataSets[index]
     }
     
-    open func addDataSet(_ dataSet: IChartDataSet!)
+    @objc open func addDataSet(_ dataSet: IChartDataSet!)
     {
         calcMinMax(dataSet: dataSet)
         
@@ -454,7 +454,7 @@ open class ChartData: NSObject
     /// Also recalculates all minimum and maximum values.
     ///
     /// - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
-    @discardableResult open func removeDataSet(_ dataSet: IChartDataSet!) -> Bool
+    @objc @discardableResult open func removeDataSet(_ dataSet: IChartDataSet!) -> Bool
     {
         if dataSet === nil
         {
@@ -476,7 +476,7 @@ open class ChartData: NSObject
     /// Also recalculates all minimum and maximum values. 
     ///
     /// - returns: `true` if a DataSet was removed, `false` ifno DataSet could be removed.
-    @discardableResult open func removeDataSetByIndex(_ index: Int) -> Bool
+    @objc @discardableResult open func removeDataSetByIndex(_ index: Int) -> Bool
     {
         if index >= _dataSets.count || index < 0
         {
@@ -491,7 +491,7 @@ open class ChartData: NSObject
     }
     
     /// Adds an Entry to the DataSet at the specified index. Entries are added to the end of the list.
-    open func addEntry(_ e: ChartDataEntry, dataSetIndex: Int)
+    @objc open func addEntry(_ e: ChartDataEntry, dataSetIndex: Int)
     {
         if _dataSets.count > dataSetIndex && dataSetIndex >= 0
         {
@@ -508,7 +508,7 @@ open class ChartData: NSObject
     }
     
     /// Removes the given Entry object from the DataSet at the specified index.
-    @discardableResult open func removeEntry(_ entry: ChartDataEntry, dataSetIndex: Int) -> Bool
+    @objc @discardableResult open func removeEntry(_ entry: ChartDataEntry, dataSetIndex: Int) -> Bool
     {
         // entry outofbounds
         if dataSetIndex >= _dataSets.count
@@ -530,7 +530,7 @@ open class ChartData: NSObject
     /// Removes the Entry object closest to the given xIndex from the ChartDataSet at the
     /// specified index. 
     /// - returns: `true` if an entry was removed, `false` ifno Entry was found that meets the specified requirements.
-    @discardableResult open func removeEntry(xValue: Double, dataSetIndex: Int) -> Bool
+    @objc @discardableResult open func removeEntry(xValue: Double, dataSetIndex: Int) -> Bool
     {
         if dataSetIndex >= _dataSets.count
         {
@@ -546,7 +546,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The DataSet that contains the provided Entry, or null, if no DataSet contains this entry.
-    open func getDataSetForEntry(_ e: ChartDataEntry!) -> IChartDataSet?
+    @objc open func getDataSetForEntry(_ e: ChartDataEntry!) -> IChartDataSet?
     {
         if e == nil
         {
@@ -567,7 +567,7 @@ open class ChartData: NSObject
     }
 
     /// - returns: The index of the provided DataSet in the DataSet array of this data object, or -1 if it does not exist.
-    open func indexOfDataSet(_ dataSet: IChartDataSet) -> Int
+    @objc open func indexOfDataSet(_ dataSet: IChartDataSet) -> Int
     {
         for i in 0 ..< _dataSets.count
         {
@@ -581,7 +581,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The first DataSet from the datasets-array that has it's dependency on the left axis. Returns null if no DataSet with left dependency could be found.
-    open func getFirstLeft(dataSets: [IChartDataSet]) -> IChartDataSet?
+    @objc open func getFirstLeft(dataSets: [IChartDataSet]) -> IChartDataSet?
     {
         for dataSet in dataSets
         {
@@ -595,7 +595,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The first DataSet from the datasets-array that has it's dependency on the right axis. Returns null if no DataSet with right dependency could be found.
-    open func getFirstRight(dataSets: [IChartDataSet]) -> IChartDataSet?
+    @objc open func getFirstRight(dataSets: [IChartDataSet]) -> IChartDataSet?
     {
         for dataSet in _dataSets
         {
@@ -609,7 +609,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: All colors used across all DataSet objects this object represents.
-    open func getColors() -> [NSUIColor]?
+    @objc open func getColors() -> [NSUIColor]?
     {
         var clrcnt = 0
         
@@ -634,7 +634,7 @@ open class ChartData: NSObject
     }
     
     /// Sets a custom IValueFormatter for all DataSets this data object contains.
-    open func setValueFormatter(_ formatter: IValueFormatter?)
+    @objc open func setValueFormatter(_ formatter: IValueFormatter?)
     {
         guard let formatter = formatter
             else { return }
@@ -646,7 +646,7 @@ open class ChartData: NSObject
     }
     
     /// Sets the color of the value-text (color in which the value-labels are drawn) for all DataSets this data object contains.
-    open func setValueTextColor(_ color: NSUIColor!)
+    @objc open func setValueTextColor(_ color: NSUIColor!)
     {
         for set in dataSets
         {
@@ -655,7 +655,7 @@ open class ChartData: NSObject
     }
     
     /// Sets the font for all value-labels for all DataSets this data object contains.
-    open func setValueFont(_ font: NSUIFont!)
+    @objc open func setValueFont(_ font: NSUIFont!)
     {
         for set in dataSets
         {
@@ -664,7 +664,7 @@ open class ChartData: NSObject
     }
     
     /// Enables / disables drawing values (value-text) for all DataSets this data object contains.
-    open func setDrawValues(_ enabled: Bool)
+    @objc open func setDrawValues(_ enabled: Bool)
     {
         for set in dataSets
         {
@@ -674,7 +674,7 @@ open class ChartData: NSObject
     
     /// Enables / disables highlighting values for all DataSets this data object contains.
     /// If set to true, this means that values can be highlighted programmatically or by touch gesture.
-    open var highlightEnabled: Bool
+    @objc open var highlightEnabled: Bool
     {
         get
         {
@@ -698,11 +698,11 @@ open class ChartData: NSObject
     }
     
     /// if true, value highlightning is enabled
-    open var isHighlightEnabled: Bool { return highlightEnabled }
+    @objc open var isHighlightEnabled: Bool { return highlightEnabled }
     
     /// Clears this data object from all DataSets and removes all Entries.
     /// Don't forget to invalidate the chart after this.
-    open func clearValues()
+    @objc open func clearValues()
     {
         dataSets.removeAll(keepingCapacity: false)
         notifyDataChanged()
@@ -710,7 +710,7 @@ open class ChartData: NSObject
     
     /// Checks if this data object contains the specified DataSet. 
     /// - returns: `true` if so, `false` ifnot.
-    open func contains(dataSet: IChartDataSet) -> Bool
+    @objc open func contains(dataSet: IChartDataSet) -> Bool
     {
         for set in dataSets
         {
@@ -724,7 +724,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The total entry count across all DataSet objects this data object contains.
-    open var entryCount: Int
+    @objc open var entryCount: Int
     {
         var count = 0
         
@@ -737,7 +737,7 @@ open class ChartData: NSObject
     }
 
     /// - returns: The DataSet object with the maximum number of entries or null if there are no DataSets.
-    open var maxEntryCountSet: IChartDataSet?
+    @objc open var maxEntryCountSet: IChartDataSet?
     {
         if _dataSets.count == 0
         {

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -14,7 +14,7 @@ import Foundation
 open class ChartDataEntry: ChartDataEntryBase
 {
     /// the x value
-    open var x = Double(0.0)
+    @objc open var x = Double(0.0)
     
     public required init()
     {
@@ -24,7 +24,7 @@ open class ChartDataEntry: ChartDataEntryBase
     /// An Entry represents one single entry in the chart.
     /// - parameter x: the x value
     /// - parameter y: the y value (the actual value of the entry)
-    public init(x: Double, y: Double)
+    @objc public init(x: Double, y: Double)
     {
         super.init(y: y)
         
@@ -36,7 +36,7 @@ open class ChartDataEntry: ChartDataEntryBase
     /// - parameter y: the y value (the actual value of the entry)
     /// - parameter data: Space for additional data this Entry represents.
     
-    public init(x: Double, y: Double, data: AnyObject?)
+    @objc public init(x: Double, y: Double, data: AnyObject?)
     {
         super.init(y: y)
         
@@ -50,7 +50,7 @@ open class ChartDataEntry: ChartDataEntryBase
     /// - parameter y: the y value (the actual value of the entry)
     /// - parameter icon: icon image
     
-    public init(x: Double, y: Double, icon: NSUIImage?)
+    @objc public init(x: Double, y: Double, icon: NSUIImage?)
     {
         super.init(y: y, icon: icon)
         
@@ -63,7 +63,7 @@ open class ChartDataEntry: ChartDataEntryBase
     /// - parameter icon: icon image
     /// - parameter data: Space for additional data this Entry represents.
     
-    public init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(y: y, icon: icon, data: data)
         
@@ -96,7 +96,7 @@ open class ChartDataEntry: ChartDataEntryBase
     
     // MARK: NSCopying
     
-    open func copyWithZone(_ zone: NSZone?) -> AnyObject
+    @objc open func copyWithZone(_ zone: NSZone?) -> AnyObject
     {
         let copy = type(of: self).init()
         

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -14,13 +14,13 @@ import Foundation
 open class ChartDataEntryBase: NSObject
 {
     /// the y value
-    open var y = Double(0.0)
+    @objc open var y = Double(0.0)
     
     /// optional spot for additional data this Entry represents
-    open var data: AnyObject?
+    @objc open var data: AnyObject?
     
     /// optional icon image
-    open var icon: NSUIImage?
+    @objc open var icon: NSUIImage?
     
     public override required init()
     {
@@ -29,7 +29,7 @@ open class ChartDataEntryBase: NSObject
     
     /// An Entry represents one single entry in the chart.
     /// - parameter y: the y value (the actual value of the entry)
-    public init(y: Double)
+    @objc public init(y: Double)
     {
         super.init()
         
@@ -39,7 +39,7 @@ open class ChartDataEntryBase: NSObject
     /// - parameter y: the y value (the actual value of the entry)
     /// - parameter data: Space for additional data this Entry represents.
     
-    public init(y: Double, data: AnyObject?)
+    @objc public init(y: Double, data: AnyObject?)
     {
         super.init()
         
@@ -50,7 +50,7 @@ open class ChartDataEntryBase: NSObject
     /// - parameter y: the y value (the actual value of the entry)
     /// - parameter icon: icon image
     
-    public init(y: Double, icon: NSUIImage?)
+    @objc public init(y: Double, icon: NSUIImage?)
     {
         super.init()
         
@@ -62,7 +62,7 @@ open class ChartDataEntryBase: NSObject
     /// - parameter icon: icon image
     /// - parameter data: Space for additional data this Entry represents.
     
-    public init(y: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public init(y: Double, icon: NSUIImage?, data: AnyObject?)
     {
         super.init()
         

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -38,7 +38,7 @@ open class ChartDataSet: ChartBaseDataSet
         _values = [ChartDataEntry]()
     }
     
-    public init(values: [ChartDataEntry]?, label: String?)
+    @objc public init(values: [ChartDataEntry]?, label: String?)
     {
         super.init(label: label)
         
@@ -47,7 +47,7 @@ open class ChartDataSet: ChartBaseDataSet
         self.calcMinMax()
     }
     
-    public convenience init(values: [ChartDataEntry]?)
+    @objc public convenience init(values: [ChartDataEntry]?)
     {
         self.init(values: values, label: "DataSet")
     }
@@ -55,24 +55,24 @@ open class ChartDataSet: ChartBaseDataSet
     // MARK: - Data functions and accessors
     
     /// the entries that this dataset represents / holds together
-    internal var _values: [ChartDataEntry]!
+    @objc internal var _values: [ChartDataEntry]!
     
     /// maximum y-value in the value array
-    internal var _yMax: Double = -Double.greatestFiniteMagnitude
+    @objc internal var _yMax: Double = -Double.greatestFiniteMagnitude
     
     /// minimum y-value in the value array
-    internal var _yMin: Double = Double.greatestFiniteMagnitude
+    @objc internal var _yMin: Double = Double.greatestFiniteMagnitude
     
     /// maximum x-value in the value array
-    internal var _xMax: Double = -Double.greatestFiniteMagnitude
+    @objc internal var _xMax: Double = -Double.greatestFiniteMagnitude
     
     /// minimum x-value in the value array
-    internal var _xMin: Double = Double.greatestFiniteMagnitude
+    @objc internal var _xMin: Double = Double.greatestFiniteMagnitude
     
     /// *
     /// - note: Calls `notifyDataSetChanged()` after setting a new value.
     /// - returns: The array of y-values that this DataSet represents.
-    open var values: [ChartDataEntry]
+    @objc open var values: [ChartDataEntry]
     {
         get
         {
@@ -131,7 +131,7 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    open func calcMinMaxX(entry e: ChartDataEntry)
+    @objc open func calcMinMaxX(entry e: ChartDataEntry)
     {
         if e.x < _xMin
         {
@@ -143,7 +143,7 @@ open class ChartDataSet: ChartBaseDataSet
         }
     }
     
-    open func calcMinMaxY(entry e: ChartDataEntry)
+    @objc open func calcMinMaxY(entry e: ChartDataEntry)
     {
         if e.y < _yMin
         {
@@ -158,7 +158,7 @@ open class ChartDataSet: ChartBaseDataSet
     /// Updates the min and max x and y value of this DataSet based on the given Entry.
     ///
     /// - parameter e:
-    internal func calcMinMax(entry e: ChartDataEntry)
+    @objc internal func calcMinMax(entry e: ChartDataEntry)
     {
         calcMinMaxX(entry: e)
         calcMinMaxY(entry: e)

--- a/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
@@ -29,7 +29,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         super.init(dataSets: dataSets)
     }
     
-    open var lineData: LineChartData!
+    @objc open var lineData: LineChartData!
     {
         get
         {
@@ -42,7 +42,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         }
     }
     
-    open var barData: BarChartData!
+    @objc open var barData: BarChartData!
     {
         get
         {
@@ -55,7 +55,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         }
     }
     
-    open var scatterData: ScatterChartData!
+    @objc open var scatterData: ScatterChartData!
     {
         get
         {
@@ -68,7 +68,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         }
     }
     
-    open var candleData: CandleChartData!
+    @objc open var candleData: CandleChartData!
     {
         get
         {
@@ -81,7 +81,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         }
     }
     
-    open var bubbleData: BubbleChartData!
+    @objc open var bubbleData: BubbleChartData!
     {
         get
         {
@@ -160,7 +160,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
     }
     
     /// - returns: All data objects in row: line-bar-scatter-candle-bubble if not null.
-    open var allData: [ChartData]
+    @objc open var allData: [ChartData]
     {
         var data = [ChartData]()
         
@@ -188,7 +188,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         return data
     }
     
-    open func dataByIndex(_ index: Int) -> ChartData
+    @objc open func dataByIndex(_ index: Int) -> ChartData
     {
         return allData[index]
     }
@@ -297,7 +297,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
     ///
     /// - Parameter highlight: current highlight
     /// - Returns: dataset related to highlight
-    open func getDataSetByHighlight(_ highlight: Highlight) -> IChartDataSet!
+    @objc open func getDataSetByHighlight(_ highlight: Highlight) -> IChartDataSet!
     {  
         if highlight.dataIndex >= allData.count
         {

--- a/Source/Charts/Data/Implementations/Standard/PieChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartData.swift
@@ -23,7 +23,7 @@ open class PieChartData: ChartData
         super.init(dataSets: dataSets)
     }
 
-    var dataSet: IPieChartDataSet?
+    @objc var dataSet: IPieChartDataSet?
     {
         get
         {
@@ -100,7 +100,7 @@ open class PieChartData: ChartData
     }
     
     /// - returns: The total y-value sum across all DataSet objects the this object represents.
-    open var yValueSum: Double
+    @objc open var yValueSum: Double
     {
         guard let dataSet = dataSet else { return 0.0 }
         

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
@@ -21,7 +21,7 @@ open class PieChartDataEntry: ChartDataEntry
     
     /// - parameter value: The value on the y-axis
     /// - parameter label: The label for the x-axis
-    public convenience init(value: Double, label: String?)
+    @objc public convenience init(value: Double, label: String?)
     {
         self.init(value: value, label: label, icon: nil, data: nil)
     }
@@ -29,7 +29,7 @@ open class PieChartDataEntry: ChartDataEntry
     /// - parameter value: The value on the y-axis
     /// - parameter label: The label for the x-axis
     /// - parameter data: Spot for additional data this Entry represents
-    public convenience init(value: Double, label: String?, data: AnyObject?)
+    @objc public convenience init(value: Double, label: String?, data: AnyObject?)
     {
         self.init(value: value, label: label, icon: nil, data: data)
     }
@@ -37,7 +37,7 @@ open class PieChartDataEntry: ChartDataEntry
     /// - parameter value: The value on the y-axis
     /// - parameter label: The label for the x-axis
     /// - parameter icon: icon image
-    public convenience init(value: Double, label: String?, icon: NSUIImage?)
+    @objc public convenience init(value: Double, label: String?, icon: NSUIImage?)
     {
         self.init(value: value, label: label, icon: icon, data: nil)
     }
@@ -46,7 +46,7 @@ open class PieChartDataEntry: ChartDataEntry
     /// - parameter label: The label for the x-axis
     /// - parameter icon: icon image
     /// - parameter data: Spot for additional data this Entry represents
-    public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
+    @objc public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
     {
         super.init(x: 0.0, y: value, icon: icon, data: data)
         
@@ -54,21 +54,21 @@ open class PieChartDataEntry: ChartDataEntry
     }
     
     /// - parameter value: The value on the y-axis
-    public convenience init(value: Double)
+    @objc public convenience init(value: Double)
     {
         self.init(value: value, label: nil, icon: nil, data: nil)
     }
     
     /// - parameter value: The value on the y-axis
     /// - parameter data: Spot for additional data this Entry represents
-    public convenience init(value: Double, data: AnyObject?)
+    @objc public convenience init(value: Double, data: AnyObject?)
     {
         self.init(value: value, label: nil, icon: nil, data: data)
     }
     
     /// - parameter value: The value on the y-axis
     /// - parameter icon: icon image
-    public convenience init(value: Double, icon: NSUIImage?)
+    @objc public convenience init(value: Double, icon: NSUIImage?)
     {
         self.init(value: value, label: nil, icon: icon, data: nil)
     }
@@ -76,16 +76,16 @@ open class PieChartDataEntry: ChartDataEntry
     /// - parameter value: The value on the y-axis
     /// - parameter icon: icon image
     /// - parameter data: Spot for additional data this Entry represents
-    public convenience init(value: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(value: Double, icon: NSUIImage?, data: AnyObject?)
     {
         self.init(value: value, label: nil, icon: icon, data: data)
     }
     
     // MARK: Data property accessors
     
-    open var label: String?
+    @objc open var label: String?
     
-    open var value: Double
+    @objc open var value: Double
     {
         get { return y }
         set { y = newValue }

--- a/Source/Charts/Data/Implementations/Standard/RadarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartData.swift
@@ -15,13 +15,13 @@ import CoreGraphics
 
 open class RadarChartData: ChartData
 {
-    open var highlightColor = NSUIColor(red: 255.0/255.0, green: 187.0/255.0, blue: 115.0/255.0, alpha: 1.0)
-    open var highlightLineWidth = CGFloat(1.0)
-    open var highlightLineDashPhase = CGFloat(0.0)
-    open var highlightLineDashLengths: [CGFloat]?
+    @objc open var highlightColor = NSUIColor(red: 255.0/255.0, green: 187.0/255.0, blue: 115.0/255.0, alpha: 1.0)
+    @objc open var highlightLineWidth = CGFloat(1.0)
+    @objc open var highlightLineDashPhase = CGFloat(0.0)
+    @objc open var highlightLineDashLengths: [CGFloat]?
     
     /// Sets labels that should be drawn around the RadarChart at the end of each web line.
-    open var labels = [String]()
+    @objc open var labels = [String]()
     
     /// Sets the labels that should be drawn around the RadarChart at the end of each web line.
     open func setLabels(_ labels: String...)

--- a/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
@@ -21,20 +21,20 @@ open class RadarChartDataEntry: ChartDataEntry
     
     /// - parameter value: The value on the y-axis.
     /// - parameter data: Spot for additional data this Entry represents.
-    public init(value: Double, data: AnyObject?)
+    @objc public init(value: Double, data: AnyObject?)
     {
         super.init(x: 0.0, y: value, data: data)
     }
     
     /// - parameter value: The value on the y-axis.
-    public convenience init(value: Double)
+    @objc public convenience init(value: Double)
     {
         self.init(value: value, data: nil)
     }
     
     // MARK: Data property accessors
     
-    open var value: Double
+    @objc open var value: Double
     {
         get { return y }
         set { y = value }

--- a/Source/Charts/Data/Implementations/Standard/ScatterChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ScatterChartData.swift
@@ -25,7 +25,7 @@ open class ScatterChartData: BarLineScatterCandleBubbleChartData
     }
     
     /// - returns: The maximum shape-size across all DataSets.
-    open func getGreatestShapeSize() -> CGFloat
+    @objc open func getGreatestShapeSize() -> CGFloat
     {
         var max = CGFloat(0.0)
         

--- a/Source/Charts/Data/Implementations/Standard/ScatterChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ScatterChartDataSet.swift
@@ -40,7 +40,7 @@ open class ScatterChartDataSet: LineScatterCandleRadarChartDataSet, IScatterChar
     
     /// Sets the ScatterShape this DataSet should be drawn with.
     /// This will search for an available IShapeRenderer and set this renderer for the DataSet
-    open func setScatterShape(_ shape: Shape)
+    @objc open func setScatterShape(_ shape: Shape)
     {
         self.shapeRenderer = ScatterChartDataSet.renderer(forShape: shape)
     }
@@ -50,7 +50,7 @@ open class ScatterChartDataSet: LineScatterCandleRadarChartDataSet, IScatterChar
     /// **default**: `SquareShapeRenderer`
     open var shapeRenderer: IShapeRenderer? = SquareShapeRenderer()
     
-    open class func renderer(forShape shape: Shape) -> IShapeRenderer
+    @objc open class func renderer(forShape shape: Shape) -> IShapeRenderer
     {
         switch shape
         {

--- a/Source/Charts/Filters/DataApproximator.swift
+++ b/Source/Charts/Filters/DataApproximator.swift
@@ -15,7 +15,7 @@ import Foundation
 open class DataApproximator: NSObject
 {
     /// uses the douglas peuker algorithm to reduce the given arraylist of entries
-    open class func reduceWithDouglasPeuker(_ points: [CGPoint], tolerance: CGFloat) -> [CGPoint]
+    @objc open class func reduceWithDouglasPeuker(_ points: [CGPoint], tolerance: CGFloat) -> [CGPoint]
     {
         // if a shape has 2 or less points it cannot be reduced
         if tolerance <= 0 || points.count < 3

--- a/Source/Charts/Formatters/DefaultAxisValueFormatter.swift
+++ b/Source/Charts/Formatters/DefaultAxisValueFormatter.swift
@@ -18,12 +18,12 @@ open class DefaultAxisValueFormatter: NSObject, IAxisValueFormatter
         _ value: Double,
         _ axis: AxisBase?) -> String
     
-    open var block: Block?
+    @objc open var block: Block?
     
-    open var hasAutoDecimals: Bool = false
+    @objc open var hasAutoDecimals: Bool = false
     
     fileprivate var _formatter: NumberFormatter?
-    open var formatter: NumberFormatter?
+    @objc open var formatter: NumberFormatter?
     {
         get { return _formatter }
         set
@@ -58,14 +58,14 @@ open class DefaultAxisValueFormatter: NSObject, IAxisValueFormatter
         hasAutoDecimals = true
     }
     
-    public init(formatter: NumberFormatter)
+    @objc public init(formatter: NumberFormatter)
     {
         super.init()
         
         self.formatter = formatter
     }
     
-    public init(decimals: Int)
+    @objc public init(decimals: Int)
     {
         super.init()
         
@@ -75,14 +75,14 @@ open class DefaultAxisValueFormatter: NSObject, IAxisValueFormatter
         hasAutoDecimals = true
     }
     
-    public init(block: @escaping Block)
+    @objc public init(block: @escaping Block)
     {
         super.init()
         
         self.block = block
     }
     
-    public static func with(block: @escaping Block) -> DefaultAxisValueFormatter?
+    @objc public static func with(block: @escaping Block) -> DefaultAxisValueFormatter?
     {
         return DefaultAxisValueFormatter(block: block)
     }

--- a/Source/Charts/Formatters/DefaultFillFormatter.swift
+++ b/Source/Charts/Formatters/DefaultFillFormatter.swift
@@ -24,19 +24,19 @@ open class DefaultFillFormatter: NSObject, IFillFormatter
         _ dataSet: ILineChartDataSet,
         _ dataProvider: LineChartDataProvider) -> CGFloat
     
-    open var block: Block?
+    @objc open var block: Block?
     
     public override init()
     {
         
     }
     
-    public init(block: @escaping Block)
+    @objc public init(block: @escaping Block)
     {
         self.block = block
     }
     
-    public static func with(block: @escaping Block) -> DefaultFillFormatter?
+    @objc public static func with(block: @escaping Block) -> DefaultFillFormatter?
     {
         return DefaultFillFormatter(block: block)
     }

--- a/Source/Charts/Formatters/DefaultValueFormatter.swift
+++ b/Source/Charts/Formatters/DefaultValueFormatter.swift
@@ -20,12 +20,12 @@ open class DefaultValueFormatter: NSObject, IValueFormatter
         _ dataSetIndex: Int,
         _ viewPortHandler: ViewPortHandler?) -> String
     
-    open var block: Block?
+    @objc open var block: Block?
     
-    open var hasAutoDecimals: Bool = false
+    @objc open var hasAutoDecimals: Bool = false
     
     fileprivate var _formatter: NumberFormatter?
-    open var formatter: NumberFormatter?
+    @objc open var formatter: NumberFormatter?
     {
         get { return _formatter }
         set
@@ -60,14 +60,14 @@ open class DefaultValueFormatter: NSObject, IValueFormatter
         hasAutoDecimals = true
     }
     
-    public init(formatter: NumberFormatter)
+    @objc public init(formatter: NumberFormatter)
     {
         super.init()
         
         self.formatter = formatter
     }
     
-    public init(decimals: Int)
+    @objc public init(decimals: Int)
     {
         super.init()
         
@@ -77,14 +77,14 @@ open class DefaultValueFormatter: NSObject, IValueFormatter
         hasAutoDecimals = true
     }
     
-    public init(block: @escaping Block)
+    @objc public init(block: @escaping Block)
     {
         super.init()
         
         self.block = block
     }
     
-    public static func with(block: @escaping Block) -> DefaultValueFormatter?
+    @objc public static func with(block: @escaping Block) -> DefaultValueFormatter?
     {
         return DefaultValueFormatter(block: block)
     }

--- a/Source/Charts/Formatters/IndexAxisValueFormatter.swift
+++ b/Source/Charts/Formatters/IndexAxisValueFormatter.swift
@@ -18,7 +18,7 @@ open class IndexAxisValueFormatter: NSObject, IAxisValueFormatter
     private var _values: [String] = [String]()
     private var _valueCount: Int = 0
     
-    public var values: [String]
+    @objc public var values: [String]
     {
         get
         {
@@ -37,14 +37,14 @@ open class IndexAxisValueFormatter: NSObject, IAxisValueFormatter
         
     }
     
-    public init(values: [String])
+    @objc public init(values: [String])
     {
         super.init()
         
         self.values = values
     }
     
-    public static func with(values: [String]) -> IndexAxisValueFormatter?
+    @objc public static func with(values: [String]) -> IndexAxisValueFormatter?
     {
         return IndexAxisValueFormatter(values: values)
     }

--- a/Source/Charts/Highlight/BarHighlighter.swift
+++ b/Source/Charts/Highlight/BarHighlighter.swift
@@ -59,7 +59,7 @@ open class BarHighlighter: ChartHighlighter
     /// - parameter xIndex:
     /// - parameter yValue:
     /// - returns:
-    open func getStackedHighlight(high: Highlight,
+    @objc open func getStackedHighlight(high: Highlight,
                                   set: IBarChartDataSet,
                                   xValue: Double,
                                   yValue: Double) -> Highlight?
@@ -100,7 +100,7 @@ open class BarHighlighter: ChartHighlighter
     /// - parameter entry:
     /// - parameter value:
     /// - returns:
-    open func getClosestStackIndex(ranges: [Range]?, value: Double) -> Int
+    @objc open func getClosestStackIndex(ranges: [Range]?, value: Double) -> Int
     {
         if ranges == nil
         {

--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -15,9 +15,9 @@ import CoreGraphics
 open class ChartHighlighter : NSObject, IHighlighter
 {
     /// instance of the data-provider
-    open weak var chart: ChartDataProvider?
+    @objc open weak var chart: ChartDataProvider?
     
-    public init(chart: ChartDataProvider)
+    @objc public init(chart: ChartDataProvider)
     {
         self.chart = chart
     }
@@ -32,7 +32,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     /// - returns: The corresponding x-pos for a given touch-position in pixels.
     /// - parameter x:
     /// - returns:
-    open func getValsForTouch(x: CGFloat, y: CGFloat) -> CGPoint
+    @objc open func getValsForTouch(x: CGFloat, y: CGFloat) -> CGPoint
     {
         guard let chart = self.chart as? BarLineScatterCandleBubbleChartDataProvider
             else { return CGPoint.zero }
@@ -46,7 +46,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     /// - parameter x:
     /// - parameter y:
     /// - returns:
-    open func getHighlight(xValue xVal: Double, x: CGFloat, y: CGFloat) -> Highlight?
+    @objc open func getHighlight(xValue xVal: Double, x: CGFloat, y: CGFloat) -> Highlight?
     {
         guard let chart = chart
             else { return nil }
@@ -73,7 +73,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     /// - parameter x: touch position
     /// - parameter y: touch position
     /// - returns:
-    open func getHighlights(xValue: Double, x: CGFloat, y: CGFloat) -> [Highlight]
+    @objc open func getHighlights(xValue: Double, x: CGFloat, y: CGFloat) -> [Highlight]
     {
         var vals = [Highlight]()
         
@@ -102,7 +102,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     }
     
     /// - returns: An array of `Highlight` objects corresponding to the selected xValue and dataSetIndex.
-    internal func buildHighlights(
+    @objc internal func buildHighlights(
         dataSet set: IChartDataSet,
         dataSetIndex: Int,
         xValue: Double,
@@ -166,7 +166,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     }
     
     /// - returns: The minimum distance from a touch-y-value (in pixels) to the closest y-value (in pixels) that is displayed in the chart.
-    internal func getMinimumDistance(
+    @objc internal func getMinimumDistance(
         closestValues: [Highlight],
         y: CGFloat,
         axis: YAxis.AxisDependency) -> CGFloat
@@ -190,17 +190,17 @@ open class ChartHighlighter : NSObject, IHighlighter
         return distance
     }
     
-    internal func getHighlightPos(high: Highlight) -> CGFloat
+    @objc internal func getHighlightPos(high: Highlight) -> CGFloat
     {
         return high.yPx
     }
     
-    internal func getDistance(x1: CGFloat, y1: CGFloat, x2: CGFloat, y2: CGFloat) -> CGFloat
+    @objc internal func getDistance(x1: CGFloat, y1: CGFloat, x2: CGFloat, y2: CGFloat) -> CGFloat
     {
         return hypot(x1 - x2, y1 - y2)
     }
     
-    internal var data: ChartData?
+    @objc internal var data: ChartData?
     {
         return chart?.data
     }

--- a/Source/Charts/Highlight/CombinedHighlighter.swift
+++ b/Source/Charts/Highlight/CombinedHighlighter.swift
@@ -18,7 +18,7 @@ open class CombinedHighlighter: ChartHighlighter
     /// bar highlighter for supporting stacked highlighting
     fileprivate var barHighlighter: BarHighlighter?
     
-    public init(chart: CombinedChartDataProvider, barDataProvider: BarChartDataProvider)
+    @objc public init(chart: CombinedChartDataProvider, barDataProvider: BarChartDataProvider)
     {
         super.init(chart: chart)
         

--- a/Source/Charts/Highlight/Highlight.swift
+++ b/Source/Charts/Highlight/Highlight.swift
@@ -27,7 +27,7 @@ open class Highlight: NSObject
     fileprivate var _yPx = CGFloat.nan
     
     /// the index of the data object - in case it refers to more than one
-    open var dataIndex = Int(-1)
+    @objc open var dataIndex = Int(-1)
     
     /// the index of the dataset the highlighted value is in
     fileprivate var _dataSetIndex = Int(0)
@@ -41,10 +41,10 @@ open class Highlight: NSObject
     fileprivate var _axis: YAxis.AxisDependency = YAxis.AxisDependency.left
     
     /// the x-position (pixels) on which this highlight object was last drawn
-    open var drawX: CGFloat = 0.0
+    @objc open var drawX: CGFloat = 0.0
     
     /// the y-position (pixels) on which this highlight object was last drawn
-    open var drawY: CGFloat = 0.0
+    @objc open var drawY: CGFloat = 0.0
     
     public override init()
     {
@@ -59,7 +59,7 @@ open class Highlight: NSObject
     /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
     /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
     /// - parameter axis: the axis the highlighted value belongs to
-    public init(
+    @objc public init(
         x: Double, y: Double,
         xPx: CGFloat, yPx: CGFloat,
         dataIndex: Int,
@@ -86,7 +86,7 @@ open class Highlight: NSObject
     /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
     /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
     /// - parameter axis: the axis the highlighted value belongs to
-    public convenience init(
+    @objc public convenience init(
         x: Double, y: Double,
         xPx: CGFloat, yPx: CGFloat,
         dataSetIndex: Int,
@@ -108,7 +108,7 @@ open class Highlight: NSObject
     /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
     /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
     /// - parameter axis: the axis the highlighted value belongs to
-    public init(
+    @objc public init(
         x: Double, y: Double,
         xPx: CGFloat, yPx: CGFloat,
         dataSetIndex: Int,
@@ -127,7 +127,7 @@ open class Highlight: NSObject
     /// - parameter x: the x-value of the highlighted value
     /// - parameter y: the y-value of the highlighted value
     /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
-    public init(x: Double, y: Double, dataSetIndex: Int)
+    @objc public init(x: Double, y: Double, dataSetIndex: Int)
     {
         _x = x
         _y = y
@@ -137,31 +137,31 @@ open class Highlight: NSObject
     /// - parameter x: the x-value of the highlighted value
     /// - parameter dataSetIndex: the index of the DataSet the highlighted value belongs to
     /// - parameter stackIndex: references which value of a stacked-bar entry has been selected
-    public convenience init(x: Double, dataSetIndex: Int, stackIndex: Int)
+    @objc public convenience init(x: Double, dataSetIndex: Int, stackIndex: Int)
     {
         self.init(x: x, y: Double.nan, dataSetIndex: dataSetIndex)
         _stackIndex = stackIndex
     }
     
-    open var x: Double { return _x }
-    open var y: Double { return _y }
-    open var xPx: CGFloat { return _xPx }
-    open var yPx: CGFloat { return _yPx }
-    open var dataSetIndex: Int { return _dataSetIndex }
-    open var stackIndex: Int { return _stackIndex }
-    open var axis: YAxis.AxisDependency { return _axis }
+    @objc open var x: Double { return _x }
+    @objc open var y: Double { return _y }
+    @objc open var xPx: CGFloat { return _xPx }
+    @objc open var yPx: CGFloat { return _yPx }
+    @objc open var dataSetIndex: Int { return _dataSetIndex }
+    @objc open var stackIndex: Int { return _stackIndex }
+    @objc open var axis: YAxis.AxisDependency { return _axis }
     
-    open var isStacked: Bool { return _stackIndex >= 0 }
+    @objc open var isStacked: Bool { return _stackIndex >= 0 }
     
     /// Sets the x- and y-position (pixels) where this highlight was last drawn.
-    open func setDraw(x: CGFloat, y: CGFloat)
+    @objc open func setDraw(x: CGFloat, y: CGFloat)
     {
         self.drawX = x
         self.drawY = y
     }
     
     /// Sets the x- and y-position (pixels) where this highlight was last drawn.
-    open func setDraw(pt: CGPoint)
+    @objc open func setDraw(pt: CGPoint)
     {
         self.drawX = pt.x
         self.drawY = pt.y

--- a/Source/Charts/Highlight/PieRadarHighlighter.swift
+++ b/Source/Charts/Highlight/PieRadarHighlighter.swift
@@ -55,7 +55,7 @@ open class PieRadarHighlighter: ChartHighlighter
     /// - parameter index:
     /// - parameter x:
     /// - parameter y:
-    open func closestHighlight(index: Int, x: CGFloat, y: CGFloat) -> Highlight?
+    @objc open func closestHighlight(index: Int, x: CGFloat, y: CGFloat) -> Highlight?
     {
         fatalError("closestHighlight(index, x, y) cannot be called on PieRadarChartHighlighter")
     }

--- a/Source/Charts/Highlight/RadarHighlighter.swift
+++ b/Source/Charts/Highlight/RadarHighlighter.swift
@@ -44,7 +44,7 @@ open class RadarHighlighter: PieRadarHighlighter
     /// The Highlight objects give information about the value at the selected index and DataSet it belongs to.
     ///
     /// - parameter index:
-    internal func getHighlights(forIndex index: Int) -> [Highlight]
+    @objc internal func getHighlights(forIndex index: Int) -> [Highlight]
     {
         var vals = [Highlight]()
         

--- a/Source/Charts/Highlight/Range.swift
+++ b/Source/Charts/Highlight/Range.swift
@@ -14,10 +14,10 @@ import Foundation
 @objc(ChartRange)
 open class Range: NSObject
 {
-    open var from: Double
-    open var to: Double
+    @objc open var from: Double
+    @objc open var to: Double
     
-    public init(from: Double, to: Double)
+    @objc public init(from: Double, to: Double)
     {
         self.from = from
         self.to = to
@@ -27,7 +27,7 @@ open class Range: NSObject
 
     /// - returns: `true` if this range contains (if the value is in between) the given value, `false` ifnot.
     /// - parameter value:
-    open func contains(_ value: Double) -> Bool
+    @objc open func contains(_ value: Double) -> Bool
     {
         if value > from && value <= to
         {
@@ -39,12 +39,12 @@ open class Range: NSObject
         }
     }
     
-    open func isLarger(_ value: Double) -> Bool
+    @objc open func isLarger(_ value: Double) -> Bool
     {
         return value > to
     }
     
-    open func isSmaller(_ value: Double) -> Bool
+    @objc open func isSmaller(_ value: Double) -> Bool
     {
         return value < from
     }

--- a/Source/Charts/Jobs/AnimatedViewPortJob.swift
+++ b/Source/Charts/Jobs/AnimatedViewPortJob.swift
@@ -18,9 +18,9 @@ import CoreGraphics
 
 open class AnimatedViewPortJob: ViewPortJob
 {
-    internal var phase: CGFloat = 1.0
-    internal var xOrigin: CGFloat = 0.0
-    internal var yOrigin: CGFloat = 0.0
+    @objc internal var phase: CGFloat = 1.0
+    @objc internal var xOrigin: CGFloat = 0.0
+    @objc internal var yOrigin: CGFloat = 0.0
     
     fileprivate var _startTime: TimeInterval = 0.0
     fileprivate var _displayLink: NSUIDisplayLink!
@@ -29,7 +29,7 @@ open class AnimatedViewPortJob: ViewPortJob
     
     fileprivate var _easing: ChartEasingFunctionBlock?
     
-    public init(
+    @objc public init(
         viewPortHandler: ViewPortHandler,
         xValue: Double,
         yValue: Double,
@@ -62,7 +62,7 @@ open class AnimatedViewPortJob: ViewPortJob
         start()
     }
     
-    open func start()
+    @objc open func start()
     {
         _startTime = CACurrentMediaTime()
         _endTime = _startTime + _duration
@@ -74,7 +74,7 @@ open class AnimatedViewPortJob: ViewPortJob
         _displayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
     }
     
-    open func stop(finish: Bool)
+    @objc open func stop(finish: Bool)
     {
         if _displayLink != nil
         {
@@ -130,12 +130,12 @@ open class AnimatedViewPortJob: ViewPortJob
         }
     }
     
-    internal func animationUpdate()
+    @objc internal func animationUpdate()
     {
         // Override this
     }
     
-    internal func animationEnd()
+    @objc internal func animationEnd()
     {
         // Override this
     }

--- a/Source/Charts/Jobs/AnimatedZoomViewJob.swift
+++ b/Source/Charts/Jobs/AnimatedZoomViewJob.swift
@@ -14,16 +14,16 @@ import CoreGraphics
 
 open class AnimatedZoomViewJob: AnimatedViewPortJob
 {
-    internal var yAxis: YAxis?
-    internal var xAxisRange: Double = 0.0
-    internal var scaleX: CGFloat = 0.0
-    internal var scaleY: CGFloat = 0.0
-    internal var zoomOriginX: CGFloat = 0.0
-    internal var zoomOriginY: CGFloat = 0.0
-    internal var zoomCenterX: CGFloat = 0.0
-    internal var zoomCenterY: CGFloat = 0.0
+    @objc internal var yAxis: YAxis?
+    @objc internal var xAxisRange: Double = 0.0
+    @objc internal var scaleX: CGFloat = 0.0
+    @objc internal var scaleY: CGFloat = 0.0
+    @objc internal var zoomOriginX: CGFloat = 0.0
+    @objc internal var zoomOriginY: CGFloat = 0.0
+    @objc internal var zoomCenterX: CGFloat = 0.0
+    @objc internal var zoomCenterY: CGFloat = 0.0
 
-    public init(
+    @objc public init(
         viewPortHandler: ViewPortHandler,
         transformer: Transformer,
         view: ChartViewBase,

--- a/Source/Charts/Jobs/ViewPortJob.swift
+++ b/Source/Charts/Jobs/ViewPortJob.swift
@@ -16,14 +16,14 @@ import CoreGraphics
 @objc(ChartViewPortJob)
 open class ViewPortJob: NSObject
 {
-    internal var point: CGPoint = CGPoint()
-    internal weak var viewPortHandler: ViewPortHandler?
-    internal var xValue: Double = 0.0
-    internal var yValue: Double = 0.0
-    internal weak var transformer: Transformer?
-    internal weak var view: ChartViewBase?
+    @objc internal var point: CGPoint = CGPoint()
+    @objc internal weak var viewPortHandler: ViewPortHandler?
+    @objc internal var xValue: Double = 0.0
+    @objc internal var yValue: Double = 0.0
+    @objc internal weak var transformer: Transformer?
+    @objc internal weak var view: ChartViewBase?
     
-    public init(
+    @objc public init(
         viewPortHandler: ViewPortHandler,
         xValue: Double,
         yValue: Double,
@@ -39,7 +39,7 @@ open class ViewPortJob: NSObject
         self.view = view
     }
     
-    open func doJob()
+    @objc open func doJob()
     {
         // Override this
     }

--- a/Source/Charts/Jobs/ZoomViewJob.swift
+++ b/Source/Charts/Jobs/ZoomViewJob.swift
@@ -19,11 +19,11 @@ import CoreGraphics
 @objc(ZoomChartViewJob)
 open class ZoomViewJob: ViewPortJob
 {
-    internal var scaleX: CGFloat = 0.0
-    internal var scaleY: CGFloat = 0.0
-    internal var axisDependency: YAxis.AxisDependency = YAxis.AxisDependency.left
+    @objc internal var scaleX: CGFloat = 0.0
+    @objc internal var scaleY: CGFloat = 0.0
+    @objc internal var axisDependency: YAxis.AxisDependency = YAxis.AxisDependency.left
     
-    public init(
+    @objc public init(
         viewPortHandler: ViewPortHandler,
         scaleX: CGFloat,
         scaleY: CGFloat,

--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -16,17 +16,17 @@ import CoreGraphics
 open class AxisRendererBase: Renderer
 {
     /// base axis this axis renderer works with
-    open var axis: AxisBase?
+    @objc open var axis: AxisBase?
     
     /// transformer to transform values to screen pixels and return
-    open var transformer: Transformer?
+    @objc open var transformer: Transformer?
     
     public override init()
     {
         super.init()
     }
     
-    public init(viewPortHandler: ViewPortHandler?, transformer: Transformer?, axis: AxisBase?)
+    @objc public init(viewPortHandler: ViewPortHandler?, transformer: Transformer?, axis: AxisBase?)
     {
         super.init(viewPortHandler: viewPortHandler)
         
@@ -35,25 +35,25 @@ open class AxisRendererBase: Renderer
     }
     
     /// Draws the axis labels on the specified context
-    open func renderAxisLabels(context: CGContext)
+    @objc open func renderAxisLabels(context: CGContext)
     {
         fatalError("renderAxisLabels() cannot be called on AxisRendererBase")
     }
     
     /// Draws the grid lines belonging to the axis.
-    open func renderGridLines(context: CGContext)
+    @objc open func renderGridLines(context: CGContext)
     {
         fatalError("renderGridLines() cannot be called on AxisRendererBase")
     }
     
     /// Draws the line that goes alongside the axis.
-    open func renderAxisLine(context: CGContext)
+    @objc open func renderAxisLine(context: CGContext)
     {
         fatalError("renderAxisLine() cannot be called on AxisRendererBase")
     }
     
     /// Draws the LimitLines associated with this axis to the screen.
-    open func renderLimitLines(context: CGContext)
+    @objc open func renderLimitLines(context: CGContext)
     {
         fatalError("renderLimitLines() cannot be called on AxisRendererBase")
     }
@@ -61,7 +61,7 @@ open class AxisRendererBase: Renderer
     /// Computes the axis values.
     /// - parameter min: the minimum value in the data object for this axis
     /// - parameter max: the maximum value in the data object for this axis
-    open func computeAxis(min: Double, max: Double, inverted: Bool)
+    @objc open func computeAxis(min: Double, max: Double, inverted: Bool)
     {
         var min = min, max = max
         
@@ -93,7 +93,7 @@ open class AxisRendererBase: Renderer
     }
     
     /// Sets up the axis values. Computes the desired number of labels between the two given extremes.
-    open func computeAxisValues(min: Double, max: Double)
+    @objc open func computeAxisValues(min: Double, max: Double)
     {
         guard let axis = self.axis else { return }
         

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -23,9 +23,9 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         var rects = [CGRect]()
     }
     
-    open weak var dataProvider: BarChartDataProvider?
+    @objc open weak var dataProvider: BarChartDataProvider?
     
-    public init(dataProvider: BarChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(dataProvider: BarChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -206,7 +206,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
     
     fileprivate var _barShadowRectBuffer: CGRect = CGRect()
     
-    open func drawDataSet(context: CGContext, dataSet: IBarChartDataSet, index: Int)
+    @objc open func drawDataSet(context: CGContext, dataSet: IBarChartDataSet, index: Int)
     {
         guard
             let dataProvider = dataProvider,
@@ -615,9 +615,9 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
     }
     
     /// Draws a value at the specified x and y position.
-    open func drawValue(context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: NSUIFont, align: NSTextAlignment, color: NSUIColor)
+    @objc open func drawValue(context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: NSUIFont, align: NSTextAlignment, color: NSUIColor)
     {
-        ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: color])
+        ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSAttributedStringKey.font.rawValue: font, NSAttributedStringKey.foregroundColor.rawValue: color])
     }
     
     open override func drawExtras(context: CGContext)
@@ -693,7 +693,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
     }
     
     /// Sets the drawing position of the highlight object based on the riven bar-rect.
-    internal func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
+    @objc internal func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
     {
         high.setDraw(x: barRect.midX, y: barRect.origin.y)
     }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -617,7 +617,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
     /// Draws a value at the specified x and y position.
     @objc open func drawValue(context: CGContext, value: String, xPos: CGFloat, yPos: CGFloat, font: NSUIFont, align: NSTextAlignment, color: NSUIColor)
     {
-        ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSAttributedStringKey.font.rawValue: font, NSAttributedStringKey.foregroundColor.rawValue: color])
+        ChartUtils.drawText(context: context, text: value, point: CGPoint(x: xPos, y: yPos), align: align, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: color])
     }
     
     open override func drawExtras(context: CGContext)

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -23,7 +23,7 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
     }
     
     /// Checks if the provided entry object is in bounds for drawing considering the current animation phase.
-    internal func isInBoundsX(entry e: ChartDataEntry, dataSet: IBarLineScatterCandleBubbleChartDataSet) -> Bool
+    @objc internal func isInBoundsX(entry e: ChartDataEntry, dataSet: IBarLineScatterCandleBubbleChartDataSet) -> Bool
     {
         let entryIndex = dataSet.entryIndex(entry: e)
         
@@ -47,7 +47,7 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
     }
     
     /// - returns: `true` if the DataSet values should be drawn, `false` if not.
-    internal func shouldDrawValues(forDataSet set: IChartDataSet) -> Bool
+    @objc internal func shouldDrawValues(forDataSet set: IChartDataSet) -> Bool
     {
         return set.isVisible && (set.isDrawValuesEnabled || set.isDrawIconsEnabled)
     }

--- a/Source/Charts/Renderers/BubbleChartRenderer.swift
+++ b/Source/Charts/Renderers/BubbleChartRenderer.swift
@@ -213,7 +213,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
                                 x: pt.x,
                                 y: pt.y - (0.5 * lineHeight)),
                             align: .center,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor])
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: valueTextColor])
                     }
                     
                     if let icon = e.icon, dataSet.isDrawIconsEnabled

--- a/Source/Charts/Renderers/BubbleChartRenderer.swift
+++ b/Source/Charts/Renderers/BubbleChartRenderer.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 
 open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
 {
-    open weak var dataProvider: BubbleChartDataProvider?
+    @objc open weak var dataProvider: BubbleChartDataProvider?
     
-    public init(dataProvider: BubbleChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(dataProvider: BubbleChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -60,7 +60,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
     fileprivate var _pointBuffer = CGPoint()
     fileprivate var _sizeBuffer = [CGPoint](repeating: CGPoint(), count: 2)
     
-    open func drawDataSet(context: CGContext, dataSet: IBubbleChartDataSet)
+    @objc open func drawDataSet(context: CGContext, dataSet: IBubbleChartDataSet)
     {
         guard
             let dataProvider = dataProvider,
@@ -213,7 +213,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
                                 x: pt.x,
                                 y: pt.y - (0.5 * lineHeight)),
                             align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor])
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor])
                     }
                     
                     if let icon = e.icon, dataSet.isDrawIconsEnabled

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -308,7 +308,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                                 x: pt.x,
                                 y: pt.y - yOffset),
                             align: .center,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)])
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: dataSet.valueTextColorAt(j)])
                     }
                     
                     if let icon = e.icon, dataSet.isDrawIconsEnabled

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 
 open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
 {
-    open weak var dataProvider: CandleChartDataProvider?
+    @objc open weak var dataProvider: CandleChartDataProvider?
     
-    public init(dataProvider: CandleChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(dataProvider: CandleChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -48,7 +48,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
     fileprivate var _bodyRect = CGRect()
     fileprivate var _lineSegments = [CGPoint](repeating: CGPoint(), count: 2)
     
-    open func drawDataSet(context: CGContext, dataSet: ICandleChartDataSet)
+    @objc open func drawDataSet(context: CGContext, dataSet: ICandleChartDataSet)
     {
         guard let
             dataProvider = dataProvider,
@@ -308,7 +308,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                                 x: pt.x,
                                 y: pt.y - yOffset),
                             align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: dataSet.valueTextColorAt(j)])
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)])
                     }
                     
                     if let icon = e.icon, dataSet.isDrawIconsEnabled

--- a/Source/Charts/Renderers/ChartDataRendererBase.swift
+++ b/Source/Charts/Renderers/ChartDataRendererBase.swift
@@ -15,26 +15,26 @@ import CoreGraphics
 @objc(ChartDataRendererBase)
 open class DataRenderer: Renderer
 {
-    open var animator: Animator?
+    @objc open var animator: Animator?
     
-    public init(animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(viewPortHandler: viewPortHandler)
         
         self.animator = animator
     }
 
-    open func drawData(context: CGContext)
+    @objc open func drawData(context: CGContext)
     {
         fatalError("drawData() cannot be called on DataRenderer")
     }
     
-    open func drawValues(context: CGContext)
+    @objc open func drawValues(context: CGContext)
     {
         fatalError("drawValues() cannot be called on DataRenderer")
     }
     
-    open func drawExtras(context: CGContext)
+    @objc open func drawExtras(context: CGContext)
     {
         fatalError("drawExtras() cannot be called on DataRenderer")
     }
@@ -42,16 +42,16 @@ open class DataRenderer: Renderer
     /// Draws all highlight indicators for the values that are currently highlighted.
     ///
     /// - parameter indices: the highlighted values
-    open func drawHighlighted(context: CGContext, indices: [Highlight])
+    @objc open func drawHighlighted(context: CGContext, indices: [Highlight])
     {
         fatalError("drawHighlighted() cannot be called on DataRenderer")
     }
     
     /// An opportunity for initializing internal buffers used for rendering with a new size.
     /// Since this might do memory allocations, it should only be called if necessary.
-    open func initBuffers() { }
+    @objc open func initBuffers() { }
     
-    open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
+    @objc open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
         guard let data = dataProvider?.data
             else { return false }

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -14,19 +14,19 @@ import CoreGraphics
 
 open class CombinedChartRenderer: DataRenderer
 {
-    open weak var chart: CombinedChartView?
+    @objc open weak var chart: CombinedChartView?
     
     /// if set to true, all values are drawn above their bars, instead of below their top
-    open var drawValueAboveBarEnabled = true
+    @objc open var drawValueAboveBarEnabled = true
     
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
-    open var drawBarShadowEnabled = false
+    @objc open var drawBarShadowEnabled = false
     
-    internal var _renderers = [DataRenderer]()
+    @objc internal var _renderers = [DataRenderer]()
     
     internal var _drawOrder: [CombinedChartView.DrawOrder] = [.bar, .bubble, .line, .candle, .scatter]
     
-    public init(chart: CombinedChartView?, animator: Animator, viewPortHandler: ViewPortHandler?)
+    @objc public init(chart: CombinedChartView?, animator: Animator, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -36,7 +36,7 @@ open class CombinedChartRenderer: DataRenderer
     }
     
     /// Creates the renderers needed for this combined-renderer in the required order. Also takes the DrawOrder into consideration.
-    internal func createRenderers()
+    @objc internal func createRenderers()
     {
         _renderers = [DataRenderer]()
         
@@ -157,7 +157,7 @@ open class CombinedChartRenderer: DataRenderer
     }
 
     /// - returns: The sub-renderer object at the specified index.
-    open func getSubRenderer(index: Int) -> DataRenderer?
+    @objc open func getSubRenderer(index: Int) -> DataRenderer?
     {
         if index >= _renderers.count || index < 0
         {
@@ -170,7 +170,7 @@ open class CombinedChartRenderer: DataRenderer
     }
 
     /// - returns: All sub-renderers.
-    open var subRenderers: [DataRenderer]
+    @objc open var subRenderers: [DataRenderer]
     {
         get { return _renderers }
         set { _renderers = newValue }
@@ -179,10 +179,10 @@ open class CombinedChartRenderer: DataRenderer
     // MARK: Accessors
     
     /// - returns: `true` if drawing values above bars is enabled, `false` ifnot
-    open var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
+    @objc open var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
     
     /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
-    open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
+    @objc open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
     
     /// the order in which the provided data objects should be drawn.
     /// The earlier you place them in the provided array, the further they will be in the background.

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -381,7 +381,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                             viewPortHandler: viewPortHandler)
                         
                         // calculate the correct offset depending on the draw position of the value
-                        let valueTextWidth = valueText.size(attributes: [NSFontAttributeName: valueFont]).width
+                        let valueTextWidth = valueText.size(withAttributes: [NSAttributedStringKey.font: valueFont]).width
                         posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
                         negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
                         
@@ -462,7 +462,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                                 viewPortHandler: viewPortHandler)
                             
                             // calculate the correct offset depending on the draw position of the value
-                            let valueTextWidth = valueText.size(attributes: [NSFontAttributeName: valueFont]).width
+                            let valueTextWidth = valueText.size(withAttributes: [NSAttributedStringKey.font: valueFont]).width
                             posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
                             negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
                             
@@ -546,7 +546,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                                     viewPortHandler: viewPortHandler)
                                 
                                 // calculate the correct offset depending on the draw position of the value
-                                let valueTextWidth = valueText.size(attributes: [NSFontAttributeName: valueFont]).width
+                                let valueTextWidth = valueText.size(withAttributes: [NSAttributedStringKey.font: valueFont]).width
                                 posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
                                 negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
                                 

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -20,9 +20,9 @@ import CoreGraphics
 open class LegendRenderer: Renderer
 {
     /// the legend object this renderer renders
-    open var legend: Legend?
+    @objc open var legend: Legend?
 
-    public init(viewPortHandler: ViewPortHandler?, legend: Legend?)
+    @objc public init(viewPortHandler: ViewPortHandler?, legend: Legend?)
     {
         super.init(viewPortHandler: viewPortHandler)
         
@@ -30,7 +30,7 @@ open class LegendRenderer: Renderer
     }
 
     /// Prepares the legend and calculates all needed forms, labels and colors.
-    open func computeLegend(data: ChartData)
+    @objc open func computeLegend(data: ChartData)
     {
         guard
             let legend = legend,
@@ -192,7 +192,7 @@ open class LegendRenderer: Renderer
         legend.calculateDimensions(labelFont: legend.font, viewPortHandler: viewPortHandler)
     }
     
-    open func renderLegend(context: CGContext)
+    @objc open func renderLegend(context: CGContext)
     {
         guard
             let legend = legend,
@@ -468,7 +468,7 @@ open class LegendRenderer: Renderer
                     
                     if direction == .rightToLeft
                     {
-                        posX -= (e.label as NSString!).size(attributes: [NSFontAttributeName: labelFont]).width
+                        posX -= (e.label as NSString!).size(withAttributes: [NSAttributedStringKey.font: labelFont]).width
                     }
                     
                     if !wasStacked
@@ -497,7 +497,7 @@ open class LegendRenderer: Renderer
     fileprivate var _formLineSegmentsBuffer = [CGPoint](repeating: CGPoint(), count: 2)
     
     /// Draws the Legend-form at the given position with the color at the given index.
-    open func drawForm(
+    @objc open func drawForm(
         context: CGContext,
         x: CGFloat,
         y: CGFloat,
@@ -569,8 +569,8 @@ open class LegendRenderer: Renderer
     }
 
     /// Draws the provided label at the given position.
-    open func drawLabel(context: CGContext, x: CGFloat, y: CGFloat, label: String, font: NSUIFont, textColor: NSUIColor)
+    @objc open func drawLabel(context: CGContext, x: CGFloat, y: CGFloat, label: String, font: NSUIFont, textColor: NSUIColor)
     {
-        ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .left, attributes: [NSFontAttributeName: font, NSForegroundColorAttributeName: textColor])
+        ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .left, attributes: [NSAttributedStringKey.font.rawValue: font, NSAttributedStringKey.foregroundColor.rawValue: textColor])
     }
 }

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -571,6 +571,6 @@ open class LegendRenderer: Renderer
     /// Draws the provided label at the given position.
     @objc open func drawLabel(context: CGContext, x: CGFloat, y: CGFloat, label: String, font: NSUIFont, textColor: NSUIColor)
     {
-        ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .left, attributes: [NSAttributedStringKey.font.rawValue: font, NSAttributedStringKey.foregroundColor.rawValue: textColor])
+        ChartUtils.drawText(context: context, text: label, point: CGPoint(x: x, y: y), align: .left, attributes: [NSAttributedStringKey.font: font, NSAttributedStringKey.foregroundColor: textColor])
     }
 }

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 
 open class LineChartRenderer: LineRadarRenderer
 {
-    open weak var dataProvider: LineChartDataProvider?
+    @objc open weak var dataProvider: LineChartDataProvider?
     
-    public init(dataProvider: LineChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(dataProvider: LineChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -48,7 +48,7 @@ open class LineChartRenderer: LineRadarRenderer
         }
     }
     
-    open func drawDataSet(context: CGContext, dataSet: ILineChartDataSet)
+    @objc open func drawDataSet(context: CGContext, dataSet: ILineChartDataSet)
     {
         if dataSet.entryCount < 1
         {
@@ -84,7 +84,7 @@ open class LineChartRenderer: LineRadarRenderer
         context.restoreGState()
     }
     
-    open func drawCubicBezier(context: CGContext, dataSet: ILineChartDataSet)
+    @objc open func drawCubicBezier(context: CGContext, dataSet: ILineChartDataSet)
     {
         guard
             let dataProvider = dataProvider,
@@ -181,7 +181,7 @@ open class LineChartRenderer: LineRadarRenderer
         context.restoreGState()
     }
     
-    open func drawHorizontalBezier(context: CGContext, dataSet: ILineChartDataSet)
+    @objc open func drawHorizontalBezier(context: CGContext, dataSet: ILineChartDataSet)
     {
         guard
             let dataProvider = dataProvider,
@@ -290,7 +290,7 @@ open class LineChartRenderer: LineRadarRenderer
     
     fileprivate var _lineSegments = [CGPoint](repeating: CGPoint(), count: 2)
     
-    open func drawLinear(context: CGContext, dataSet: ILineChartDataSet)
+    @objc open func drawLinear(context: CGContext, dataSet: ILineChartDataSet)
     {
         guard
             let dataProvider = dataProvider,
@@ -580,7 +580,7 @@ open class LineChartRenderer: LineRadarRenderer
                                 x: pt.x,
                                 y: pt.y - CGFloat(valOffset) - valueFont.lineHeight),
                             align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: dataSet.valueTextColorAt(j)])
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)])
                     }
                     
                     if let icon = e.icon, dataSet.isDrawIconsEnabled

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -580,7 +580,7 @@ open class LineChartRenderer: LineRadarRenderer
                                 x: pt.x,
                                 y: pt.y - CGFloat(valOffset) - valueFont.lineHeight),
                             align: .center,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)])
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: dataSet.valueTextColorAt(j)])
                     }
                     
                     if let icon = e.icon, dataSet.isDrawIconsEnabled

--- a/Source/Charts/Renderers/LineRadarRenderer.swift
+++ b/Source/Charts/Renderers/LineRadarRenderer.swift
@@ -21,7 +21,7 @@ open class LineRadarRenderer: LineScatterCandleRadarRenderer
     }
     
     /// Draws the provided path in filled mode with the provided drawable.
-    open func drawFilledPath(context: CGContext, path: CGPath, fill: Fill, fillAlpha: CGFloat)
+    @objc open func drawFilledPath(context: CGContext, path: CGPath, fill: Fill, fillAlpha: CGFloat)
     {
         guard let viewPortHandler = self.viewPortHandler
             else { return }
@@ -39,7 +39,7 @@ open class LineRadarRenderer: LineScatterCandleRadarRenderer
     }
     
     /// Draws the provided path in filled mode with the provided color and alpha.
-    open func drawFilledPath(context: CGContext, path: CGPath, fillColor: NSUIColor, fillAlpha: CGFloat)
+    @objc open func drawFilledPath(context: CGContext, path: CGPath, fillColor: NSUIColor, fillAlpha: CGFloat)
     {
         context.saveGState()
         context.beginPath()

--- a/Source/Charts/Renderers/LineScatterCandleRadarRenderer.swift
+++ b/Source/Charts/Renderers/LineScatterCandleRadarRenderer.swift
@@ -25,7 +25,7 @@ open class LineScatterCandleRadarRenderer: BarLineScatterCandleBubbleRenderer
     /// :param: points
     /// :param: horizontal
     /// :param: vertical
-    open func drawHighlightLines(context: CGContext, point: CGPoint, set: ILineScatterCandleRadarChartDataSet)
+    @objc open func drawHighlightLines(context: CGContext, point: CGPoint, set: ILineScatterCandleRadarChartDataSet)
     {
         guard let
             viewPortHandler = self.viewPortHandler

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 
 open class PieChartRenderer: DataRenderer
 {
-    open weak var chart: PieChartView?
+    @objc open weak var chart: PieChartView?
     
-    public init(chart: PieChartView?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(chart: PieChartView?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -46,7 +46,7 @@ open class PieChartRenderer: DataRenderer
         }
     }
     
-    open func calculateMinimumRadiusForSpacedSlice(
+    @objc open func calculateMinimumRadiusForSpacedSlice(
         center: CGPoint,
         radius: CGFloat,
         angle: CGFloat,
@@ -88,7 +88,7 @@ open class PieChartRenderer: DataRenderer
     }
     
     /// Calculates the sliceSpace to use based on visible values and their size compared to the set sliceSpace.
-    open func getSliceSpace(dataSet: IPieChartDataSet) -> CGFloat
+    @objc open func getSliceSpace(dataSet: IPieChartDataSet) -> CGFloat
     {
         guard
             dataSet.automaticallyDisableSliceSpacing,
@@ -106,7 +106,7 @@ open class PieChartRenderer: DataRenderer
         return sliceSpace
     }
 
-    open func drawDataSet(context: CGContext, dataSet: IPieChartDataSet)
+    @objc open func drawDataSet(context: CGContext, dataSet: IPieChartDataSet)
     {
         guard
             let chart = chart,
@@ -431,7 +431,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: labelPoint,
                             align: align,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
                         )
                         
                         if j < data.entryCount && pe?.label != nil
@@ -442,8 +442,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight),
                                 align: align,
                                 attributes: [
-                                    NSFontAttributeName: entryLabelFont ?? valueFont,
-                                    NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -457,8 +457,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight / 2.0),
                                 align: align,
                                 attributes: [
-                                    NSFontAttributeName: entryLabelFont ?? valueFont,
-                                    NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -469,7 +469,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight / 2.0),
                             align: align,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
                         )
                     }
                 }
@@ -487,7 +487,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: CGPoint(x: x, y: y),
                             align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
                         )
                         
                         if j < data.entryCount && pe?.label != nil
@@ -498,8 +498,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: x, y: y + lineHeight),
                                 align: .center,
                                 attributes: [
-                                    NSFontAttributeName: entryLabelFont ?? valueFont,
-                                    NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -513,8 +513,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: x, y: y + lineHeight / 2.0),
                                 align: .center,
                                 attributes: [
-                                    NSFontAttributeName: entryLabelFont ?? valueFont,
-                                    NSForegroundColorAttributeName: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -525,7 +525,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: CGPoint(x: x, y: y + lineHeight / 2.0),
                             align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: valueTextColor]
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
                         )
                     }
                 }

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -431,7 +431,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: labelPoint,
                             align: align,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: valueTextColor]
                         )
                         
                         if j < data.entryCount && pe?.label != nil
@@ -442,8 +442,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight),
                                 align: align,
                                 attributes: [
-                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
-                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -457,8 +457,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight / 2.0),
                                 align: align,
                                 attributes: [
-                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
-                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -469,7 +469,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: CGPoint(x: labelPoint.x, y: labelPoint.y + lineHeight / 2.0),
                             align: align,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: valueTextColor]
                         )
                     }
                 }
@@ -487,7 +487,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: CGPoint(x: x, y: y),
                             align: .center,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: valueTextColor]
                         )
                         
                         if j < data.entryCount && pe?.label != nil
@@ -498,8 +498,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: x, y: y + lineHeight),
                                 align: .center,
                                 attributes: [
-                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
-                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -513,8 +513,8 @@ open class PieChartRenderer: DataRenderer
                                 point: CGPoint(x: x, y: y + lineHeight / 2.0),
                                 align: .center,
                                 attributes: [
-                                    NSAttributedStringKey.font.rawValue: entryLabelFont ?? valueFont,
-                                    NSAttributedStringKey.foregroundColor.rawValue: entryLabelColor ?? valueTextColor]
+                                    NSAttributedStringKey.font: entryLabelFont ?? valueFont,
+                                    NSAttributedStringKey.foregroundColor: entryLabelColor ?? valueTextColor]
                             )
                         }
                     }
@@ -525,7 +525,7 @@ open class PieChartRenderer: DataRenderer
                             text: valueText,
                             point: CGPoint(x: x, y: y + lineHeight / 2.0),
                             align: .center,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: valueTextColor]
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: valueTextColor]
                         )
                     }
                 }

--- a/Source/Charts/Renderers/RadarChartRenderer.swift
+++ b/Source/Charts/Renderers/RadarChartRenderer.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 
 open class RadarChartRenderer: LineRadarRenderer
 {
-    open weak var chart: RadarChartView?
+    @objc open weak var chart: RadarChartView?
 
-    public init(chart: RadarChartView?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(chart: RadarChartView?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -53,7 +53,7 @@ open class RadarChartRenderer: LineRadarRenderer
     /// - parameter context:
     /// - parameter dataSet:
     /// - parameter mostEntries: the entry count of the dataset with the most entries
-    internal func drawDataSet(context: CGContext, dataSet: IRadarChartDataSet, mostEntries: Int)
+    @objc internal func drawDataSet(context: CGContext, dataSet: IRadarChartDataSet, mostEntries: Int)
     {
         guard let
             chart = chart,
@@ -194,8 +194,8 @@ open class RadarChartRenderer: LineRadarRenderer
                             viewPortHandler: viewPortHandler),
                         point: CGPoint(x: p.x, y: p.y - yoffset - valueFont.lineHeight),
                         align: .center,
-                        attributes: [NSFontAttributeName: valueFont,
-                            NSForegroundColorAttributeName: dataSet.valueTextColorAt(j)]
+                        attributes: [NSAttributedStringKey.font.rawValue: valueFont,
+                            NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)]
                     )
                 }
                 
@@ -224,7 +224,7 @@ open class RadarChartRenderer: LineRadarRenderer
     
     fileprivate var _webLineSegmentsBuffer = [CGPoint](repeating: CGPoint(), count: 2)
     
-    open func drawWeb(context: CGContext)
+    @objc open func drawWeb(context: CGContext)
     {
         guard
             let chart = chart,
@@ -380,7 +380,7 @@ open class RadarChartRenderer: LineRadarRenderer
         context.restoreGState()
     }
     
-    internal func drawHighlightCircle(
+    @objc internal func drawHighlightCircle(
         context: CGContext,
         atPoint point: CGPoint,
         innerRadius: CGFloat,

--- a/Source/Charts/Renderers/RadarChartRenderer.swift
+++ b/Source/Charts/Renderers/RadarChartRenderer.swift
@@ -194,8 +194,8 @@ open class RadarChartRenderer: LineRadarRenderer
                             viewPortHandler: viewPortHandler),
                         point: CGPoint(x: p.x, y: p.y - yoffset - valueFont.lineHeight),
                         align: .center,
-                        attributes: [NSAttributedStringKey.font.rawValue: valueFont,
-                            NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)]
+                        attributes: [NSAttributedStringKey.font: valueFont,
+                            NSAttributedStringKey.foregroundColor: dataSet.valueTextColorAt(j)]
                     )
                 }
                 

--- a/Source/Charts/Renderers/Renderer.swift
+++ b/Source/Charts/Renderers/Renderer.swift
@@ -16,14 +16,14 @@ import CoreGraphics
 open class Renderer: NSObject
 {
     /// the component that handles the drawing area of the chart and it's offsets
-    open var viewPortHandler: ViewPortHandler?
+    @objc open var viewPortHandler: ViewPortHandler?
     
     public override init()
     {
         super.init()
     }
     
-    public init(viewPortHandler: ViewPortHandler?)
+    @objc public init(viewPortHandler: ViewPortHandler?)
     {
         super.init()
         self.viewPortHandler = viewPortHandler

--- a/Source/Charts/Renderers/ScatterChartRenderer.swift
+++ b/Source/Charts/Renderers/ScatterChartRenderer.swift
@@ -178,7 +178,7 @@ open class ScatterChartRenderer: LineScatterCandleRadarRenderer
                                 x: pt.x,
                                 y: pt.y - shapeSize - lineHeight),
                             align: .center,
-                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)]
+                            attributes: [NSAttributedStringKey.font: valueFont, NSAttributedStringKey.foregroundColor: dataSet.valueTextColorAt(j)]
                         )
                     }
                     

--- a/Source/Charts/Renderers/ScatterChartRenderer.swift
+++ b/Source/Charts/Renderers/ScatterChartRenderer.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 
 open class ScatterChartRenderer: LineScatterCandleRadarRenderer
 {
-    open weak var dataProvider: ScatterChartDataProvider?
+    @objc open weak var dataProvider: ScatterChartDataProvider?
     
-    public init(dataProvider: ScatterChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
+    @objc public init(dataProvider: ScatterChartDataProvider?, animator: Animator?, viewPortHandler: ViewPortHandler?)
     {
         super.init(animator: animator, viewPortHandler: viewPortHandler)
         
@@ -50,7 +50,7 @@ open class ScatterChartRenderer: LineScatterCandleRadarRenderer
     
     fileprivate var _lineSegments = [CGPoint](repeating: CGPoint(), count: 2)
     
-    open func drawDataSet(context: CGContext, dataSet: IScatterChartDataSet)
+    @objc open func drawDataSet(context: CGContext, dataSet: IScatterChartDataSet)
     {
         guard
             let dataProvider = dataProvider,
@@ -178,7 +178,7 @@ open class ScatterChartRenderer: LineScatterCandleRadarRenderer
                                 x: pt.x,
                                 y: pt.y - shapeSize - lineHeight),
                             align: .center,
-                            attributes: [NSFontAttributeName: valueFont, NSForegroundColorAttributeName: dataSet.valueTextColorAt(j)]
+                            attributes: [NSAttributedStringKey.font.rawValue: valueFont, NSAttributedStringKey.foregroundColor.rawValue: dataSet.valueTextColorAt(j)]
                         )
                     }
                     

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 @objc(ChartXAxisRenderer)
 open class XAxisRenderer: AxisRendererBase
 {
-    public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, transformer: Transformer?)
+    @objc public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, transformer: Transformer?)
     {
         super.init(viewPortHandler: viewPortHandler, transformer: transformer, axis: xAxis)
     }
@@ -64,7 +64,7 @@ open class XAxisRenderer: AxisRendererBase
         computeSize()
     }
     
-    open func computeSize()
+    @objc open func computeSize()
     {
         guard let
             xAxis = self.axis as? XAxis
@@ -72,7 +72,7 @@ open class XAxisRenderer: AxisRendererBase
         
         let longest = xAxis.getLongestLabel()
         
-        let labelSize = longest.size(attributes: [NSFontAttributeName: xAxis.labelFont])
+        let labelSize = longest.size(withAttributes: [NSAttributedStringKey.font: xAxis.labelFont])
         
         let labelWidth = labelSize.width
         let labelHeight = labelSize.height
@@ -175,7 +175,7 @@ open class XAxisRenderer: AxisRendererBase
     }
     
     /// draws the x-labels on the specified y-position
-    open func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint)
+    @objc open func drawLabels(context: CGContext, pos: CGFloat, anchor: CGPoint)
     {
         guard
             let xAxis = self.axis as? XAxis,
@@ -190,9 +190,9 @@ open class XAxisRenderer: AxisRendererBase
         #endif
         paraStyle.alignment = .center
         
-        let labelAttrs = [NSFontAttributeName: xAxis.labelFont,
-            NSForegroundColorAttributeName: xAxis.labelTextColor,
-            NSParagraphStyleAttributeName: paraStyle] as [String : NSObject]
+        let labelAttrs = [NSAttributedStringKey.font.rawValue: xAxis.labelFont,
+            NSAttributedStringKey.foregroundColor: xAxis.labelTextColor,
+            NSAttributedStringKey.paragraphStyle: paraStyle] as! [String : NSObject]
         let labelRotationAngleRadians = xAxis.labelRotationAngle * ChartUtils.Math.FDEG2RAD
         
         let centeringEnabled = xAxis.isCenterAxisLabelsEnabled
@@ -262,7 +262,7 @@ open class XAxisRenderer: AxisRendererBase
         }
     }
     
-    open func drawLabel(
+    @objc open func drawLabel(
         context: CGContext,
         formattedLabel: String,
         x: CGFloat,
@@ -328,7 +328,7 @@ open class XAxisRenderer: AxisRendererBase
         }
     }
     
-    open var gridClippingRect: CGRect
+    @objc open var gridClippingRect: CGRect
     {
         var contentRect = viewPortHandler?.contentRect ?? CGRect.zero
         let dx = self.axis?.gridLineWidth ?? 0.0
@@ -337,7 +337,7 @@ open class XAxisRenderer: AxisRendererBase
         return contentRect
     }
     
-    open func drawGridLine(context: CGContext, x: CGFloat, y: CGFloat)
+    @objc open func drawGridLine(context: CGContext, x: CGFloat, y: CGFloat)
     {
         guard
             let viewPortHandler = self.viewPortHandler
@@ -398,7 +398,7 @@ open class XAxisRenderer: AxisRendererBase
         }
     }
     
-    open func renderLimitLineLine(context: CGContext, limitLine: ChartLimitLine, position: CGPoint)
+    @objc open func renderLimitLineLine(context: CGContext, limitLine: ChartLimitLine, position: CGPoint)
     {
         guard
             let viewPortHandler = self.viewPortHandler
@@ -422,7 +422,7 @@ open class XAxisRenderer: AxisRendererBase
         context.strokePath()
     }
     
-    open func renderLimitLineLabel(context: CGContext, limitLine: ChartLimitLine, position: CGPoint, yOffset: CGFloat)
+    @objc open func renderLimitLineLabel(context: CGContext, limitLine: ChartLimitLine, position: CGPoint, yOffset: CGFloat)
     {
         guard
             let viewPortHandler = self.viewPortHandler
@@ -445,7 +445,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x + xOffset,
                         y: viewPortHandler.contentTop + yOffset),
                     align: .left,
-                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
             }
             else if limitLine.labelPosition == .rightBottom
             {
@@ -455,7 +455,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x + xOffset,
                         y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                     align: .left,
-                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
             }
             else if limitLine.labelPosition == .leftTop
             {
@@ -465,7 +465,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x - xOffset,
                         y: viewPortHandler.contentTop + yOffset),
                     align: .right,
-                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
             }
             else
             {
@@ -475,7 +475,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x - xOffset,
                         y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                     align: .right,
-                    attributes: [NSFontAttributeName: limitLine.valueFont, NSForegroundColorAttributeName: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
             }
         }
     }

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -184,15 +184,15 @@ open class XAxisRenderer: AxisRendererBase
             else { return }
         
         #if os(OSX)
-            let paraStyle = NSParagraphStyle.default().mutableCopy() as! NSMutableParagraphStyle
+            let paraStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
         #else
             let paraStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
         #endif
         paraStyle.alignment = .center
         
-        let labelAttrs = [NSAttributedStringKey.font.rawValue: xAxis.labelFont,
+        let labelAttrs: [NSAttributedStringKey : Any] = [NSAttributedStringKey.font: xAxis.labelFont,
             NSAttributedStringKey.foregroundColor: xAxis.labelTextColor,
-            NSAttributedStringKey.paragraphStyle: paraStyle] as! [String : NSObject]
+            NSAttributedStringKey.paragraphStyle: paraStyle]
         let labelRotationAngleRadians = xAxis.labelRotationAngle * ChartUtils.Math.FDEG2RAD
         
         let centeringEnabled = xAxis.isCenterAxisLabelsEnabled
@@ -267,7 +267,7 @@ open class XAxisRenderer: AxisRendererBase
         formattedLabel: String,
         x: CGFloat,
         y: CGFloat,
-        attributes: [String: NSObject],
+        attributes: [NSAttributedStringKey : Any],
         constrainedToSize: CGSize,
         anchor: CGPoint,
         angleRadians: CGFloat)
@@ -445,7 +445,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x + xOffset,
                         y: viewPortHandler.contentTop + yOffset),
                     align: .left,
-                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font: limitLine.valueFont, NSAttributedStringKey.foregroundColor: limitLine.valueTextColor])
             }
             else if limitLine.labelPosition == .rightBottom
             {
@@ -455,7 +455,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x + xOffset,
                         y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                     align: .left,
-                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font: limitLine.valueFont, NSAttributedStringKey.foregroundColor: limitLine.valueTextColor])
             }
             else if limitLine.labelPosition == .leftTop
             {
@@ -465,7 +465,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x - xOffset,
                         y: viewPortHandler.contentTop + yOffset),
                     align: .right,
-                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font: limitLine.valueFont, NSAttributedStringKey.foregroundColor: limitLine.valueTextColor])
             }
             else
             {
@@ -475,7 +475,7 @@ open class XAxisRenderer: AxisRendererBase
                         x: position.x - xOffset,
                         y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                     align: .right,
-                    attributes: [NSAttributedStringKey.font.rawValue: limitLine.valueFont, NSAttributedStringKey.foregroundColor.rawValue: limitLine.valueTextColor])
+                    attributes: [NSAttributedStringKey.font: limitLine.valueFont, NSAttributedStringKey.foregroundColor: limitLine.valueTextColor])
             }
         }
     }

--- a/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
@@ -162,7 +162,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                         formattedLabel: label,
                         x: pos,
                         y: position.y,
-                        attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor],
+                        attributes: [NSAttributedStringKey.font: labelFont, NSAttributedStringKey.foregroundColor: labelTextColor],
                         anchor: anchor,
                         angleRadians: labelRotationAngleRadians)
                 }
@@ -175,7 +175,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
         formattedLabel: String,
         x: CGFloat,
         y: CGFloat,
-        attributes: [String: NSObject],
+        attributes: [NSAttributedStringKey : Any],
         anchor: CGPoint,
         angleRadians: CGFloat)
     {
@@ -337,7 +337,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y - yOffset),
                         align: .right,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else if l.labelPosition == .rightBottom
                 {
@@ -347,7 +347,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .right,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else if l.labelPosition == .leftTop
                 {
@@ -357,7 +357,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y - yOffset),
                         align: .left,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else
                 {
@@ -367,7 +367,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .left,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
             }
         }

--- a/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
@@ -18,9 +18,9 @@ import CoreGraphics
 
 open class XAxisRendererHorizontalBarChart: XAxisRenderer
 {
-    internal var chart: BarChartView?
+    @objc internal var chart: BarChartView?
     
-    public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, transformer: Transformer?, chart: BarChartView?)
+    @objc public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, transformer: Transformer?, chart: BarChartView?)
     {
         super.init(viewPortHandler: viewPortHandler, xAxis: xAxis, transformer: transformer)
         
@@ -68,7 +68,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
        
         let longest = xAxis.getLongestLabel() as NSString
         
-        let labelSize = longest.size(attributes: [NSFontAttributeName: xAxis.labelFont])
+        let labelSize = longest.size(withAttributes: [NSAttributedStringKey.font: xAxis.labelFont])
         
         let labelWidth = floor(labelSize.width + xAxis.xOffset * 3.5)
         let labelHeight = labelSize.height
@@ -162,7 +162,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                         formattedLabel: label,
                         x: pos,
                         y: position.y,
-                        attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor],
+                        attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor],
                         anchor: anchor,
                         angleRadians: labelRotationAngleRadians)
                 }
@@ -170,7 +170,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
         }
     }
     
-    open func drawLabel(
+    @objc open func drawLabel(
         context: CGContext,
         formattedLabel: String,
         x: CGFloat,
@@ -337,7 +337,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y - yOffset),
                         align: .right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else if l.labelPosition == .rightBottom
                 {
@@ -347,7 +347,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else if l.labelPosition == .leftTop
                 {
@@ -357,7 +357,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y - yOffset),
                         align: .left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else
                 {
@@ -367,7 +367,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
             }
         }

--- a/Source/Charts/Renderers/XAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererRadarChart.swift
@@ -64,7 +64,7 @@ open class XAxisRendererRadarChart: XAxisRenderer
                       formattedLabel: label,
                       x: p.x,
                       y: p.y - xAxis.labelRotatedHeight / 2.0,
-                      attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor],
+                      attributes: [NSAttributedStringKey.font: labelFont, NSAttributedStringKey.foregroundColor: labelTextColor],
                       anchor: drawLabelAnchor,
                       angleRadians: labelRotationAngleRadians)
         }
@@ -75,7 +75,7 @@ open class XAxisRendererRadarChart: XAxisRenderer
         formattedLabel: String,
         x: CGFloat,
         y: CGFloat,
-        attributes: [String: NSObject],
+        attributes: [NSAttributedStringKey : Any],
         anchor: CGPoint,
         angleRadians: CGFloat)
     {

--- a/Source/Charts/Renderers/XAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererRadarChart.swift
@@ -18,9 +18,9 @@ import CoreGraphics
 
 open class XAxisRendererRadarChart: XAxisRenderer
 {
-    open weak var chart: RadarChartView?
+    @objc open weak var chart: RadarChartView?
     
-    public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, chart: RadarChartView?)
+    @objc public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, chart: RadarChartView?)
     {
         super.init(viewPortHandler: viewPortHandler, xAxis: xAxis, transformer: nil)
         
@@ -64,13 +64,13 @@ open class XAxisRendererRadarChart: XAxisRenderer
                       formattedLabel: label,
                       x: p.x,
                       y: p.y - xAxis.labelRotatedHeight / 2.0,
-                      attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor],
+                      attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor],
                       anchor: drawLabelAnchor,
                       angleRadians: labelRotationAngleRadians)
         }
     }
     
-    open func drawLabel(
+    @objc open func drawLabel(
         context: CGContext,
         formattedLabel: String,
         x: CGFloat,

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -153,7 +153,7 @@ open class YAxisRenderer: AxisRendererBase
                 text: text,
                 point: CGPoint(x: fixedPosition, y: positions[i].y + offset),
                 align: textAlign,
-                attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor])
+                attributes: [NSAttributedStringKey.font: labelFont, NSAttributedStringKey.foregroundColor: labelTextColor])
         }
     }
     
@@ -364,7 +364,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y - yOffset),
                         align: .right,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else if l.labelPosition == .rightBottom
                 {
@@ -374,7 +374,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .right,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else if l.labelPosition == .leftTop
                 {
@@ -384,7 +384,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y - yOffset),
                         align: .left,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else
                 {
@@ -394,7 +394,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .left,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
             }
         }

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 @objc(ChartYAxisRenderer)
 open class YAxisRenderer: AxisRendererBase
 {
-    public init(viewPortHandler: ViewPortHandler?, yAxis: YAxis?, transformer: Transformer?)
+    @objc public init(viewPortHandler: ViewPortHandler?, yAxis: YAxis?, transformer: Transformer?)
     {
         super.init(viewPortHandler: viewPortHandler, transformer: transformer, axis: yAxis)
     }
@@ -127,7 +127,7 @@ open class YAxisRenderer: AxisRendererBase
     }
     
     /// draws the y-labels on the specified x-position
-    internal func drawYLabels(
+    @objc internal func drawYLabels(
         context: CGContext,
         fixedPosition: CGFloat,
         positions: [CGPoint],
@@ -153,7 +153,7 @@ open class YAxisRenderer: AxisRendererBase
                 text: text,
                 point: CGPoint(x: fixedPosition, y: positions[i].y + offset),
                 align: textAlign,
-                attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
+                attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor])
         }
     }
     
@@ -205,7 +205,7 @@ open class YAxisRenderer: AxisRendererBase
         }
     }
     
-    open var gridClippingRect: CGRect
+    @objc open var gridClippingRect: CGRect
     {
         var contentRect = viewPortHandler?.contentRect ?? CGRect.zero
         let dy = self.axis?.gridLineWidth ?? 0.0
@@ -214,7 +214,7 @@ open class YAxisRenderer: AxisRendererBase
         return contentRect
     }
     
-    open func drawGridLine(
+    @objc open func drawGridLine(
         context: CGContext,
         position: CGPoint)
     {
@@ -228,7 +228,7 @@ open class YAxisRenderer: AxisRendererBase
         context.strokePath()
     }
     
-    open func transformedPositions() -> [CGPoint]
+    @objc open func transformedPositions() -> [CGPoint]
     {
         guard
             let yAxis = self.axis as? YAxis,
@@ -251,7 +251,7 @@ open class YAxisRenderer: AxisRendererBase
     }
 
     /// Draws the zero line at the specified position.
-    open func drawZeroLine(context: CGContext)
+    @objc open func drawZeroLine(context: CGContext)
     {
         guard
             let yAxis = self.axis as? YAxis,
@@ -364,7 +364,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y - yOffset),
                         align: .right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else if l.labelPosition == .rightBottom
                 {
@@ -374,7 +374,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentRight - xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else if l.labelPosition == .leftTop
                 {
@@ -384,7 +384,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y - yOffset),
                         align: .left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else
                 {
@@ -394,7 +394,7 @@ open class YAxisRenderer: AxisRendererBase
                             x: viewPortHandler.contentLeft + xOffset,
                             y: position.y + yOffset - labelLineHeight),
                         align: .left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
             }
         }

--- a/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
@@ -177,7 +177,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                 text: text,
                 point: CGPoint(x: positions[i].x, y: fixedPosition - offset),
                 align: .center,
-                attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor])
+                attributes: [NSAttributedStringKey.font: labelFont, NSAttributedStringKey.foregroundColor: labelTextColor])
         }
     }
     
@@ -342,7 +342,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x + xOffset,
                             y: viewPortHandler.contentTop + yOffset),
                         align: .left,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else if l.labelPosition == .rightBottom
                 {
@@ -352,7 +352,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x + xOffset,
                             y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                         align: .left,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else if l.labelPosition == .leftTop
                 {
@@ -362,7 +362,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x - xOffset,
                             y: viewPortHandler.contentTop + yOffset),
                         align: .right,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
                 else
                 {
@@ -372,7 +372,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x - xOffset,
                             y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                         align: .right,
-                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font: l.valueFont, NSAttributedStringKey.foregroundColor: l.valueTextColor])
                 }
             }
         }

--- a/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
@@ -152,7 +152,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
     }
 
     /// draws the y-labels on the specified x-position
-    open func drawYLabels(
+    @objc open func drawYLabels(
         context: CGContext,
         fixedPosition: CGFloat,
         positions: [CGPoint],
@@ -177,7 +177,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                 text: text,
                 point: CGPoint(x: positions[i].x, y: fixedPosition - offset),
                 align: .center,
-                attributes: [NSFontAttributeName: labelFont, NSForegroundColorAttributeName: labelTextColor])
+                attributes: [NSAttributedStringKey.font.rawValue: labelFont, NSAttributedStringKey.foregroundColor.rawValue: labelTextColor])
         }
     }
     
@@ -342,7 +342,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x + xOffset,
                             y: viewPortHandler.contentTop + yOffset),
                         align: .left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else if l.labelPosition == .rightBottom
                 {
@@ -352,7 +352,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x + xOffset,
                             y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                         align: .left,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else if l.labelPosition == .leftTop
                 {
@@ -362,7 +362,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x - xOffset,
                             y: viewPortHandler.contentTop + yOffset),
                         align: .right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
                 else
                 {
@@ -372,7 +372,7 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
                             x: position.x - xOffset,
                             y: viewPortHandler.contentBottom - labelLineHeight - yOffset),
                         align: .right,
-                        attributes: [NSFontAttributeName: l.valueFont, NSForegroundColorAttributeName: l.valueTextColor])
+                        attributes: [NSAttributedStringKey.font.rawValue: l.valueFont, NSAttributedStringKey.foregroundColor.rawValue: l.valueTextColor])
                 }
             }
         }

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -196,8 +196,8 @@ open class YAxisRendererRadarChart: YAxisRenderer
                 point: CGPoint(x: p.x + 10.0, y: p.y - labelLineHeight),
                 align: .left,
                 attributes: [
-                    NSAttributedStringKey.font.rawValue: labelFont,
-                    NSAttributedStringKey.foregroundColor.rawValue: labelTextColor
+                    NSAttributedStringKey.font: labelFont,
+                    NSAttributedStringKey.foregroundColor: labelTextColor
                 ])
         }
     }

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -20,7 +20,7 @@ open class YAxisRendererRadarChart: YAxisRenderer
 {
     fileprivate weak var chart: RadarChartView?
     
-    public init(viewPortHandler: ViewPortHandler?, yAxis: YAxis?, chart: RadarChartView?)
+    @objc public init(viewPortHandler: ViewPortHandler?, yAxis: YAxis?, chart: RadarChartView?)
     {
         super.init(viewPortHandler: viewPortHandler, yAxis: yAxis, transformer: nil)
         
@@ -196,8 +196,8 @@ open class YAxisRendererRadarChart: YAxisRenderer
                 point: CGPoint(x: p.x + 10.0, y: p.y - labelLineHeight),
                 align: .left,
                 attributes: [
-                    NSFontAttributeName: labelFont,
-                    NSForegroundColorAttributeName: labelTextColor
+                    NSAttributedStringKey.font.rawValue: labelFont,
+                    NSAttributedStringKey.foregroundColor.rawValue: labelTextColor
                 ])
         }
     }

--- a/Source/Charts/Utils/ChartColorTemplates.swift
+++ b/Source/Charts/Utils/ChartColorTemplates.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 
 open class ChartColorTemplates: NSObject
 {
-    open class func liberty () -> [NSUIColor]
+    @objc open class func liberty () -> [NSUIColor]
     {
         return [
             NSUIColor(red: 207/255.0, green: 248/255.0, blue: 246/255.0, alpha: 1.0),
@@ -30,7 +30,7 @@ open class ChartColorTemplates: NSObject
         ]
     }
     
-    open class func joyful () -> [NSUIColor]
+    @objc open class func joyful () -> [NSUIColor]
     {
         return [
             NSUIColor(red: 217/255.0, green: 80/255.0, blue: 138/255.0, alpha: 1.0),
@@ -41,7 +41,7 @@ open class ChartColorTemplates: NSObject
         ]
     }
     
-    open class func pastel () -> [NSUIColor]
+    @objc open class func pastel () -> [NSUIColor]
     {
         return [
             NSUIColor(red: 64/255.0, green: 89/255.0, blue: 128/255.0, alpha: 1.0),
@@ -52,7 +52,7 @@ open class ChartColorTemplates: NSObject
         ]
     }
     
-    open class func colorful () -> [NSUIColor]
+    @objc open class func colorful () -> [NSUIColor]
     {
         return [
             NSUIColor(red: 193/255.0, green: 37/255.0, blue: 82/255.0, alpha: 1.0),
@@ -63,7 +63,7 @@ open class ChartColorTemplates: NSObject
         ]
     }
     
-    open class func vordiplom () -> [NSUIColor]
+    @objc open class func vordiplom () -> [NSUIColor]
     {
         return [
             NSUIColor(red: 192/255.0, green: 255/255.0, blue: 140/255.0, alpha: 1.0),
@@ -74,7 +74,7 @@ open class ChartColorTemplates: NSObject
         ]
     }
     
-    open class func material () -> [NSUIColor]
+    @objc open class func material () -> [NSUIColor]
     {
         return [
             NSUIColor(red: 46/255.0, green: 204/255.0, blue: 113/255.0, alpha: 1.0),
@@ -84,7 +84,7 @@ open class ChartColorTemplates: NSObject
         ]
     }
     
-    open class func colorFromString(_ colorString: String) -> NSUIColor
+    @objc open class func colorFromString(_ colorString: String) -> NSUIColor
     {
         let leftParenCharset: CharacterSet = CharacterSet(charactersIn: "( ")
         let commaCharset: CharacterSet = CharacterSet(charactersIn: ", ")

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -129,11 +129,11 @@ open class ChartUtils
         
         if align == .center
         {
-            point.x -= text.size(attributes: attributes).width / 2.0
+            point.x -= text.size(withAttributes: attributes).width / 2.0
         }
         else if align == .right
         {
-            point.x -= text.size(attributes: attributes).width
+            point.x -= text.size(withAttributes: attributes).width
         }
         
         NSUIGraphicsPushContext(context)
@@ -151,7 +151,7 @@ open class ChartUtils
         
         if angleRadians != 0.0
         {
-            let size = text.size(attributes: attributes)
+            let size = text.size(withAttributes: attributes)
             
             // Move the text drawing rect in a way that it always rotates around its center
             drawOffset.x = -size.width * 0.5
@@ -180,7 +180,7 @@ open class ChartUtils
         {
             if anchor.x != 0.0 || anchor.y != 0.0
             {
-                let size = text.size(attributes: attributes)
+                let size = text.size(withAttributes: attributes)
                 
                 drawOffset.x = -size.width * anchor.x
                 drawOffset.y = -size.height * anchor.y

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -123,7 +123,7 @@ open class ChartUtils
         NSUIGraphicsPopContext()
     }
     
-    open class func drawText(context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [String : AnyObject]?)
+    open class func drawText(context: CGContext, text: String, point: CGPoint, align: NSTextAlignment, attributes: [NSAttributedStringKey : Any]?)
     {
         var point = point
         
@@ -143,7 +143,7 @@ open class ChartUtils
         NSUIGraphicsPopContext()
     }
     
-    open class func drawText(context: CGContext, text: String, point: CGPoint, attributes: [String : AnyObject]?, anchor: CGPoint, angleRadians: CGFloat)
+    open class func drawText(context: CGContext, text: String, point: CGPoint, attributes: [NSAttributedStringKey : Any]?, anchor: CGPoint, angleRadians: CGFloat)
     {
         var drawOffset = CGPoint()
         
@@ -195,7 +195,7 @@ open class ChartUtils
         NSUIGraphicsPopContext()
     }
     
-    internal class func drawMultilineText(context: CGContext, text: String, knownTextSize: CGSize, point: CGPoint, attributes: [String : AnyObject]?, constrainedToSize: CGSize, anchor: CGPoint, angleRadians: CGFloat)
+    internal class func drawMultilineText(context: CGContext, text: String, knownTextSize: CGSize, point: CGPoint, attributes: [NSAttributedStringKey : Any]?, constrainedToSize: CGSize, anchor: CGPoint, angleRadians: CGFloat)
     {
         var rect = CGRect(origin: CGPoint(), size: knownTextSize)
         
@@ -243,7 +243,7 @@ open class ChartUtils
         NSUIGraphicsPopContext()
     }
     
-    internal class func drawMultilineText(context: CGContext, text: String, point: CGPoint, attributes: [String : AnyObject]?, constrainedToSize: CGSize, anchor: CGPoint, angleRadians: CGFloat)
+    internal class func drawMultilineText(context: CGContext, text: String, point: CGPoint, attributes: [NSAttributedStringKey : Any]?, constrainedToSize: CGSize, anchor: CGPoint, angleRadians: CGFloat)
     {
         let rect = text.boundingRect(with: constrainedToSize, options: .usesLineFragmentOrigin, attributes: attributes, context: nil)
         drawMultilineText(context: context, text: text, knownTextSize: rect.size, point: point, attributes: attributes, constrainedToSize: constrainedToSize, anchor: anchor, angleRadians: angleRadians)

--- a/Source/Charts/Utils/Fill.swift
+++ b/Source/Charts/Utils/Fill.swift
@@ -40,52 +40,52 @@ open class Fill: NSObject
     
     // MARK: Properties
     
-    open var type: FillType
+    @objc open var type: FillType
     {
         return _type
     }
     
-    open var color: CGColor?
+    @objc open var color: CGColor?
     {
         return _color
     }
     
-    open var gradient: CGGradient?
+    @objc open var gradient: CGGradient?
     {
         return _gradient
     }
     
-    open var gradientAngle: CGFloat
+    @objc open var gradientAngle: CGFloat
     {
         return _gradientAngle
     }
     
-    open var gradientStartOffsetPercent: CGPoint
+    @objc open var gradientStartOffsetPercent: CGPoint
     {
         return _gradientStartOffsetPercent
     }
     
-    open var gradientStartRadiusPercent: CGFloat
+    @objc open var gradientStartRadiusPercent: CGFloat
     {
         return _gradientStartRadiusPercent
     }
     
-    open var gradientEndOffsetPercent: CGPoint
+    @objc open var gradientEndOffsetPercent: CGPoint
     {
         return _gradientEndOffsetPercent
     }
     
-    open var gradientEndRadiusPercent: CGFloat
+    @objc open var gradientEndRadiusPercent: CGFloat
     {
         return _gradientEndRadiusPercent
     }
     
-    open var image: CGImage?
+    @objc open var image: CGImage?
     {
         return _image
     }
     
-    open var layer: CGLayer?
+    @objc open var layer: CGLayer?
     {
         return _layer
     }
@@ -96,25 +96,25 @@ open class Fill: NSObject
     {
     }
     
-    public init(CGColor: CGColor)
+    @objc public init(CGColor: CGColor)
     {
         _type = .color
         _color = CGColor
     }
     
-    public convenience init(color: NSUIColor)
+    @objc public convenience init(color: NSUIColor)
     {
         self.init(CGColor: color.cgColor)
     }
     
-    public init(linearGradient: CGGradient, angle: CGFloat)
+    @objc public init(linearGradient: CGGradient, angle: CGFloat)
     {
         _type = .linearGradient
         _gradient = linearGradient
         _gradientAngle = angle
     }
     
-    public init(
+    @objc public init(
         radialGradient: CGGradient,
         startOffsetPercent: CGPoint,
         startRadiusPercent: CGFloat,
@@ -130,7 +130,7 @@ open class Fill: NSObject
         _gradientEndRadiusPercent = endRadiusPercent
     }
     
-    public convenience init(radialGradient: CGGradient)
+    @objc public convenience init(radialGradient: CGGradient)
     {
         self.init(
             radialGradient: radialGradient,
@@ -141,28 +141,28 @@ open class Fill: NSObject
         )
     }
     
-    public init(CGImage: CGImage, tiled: Bool)
+    @objc public init(CGImage: CGImage, tiled: Bool)
     {
         _type = tiled ? .tiledImage : .image
         _image = CGImage
     }
     
-    public convenience init(image: NSUIImage, tiled: Bool)
+    @objc public convenience init(image: NSUIImage, tiled: Bool)
     {
         self.init(CGImage: image.cgImage!, tiled: tiled)
     }
     
-    public convenience init(CGImage: CGImage)
+    @objc public convenience init(CGImage: CGImage)
     {
         self.init(CGImage: CGImage, tiled: false)
     }
     
-    public convenience init(image: NSUIImage)
+    @objc public convenience init(image: NSUIImage)
     {
         self.init(image: image, tiled: false)
     }
     
-    public init(CGLayer: CGLayer)
+    @objc public init(CGLayer: CGLayer)
     {
         _type = .layer
         _layer = CGLayer
@@ -170,24 +170,24 @@ open class Fill: NSObject
     
     // MARK: Constructors
     
-    open class func fillWithCGColor(_ CGColor: CGColor) -> Fill
+    @objc open class func fillWithCGColor(_ CGColor: CGColor) -> Fill
     {
         return Fill(CGColor: CGColor)
     }
     
-    open class func fillWithColor(_ color: NSUIColor) -> Fill
+    @objc open class func fillWithColor(_ color: NSUIColor) -> Fill
     {
         return Fill(color: color)
     }
     
-    open class func fillWithLinearGradient(
+    @objc open class func fillWithLinearGradient(
         _ linearGradient: CGGradient,
         angle: CGFloat) -> Fill
     {
         return Fill(linearGradient: linearGradient, angle: angle)
     }
     
-    open class func fillWithRadialGradient(
+    @objc open class func fillWithRadialGradient(
         _ radialGradient: CGGradient,
         startOffsetPercent: CGPoint,
         startRadiusPercent: CGFloat,
@@ -204,32 +204,32 @@ open class Fill: NSObject
         )
     }
     
-    open class func fillWithRadialGradient(_ radialGradient: CGGradient) -> Fill
+    @objc open class func fillWithRadialGradient(_ radialGradient: CGGradient) -> Fill
     {
         return Fill(radialGradient: radialGradient)
     }
     
-    open class func fillWithCGImage(_ CGImage: CGImage, tiled: Bool) -> Fill
+    @objc open class func fillWithCGImage(_ CGImage: CGImage, tiled: Bool) -> Fill
     {
         return Fill(CGImage: CGImage, tiled: tiled)
     }
     
-    open class func fillWithImage(_ image: NSUIImage, tiled: Bool) -> Fill
+    @objc open class func fillWithImage(_ image: NSUIImage, tiled: Bool) -> Fill
     {
         return Fill(image: image, tiled: tiled)
     }
     
-    open class func fillWithCGImage(_ CGImage: CGImage) -> Fill
+    @objc open class func fillWithCGImage(_ CGImage: CGImage) -> Fill
     {
         return Fill(CGImage: CGImage)
     }
     
-    open class func fillWithImage(_ image: NSUIImage) -> Fill
+    @objc open class func fillWithImage(_ image: NSUIImage) -> Fill
     {
         return Fill(image: image)
     }
     
-    open class func fillWithCGLayer(_ CGLayer: CGLayer) -> Fill
+    @objc open class func fillWithCGLayer(_ CGLayer: CGLayer) -> Fill
     {
         return Fill(CGLayer: CGLayer)
     }
@@ -237,7 +237,7 @@ open class Fill: NSObject
     // MARK: Drawing code
     
     /// Draws the provided path in filled mode with the provided area
-    open func fillPath(
+    @objc open func fillPath(
         context: CGContext,
         rect: CGRect)
     {

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -516,17 +516,6 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
             }
 		}
     }
-    
-    extension NSString
-    {
-        // iOS: size(attributes: ...), OSX: size(withAttributes: ...)
-        // Both are translated into sizeWithAttributes: on ObjC. So conflict...
-        @nonobjc
-        func size(attributes attrs: [NSAttributedStringKey : Any]? = nil) -> NSSize
-        {
-            return size(withAttributes: attrs)
-        }
-    }
 
 	func NSUIGraphicsGetCurrentContext() -> CGContext?
     {

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -27,12 +27,12 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
     
     extension NSUITapGestureRecognizer
     {
-        final func nsuiNumberOfTouches() -> Int
+        @objc final func nsuiNumberOfTouches() -> Int
         {
             return numberOfTouches
         }
         
-        final var nsuiNumberOfTapsRequired: Int
+        @objc final var nsuiNumberOfTapsRequired: Int
         {
             get
             {
@@ -47,12 +47,12 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
     
     extension NSUIPanGestureRecognizer
     {
-        final func nsuiNumberOfTouches() -> Int
+        @objc final func nsuiNumberOfTouches() -> Int
         {
             return numberOfTouches
         }
         
-        final func nsuiLocationOfTouch(_ touch: Int, inView: UIView?) -> CGPoint
+        @objc final func nsuiLocationOfTouch(_ touch: Int, inView: UIView?) -> CGPoint
         {
             return super.location(ofTouch: touch, in: inView)
         }
@@ -61,7 +61,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 #if !os(tvOS)
     extension NSUIRotationGestureRecognizer
     {
-        final var nsuiRotation: CGFloat
+        @objc final var nsuiRotation: CGFloat
         {
             get { return rotation }
             set { rotation = newValue }
@@ -72,7 +72,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 #if !os(tvOS)
     extension NSUIPinchGestureRecognizer
     {
-        final var nsuiScale: CGFloat
+        @objc final var nsuiScale: CGFloat
         {
             get
             {
@@ -84,7 +84,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
             }
         }
         
-        final func nsuiLocationOfTouch(_ touch: Int, inView: UIView?) -> CGPoint
+        @objc final func nsuiLocationOfTouch(_ touch: Int, inView: UIView?) -> CGPoint
         {
             return super.location(ofTouch: touch, in: inView)
         }
@@ -113,27 +113,27 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 			self.nsuiTouchesCancelled(touches, withEvent: event)
 		}
 
-		open func nsuiTouchesBegan(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
+		@objc open func nsuiTouchesBegan(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
         {
 			super.touchesBegan(touches, with: event!)
 		}
 
-		open func nsuiTouchesMoved(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
+		@objc open func nsuiTouchesMoved(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
         {
 			super.touchesMoved(touches, with: event!)
 		}
 
-		open func nsuiTouchesEnded(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
+		@objc open func nsuiTouchesEnded(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
         {
 			super.touchesEnded(touches, with: event!)
 		}
 
-		open func nsuiTouchesCancelled(_ touches: Set<NSUITouch>?, withEvent event: NSUIEvent?)
+		@objc open func nsuiTouchesCancelled(_ touches: Set<NSUITouch>?, withEvent event: NSUIEvent?)
         {
 			super.touchesCancelled(touches!, with: event!)
 		}
 
-		var nsuiLayer: CALayer?
+		@objc var nsuiLayer: CALayer?
         {
 			return self.layer
 		}
@@ -141,7 +141,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 
 	extension UIView
     {
-		final var nsuiGestureRecognizers: [NSUIGestureRecognizer]?
+		@objc final var nsuiGestureRecognizers: [NSUIGestureRecognizer]?
         {
 			return self.gestureRecognizers
 		}
@@ -149,7 +149,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
     
     extension UIScrollView
     {
-        var nsuiIsScrollEnabled: Bool
+        @objc var nsuiIsScrollEnabled: Bool
         {
             get { return isScrollEnabled }
             set { isScrollEnabled = newValue }
@@ -158,7 +158,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
     
     extension UIScreen
     {
-        final var nsuiScale: CGFloat
+        @objc final var nsuiScale: CGFloat
         {
             return self.scale
         }

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -222,7 +222,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 	public typealias NSUIImage = NSImage
 	public typealias NSUIScrollView = NSScrollView
 	public typealias NSUIGestureRecognizer = NSGestureRecognizer
-	public typealias NSUIGestureRecognizerState = NSGestureRecognizerState
+	public typealias NSUIGestureRecognizerState = NSGestureRecognizer.State
 	public typealias NSUIGestureRecognizerDelegate = NSGestureRecognizerDelegate
 	public typealias NSUITapGestureRecognizer = NSClickGestureRecognizer
 	public typealias NSUIPanGestureRecognizer = NSPanGestureRecognizer
@@ -522,7 +522,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
         // iOS: size(attributes: ...), OSX: size(withAttributes: ...)
         // Both are translated into sizeWithAttributes: on ObjC. So conflict...
         @nonobjc
-        func size(attributes attrs: [String : Any]? = nil) -> NSSize
+        func size(attributes attrs: [NSAttributedStringKey : Any]? = nil) -> NSSize
         {
             return size(withAttributes: attrs)
         }
@@ -530,14 +530,14 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 
 	func NSUIGraphicsGetCurrentContext() -> CGContext?
     {
-		return NSGraphicsContext.current()?.cgContext
+		return NSGraphicsContext.current?.cgContext
 	}
 
 	func NSUIGraphicsPushContext(_ context: CGContext)
     {
         let cx = NSGraphicsContext(cgContext: context, flipped: true)
 		NSGraphicsContext.saveGraphicsState()
-		NSGraphicsContext.setCurrent(cx)
+		NSGraphicsContext.current = cx
 	}
 
 	func NSUIGraphicsPopContext()
@@ -550,7 +550,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 		image.lockFocus()
 		let rep = NSBitmapImageRep(focusedViewRect: NSMakeRect(0, 0, image.size.width, image.size.height))
 		image.unlockFocus()
-		return rep?.representation(using: .PNG, properties: [:])
+        return rep?.representation(using: .png, properties: [:])
 	}
 
 	func NSUIImageJPEGRepresentation(_ image: NSUIImage, _ quality: CGFloat = 0.9) -> Data?
@@ -558,7 +558,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 		image.lockFocus()
 		let rep = NSBitmapImageRep(focusedViewRect: NSMakeRect(0, 0, image.size.width, image.size.height))
 		image.unlockFocus()
-        return rep?.representation(using: .JPEG, properties: [NSImageCompressionFactor: quality])
+        return rep?.representation(using: .jpeg, properties: [NSBitmapImageRep.PropertyKey.compressionFactor: quality])
 	}
 
 	private var imageContextStack: [CGFloat] = []
@@ -568,7 +568,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 		var scale = scale
 		if scale == 0.0
         {
-			scale = NSScreen.main()?.backingScaleFactor ?? 1.0
+            scale = NSScreen.main?.backingScaleFactor ?? 1.0
 		}
 
 		let width = Int(size.width * scale)
@@ -618,7 +618,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 
 	func NSUIMainScreen() -> NSUIScreen?
     {
-		return NSUIScreen.main()
+		return NSUIScreen.main
 	}
     
 #endif

--- a/Source/Charts/Utils/Transformer.swift
+++ b/Source/Charts/Utils/Transformer.swift
@@ -17,20 +17,20 @@ import CoreGraphics
 open class Transformer: NSObject
 {
     /// matrix to map the values to the screen pixels
-    internal var _matrixValueToPx = CGAffineTransform.identity
+    @objc internal var _matrixValueToPx = CGAffineTransform.identity
 
     /// matrix for handling the different offsets of the chart
-    internal var _matrixOffset = CGAffineTransform.identity
+    @objc internal var _matrixOffset = CGAffineTransform.identity
 
-    internal var _viewPortHandler: ViewPortHandler
+    @objc internal var _viewPortHandler: ViewPortHandler
 
-    public init(viewPortHandler: ViewPortHandler)
+    @objc public init(viewPortHandler: ViewPortHandler)
     {
         _viewPortHandler = viewPortHandler
     }
 
     /// Prepares the matrix that transforms values to pixels. Calculates the scale factors from the charts size and offsets.
-    open func prepareMatrixValuePx(chartXMin: Double, deltaX: CGFloat, deltaY: CGFloat, chartYMin: Double)
+    @objc open func prepareMatrixValuePx(chartXMin: Double, deltaX: CGFloat, deltaY: CGFloat, chartYMin: Double)
     {
         var scaleX = (_viewPortHandler.contentWidth / deltaX)
         var scaleY = (_viewPortHandler.contentHeight / deltaY)
@@ -51,7 +51,7 @@ open class Transformer: NSObject
     }
 
     /// Prepares the matrix that contains all offsets.
-    open func prepareMatrixOffset(inverted: Bool)
+    @objc open func prepareMatrixOffset(inverted: Bool)
     {
         if !inverted
         {
@@ -80,7 +80,7 @@ open class Transformer: NSObject
         point = point.applying(valueToPixelMatrix)
     }
     
-    open func pixelForValues(x: Double, y: Double) -> CGPoint
+    @objc open func pixelForValues(x: Double, y: Double) -> CGPoint
     {
         return CGPoint(x: x, y: y).applying(valueToPixelMatrix)
     }
@@ -153,7 +153,7 @@ open class Transformer: NSObject
     /// - returns: The x and y values in the chart at the given touch point
     /// (encapsulated in a CGPoint). This method transforms pixel coordinates to
     /// coordinates / values in the chart.
-    open func valueForTouchPoint(_ point: CGPoint) -> CGPoint
+    @objc open func valueForTouchPoint(_ point: CGPoint) -> CGPoint
     {
         return point.applying(pixelToValueMatrix)
     }
@@ -161,12 +161,12 @@ open class Transformer: NSObject
     /// - returns: The x and y values in the chart at the given touch point
     /// (x/y). This method transforms pixel coordinates to
     /// coordinates / values in the chart.
-    open func valueForTouchPoint(x: CGFloat, y: CGFloat) -> CGPoint
+    @objc open func valueForTouchPoint(x: CGFloat, y: CGFloat) -> CGPoint
     {
         return CGPoint(x: x, y: y).applying(pixelToValueMatrix)
     }
     
-    open var valueToPixelMatrix: CGAffineTransform
+    @objc open var valueToPixelMatrix: CGAffineTransform
     {
         return
             _matrixValueToPx.concatenating(_viewPortHandler.touchMatrix
@@ -174,7 +174,7 @@ open class Transformer: NSObject
         )
     }
     
-    open var pixelToValueMatrix: CGAffineTransform
+    @objc open var pixelToValueMatrix: CGAffineTransform
     {
         return valueToPixelMatrix.inverted()
     }

--- a/Source/Charts/Utils/ViewPortHandler.swift
+++ b/Source/Charts/Utils/ViewPortHandler.swift
@@ -60,14 +60,14 @@ open class ViewPortHandler: NSObject
     }
     
     /// Constructor - don't forget calling setChartDimens(...)
-    public init(width: CGFloat, height: CGFloat)
+    @objc public init(width: CGFloat, height: CGFloat)
     {
         super.init()
         
         setChartDimens(width: width, height: height)
     }
     
-    open func setChartDimens(width: CGFloat, height: CGFloat)
+    @objc open func setChartDimens(width: CGFloat, height: CGFloat)
     {
         let offsetLeft = self.offsetLeft
         let offsetTop = self.offsetTop
@@ -80,7 +80,7 @@ open class ViewPortHandler: NSObject
         restrainViewPort(offsetLeft: offsetLeft, offsetTop: offsetTop, offsetRight: offsetRight, offsetBottom: offsetBottom)
     }
     
-    open var hasChartDimens: Bool
+    @objc open var hasChartDimens: Bool
     {
         if _chartHeight > 0.0 && _chartWidth > 0.0
         {
@@ -92,7 +92,7 @@ open class ViewPortHandler: NSObject
         }
     }
 
-    open func restrainViewPort(offsetLeft: CGFloat, offsetTop: CGFloat, offsetRight: CGFloat, offsetBottom: CGFloat)
+    @objc open func restrainViewPort(offsetLeft: CGFloat, offsetTop: CGFloat, offsetRight: CGFloat, offsetBottom: CGFloat)
     {
         _contentRect.origin.x = offsetLeft
         _contentRect.origin.y = offsetTop
@@ -100,72 +100,72 @@ open class ViewPortHandler: NSObject
         _contentRect.size.height = _chartHeight - offsetBottom - offsetTop
     }
     
-    open var offsetLeft: CGFloat
+    @objc open var offsetLeft: CGFloat
     {
         return _contentRect.origin.x
     }
     
-    open var offsetRight: CGFloat
+    @objc open var offsetRight: CGFloat
     {
         return _chartWidth - _contentRect.size.width - _contentRect.origin.x
     }
     
-    open var offsetTop: CGFloat
+    @objc open var offsetTop: CGFloat
     {
         return _contentRect.origin.y
     }
     
-    open var offsetBottom: CGFloat
+    @objc open var offsetBottom: CGFloat
     {
         return _chartHeight - _contentRect.size.height - _contentRect.origin.y
     }
     
-    open var contentTop: CGFloat
+    @objc open var contentTop: CGFloat
     {
         return _contentRect.origin.y
     }
     
-    open var contentLeft: CGFloat
+    @objc open var contentLeft: CGFloat
     {
         return _contentRect.origin.x
     }
     
-    open var contentRight: CGFloat
+    @objc open var contentRight: CGFloat
     {
         return _contentRect.origin.x + _contentRect.size.width
     }
     
-    open var contentBottom: CGFloat
+    @objc open var contentBottom: CGFloat
     {
         return _contentRect.origin.y + _contentRect.size.height
     }
     
-    open var contentWidth: CGFloat
+    @objc open var contentWidth: CGFloat
     {
         return _contentRect.size.width
     }
     
-    open var contentHeight: CGFloat
+    @objc open var contentHeight: CGFloat
     {
         return _contentRect.size.height
     }
     
-    open var contentRect: CGRect
+    @objc open var contentRect: CGRect
     {
         return _contentRect
     }
     
-    open var contentCenter: CGPoint
+    @objc open var contentCenter: CGPoint
     {
         return CGPoint(x: _contentRect.origin.x + _contentRect.size.width / 2.0, y: _contentRect.origin.y + _contentRect.size.height / 2.0)
     }
     
-    open var chartHeight: CGFloat
+    @objc open var chartHeight: CGFloat
     { 
         return _chartHeight
     }
     
-    open var chartWidth: CGFloat
+    @objc open var chartWidth: CGFloat
     { 
         return _chartWidth
     }
@@ -173,13 +173,13 @@ open class ViewPortHandler: NSObject
     // MARK: - Scaling/Panning etc.
     
     /// Zooms by the specified zoom factors.
-    open func zoom(scaleX: CGFloat, scaleY: CGFloat) -> CGAffineTransform
+    @objc open func zoom(scaleX: CGFloat, scaleY: CGFloat) -> CGAffineTransform
     {
         return _touchMatrix.scaledBy(x: scaleX, y: scaleY)
     }
     
     /// Zooms around the specified center
-    open func zoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
+    @objc open func zoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         var matrix = _touchMatrix.translatedBy(x: x, y: y)
         matrix = matrix.scaledBy(x: scaleX, y: scaleY)
@@ -188,25 +188,25 @@ open class ViewPortHandler: NSObject
     }
     
     /// Zooms in by 1.4, x and y are the coordinates (in pixels) of the zoom center.
-    open func zoomIn(x: CGFloat, y: CGFloat) -> CGAffineTransform
+    @objc open func zoomIn(x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         return zoom(scaleX: 1.4, scaleY: 1.4, x: x, y: y)
     }
     
     /// Zooms out by 0.7, x and y are the coordinates (in pixels) of the zoom center.
-    open func zoomOut(x: CGFloat, y: CGFloat) -> CGAffineTransform
+    @objc open func zoomOut(x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         return zoom(scaleX: 0.7, scaleY: 0.7, x: x, y: y)
     }
     
     /// Zooms out to original size.
-    open func resetZoom() -> CGAffineTransform
+    @objc open func resetZoom() -> CGAffineTransform
     {
         return zoom(scaleX: 1.0, scaleY: 1.0, x: 0.0, y: 0.0)
     }
     
     /// Sets the scale factor to the specified values.
-    open func setZoom(scaleX: CGFloat, scaleY: CGFloat) -> CGAffineTransform
+    @objc open func setZoom(scaleX: CGFloat, scaleY: CGFloat) -> CGAffineTransform
     {
         var matrix = _touchMatrix
         matrix.a = scaleX
@@ -215,7 +215,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Sets the scale factor to the specified values. x and y is pivot.
-    open func setZoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
+    @objc open func setZoom(scaleX: CGFloat, scaleY: CGFloat, x: CGFloat, y: CGFloat) -> CGAffineTransform
     {
         var matrix = _touchMatrix
         matrix.a = 1.0
@@ -227,7 +227,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Resets all zooming and dragging and makes the chart fit exactly it's bounds.
-    open func fitScreen() -> CGAffineTransform
+    @objc open func fitScreen() -> CGAffineTransform
     {
         _minScaleX = 1.0
         _minScaleY = 1.0
@@ -236,7 +236,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Translates to the specified point.
-    open func translate(pt: CGPoint) -> CGAffineTransform
+    @objc open func translate(pt: CGPoint) -> CGAffineTransform
     {
         let translateX = pt.x - offsetLeft
         let translateY = pt.y - offsetTop
@@ -249,7 +249,7 @@ open class ViewPortHandler: NSObject
     /// Centers the viewport around the specified position (x-index and y-value) in the chart.
     /// Centering the viewport outside the bounds of the chart is not possible.
     /// Makes most sense in combination with the setScaleMinima(...) method.
-    open func centerViewPort(pt: CGPoint, chart: ChartViewBase)
+    @objc open func centerViewPort(pt: CGPoint, chart: ChartViewBase)
     {
         let translateX = pt.x - offsetLeft
         let translateY = pt.y - offsetTop
@@ -260,7 +260,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// call this method to refresh the graph with a given matrix
-    open func refresh(newMatrix: CGAffineTransform, chart: ChartViewBase, invalidate: Bool) -> CGAffineTransform
+    @objc open func refresh(newMatrix: CGAffineTransform, chart: ChartViewBase, invalidate: Bool) -> CGAffineTransform
     {
         _touchMatrix = newMatrix
         
@@ -304,7 +304,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Sets the minimum scale factor for the x-axis
-    open func setMinimumScaleX(_ xScale: CGFloat)
+    @objc open func setMinimumScaleX(_ xScale: CGFloat)
     {
         var newValue = xScale
         
@@ -319,7 +319,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Sets the maximum scale factor for the x-axis
-    open func setMaximumScaleX(_ xScale: CGFloat)
+    @objc open func setMaximumScaleX(_ xScale: CGFloat)
     {
         var newValue = xScale
         
@@ -334,7 +334,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Sets the minimum and maximum scale factors for the x-axis
-    open func setMinMaxScaleX(minScaleX: CGFloat, maxScaleX: CGFloat)
+    @objc open func setMinMaxScaleX(minScaleX: CGFloat, maxScaleX: CGFloat)
     {
         var newMin = minScaleX
         var newMax = minScaleY
@@ -355,7 +355,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Sets the minimum scale factor for the y-axis
-    open func setMinimumScaleY(_ yScale: CGFloat)
+    @objc open func setMinimumScaleY(_ yScale: CGFloat)
     {
         var newValue = yScale
         
@@ -370,7 +370,7 @@ open class ViewPortHandler: NSObject
     }
     
     /// Sets the maximum scale factor for the y-axis
-    open func setMaximumScaleY(_ yScale: CGFloat)
+    @objc open func setMaximumScaleY(_ yScale: CGFloat)
     {
         var newValue = yScale
         
@@ -384,7 +384,7 @@ open class ViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
     
-    open func setMinMaxScaleY(minScaleY: CGFloat, maxScaleY: CGFloat)
+    @objc open func setMinMaxScaleY(minScaleY: CGFloat, maxScaleY: CGFloat)
     {
         var minScaleY = minScaleY, maxScaleY = maxScaleY
         
@@ -404,154 +404,154 @@ open class ViewPortHandler: NSObject
         limitTransAndScale(matrix: &_touchMatrix, content: _contentRect)
     }
 
-    open var touchMatrix: CGAffineTransform
+    @objc open var touchMatrix: CGAffineTransform
     {
         return _touchMatrix
     }
     
     // MARK: - Boundaries Check
     
-    open func isInBoundsX(_ x: CGFloat) -> Bool
+    @objc open func isInBoundsX(_ x: CGFloat) -> Bool
     {
         return isInBoundsLeft(x) && isInBoundsRight(x)
     }
     
-    open func isInBoundsY(_ y: CGFloat) -> Bool
+    @objc open func isInBoundsY(_ y: CGFloat) -> Bool
     {
         return isInBoundsTop(y) && isInBoundsBottom(y)
     }
     
-    open func isInBounds(x: CGFloat, y: CGFloat) -> Bool
+    @objc open func isInBounds(x: CGFloat, y: CGFloat) -> Bool
     {
         return isInBoundsX(x) && isInBoundsY(y)
     }
     
-    open func isInBoundsLeft(_ x: CGFloat) -> Bool
+    @objc open func isInBoundsLeft(_ x: CGFloat) -> Bool
     {
         return _contentRect.origin.x <= x + 1.0
     }
     
-    open func isInBoundsRight(_ x: CGFloat) -> Bool
+    @objc open func isInBoundsRight(_ x: CGFloat) -> Bool
     {
         let x = floor(x * 100.0) / 100.0
         return (_contentRect.origin.x + _contentRect.size.width) >= x - 1.0
     }
     
-    open func isInBoundsTop(_ y: CGFloat) -> Bool
+    @objc open func isInBoundsTop(_ y: CGFloat) -> Bool
     {
         return _contentRect.origin.y <= y
     }
     
-    open func isInBoundsBottom(_ y: CGFloat) -> Bool
+    @objc open func isInBoundsBottom(_ y: CGFloat) -> Bool
     {
         let normalizedY = floor(y * 100.0) / 100.0
         return (_contentRect.origin.y + _contentRect.size.height) >= normalizedY
     }
     
     /// - returns: The current x-scale factor
-    open var scaleX: CGFloat
+    @objc open var scaleX: CGFloat
     {
         return _scaleX
     }
     
     /// - returns: The current y-scale factor
-    open var scaleY: CGFloat
+    @objc open var scaleY: CGFloat
     {
         return _scaleY
     }
     
     /// - returns: The minimum x-scale factor
-    open var minScaleX: CGFloat
+    @objc open var minScaleX: CGFloat
     {
         return _minScaleX
     }
     
     /// - returns: The minimum y-scale factor
-    open var minScaleY: CGFloat
+    @objc open var minScaleY: CGFloat
     {
         return _minScaleY
     }
     
     /// - returns: The minimum x-scale factor
-    open var maxScaleX: CGFloat
+    @objc open var maxScaleX: CGFloat
     {
         return _maxScaleX
     }
     
     /// - returns: The minimum y-scale factor
-    open var maxScaleY: CGFloat
+    @objc open var maxScaleY: CGFloat
     {
         return _maxScaleY
     }
     
     /// - returns: The translation (drag / pan) distance on the x-axis
-    open var transX: CGFloat
+    @objc open var transX: CGFloat
     {
         return _transX
     }
     
     /// - returns: The translation (drag / pan) distance on the y-axis
-    open var transY: CGFloat
+    @objc open var transY: CGFloat
     {
         return _transY
     }
     
     /// if the chart is fully zoomed out, return true
-    open var isFullyZoomedOut: Bool
+    @objc open var isFullyZoomedOut: Bool
     {
         return isFullyZoomedOutX && isFullyZoomedOutY
     }
     
     /// - returns: `true` if the chart is fully zoomed out on it's y-axis (vertical).
-    open var isFullyZoomedOutY: Bool
+    @objc open var isFullyZoomedOutY: Bool
     {
         return !(_scaleY > _minScaleY || _minScaleY > 1.0)
     }
     
     /// - returns: `true` if the chart is fully zoomed out on it's x-axis (horizontal).
-    open var isFullyZoomedOutX: Bool
+    @objc open var isFullyZoomedOutX: Bool
     {
         return !(_scaleX > _minScaleX || _minScaleX > 1.0)
     }
     
     /// Set an offset in pixels that allows the user to drag the chart over it's bounds on the x-axis.
-    open func setDragOffsetX(_ offset: CGFloat)
+    @objc open func setDragOffsetX(_ offset: CGFloat)
     {
         _transOffsetX = offset
     }
     
     /// Set an offset in pixels that allows the user to drag the chart over it's bounds on the y-axis.
-    open func setDragOffsetY(_ offset: CGFloat)
+    @objc open func setDragOffsetY(_ offset: CGFloat)
     {
         _transOffsetY = offset
     }
     
     /// - returns: `true` if both drag offsets (x and y) are zero or smaller.
-    open var hasNoDragOffset: Bool
+    @objc open var hasNoDragOffset: Bool
     {
         return _transOffsetX <= 0.0 && _transOffsetY <= 0.0
     }
     
     /// - returns: `true` if the chart is not yet fully zoomed out on the x-axis
-    open var canZoomOutMoreX: Bool
+    @objc open var canZoomOutMoreX: Bool
     {
         return _scaleX > _minScaleX
     }
     
     /// - returns: `true` if the chart is not yet fully zoomed in on the x-axis
-    open var canZoomInMoreX: Bool
+    @objc open var canZoomInMoreX: Bool
     {
         return _scaleX < _maxScaleX
     }
     
     /// - returns: `true` if the chart is not yet fully zoomed out on the y-axis
-    open var canZoomOutMoreY: Bool
+    @objc open var canZoomOutMoreY: Bool
     {
         return _scaleY > _minScaleY
     }
     
     /// - returns: `true` if the chart is not yet fully zoomed in on the y-axis
-    open var canZoomInMoreY: Bool
+    @objc open var canZoomInMoreY: Bool
     {
         return _scaleY < _maxScaleY
     }


### PR DESCRIPTION
Thanks to Swift 4's compatibility, this year is easier to upgrade on our own pace. But still works to do :(

## Part I 
modify All `NSAttributedStringKey` related methods for Swift 4

#### Note:
- `extension NSString for func size(attributes attrs: [String : Any]? = nil) -> NSSize`
is deleted due to iOS 11 uses `size(withAttributes: attrs)` now

## Known issues:
- There are tons of warnings about `@objc` usage, a new enhancement to reduce binary size since Swift 4, which is quite confusing, still waiting for newer Xcode 9 beta to see if it can help and investigating a better solution. Related SE: [SE-0160](https://github.com/apple/swift-evolution/blob/master/proposals/0160-objc-inference.md). One [SO Thread](https://stackoverflow.com/questions/44379348/the-use-of-swift-3-objc-inference-in-swift-4-mode-is-deprecated) discuss it