### PR TITLE
fix #2356

### DIFF
--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -127,7 +127,8 @@ open class AxisRendererBase: Renderer
         if intervalSigDigit > 5
         {
             // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
-            interval = floor(10.0 * Double(intervalMagnitude))
+            // if it's 0.0 after floor(), we use the old value
+            interval = floor(10.0 * intervalMagnitude) == 0.0 ? interval : floor(10.0 * intervalMagnitude)
         }
         
         var n = axis.centerAxisLabelsEnabled ? 1 : 0

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -60,9 +60,9 @@ open class YAxisRendererRadarChart: YAxisRenderer
         
         if intervalSigDigit > 5
         {
-            // Use one order of magnitude higher, to avoid intervals like 0.9 or
-            // 90
-            interval = floor(10 * intervalMagnitude)
+            // Use one order of magnitude higher, to avoid intervals like 0.9 or 90
+            // if it's 0.0 after floor(), we use the old value
+            interval = floor(10.0 * intervalMagnitude) == 0.0 ? interval : floor(10.0 * intervalMagnitude)
         }
         
         let centeringEnabled = axis.isCenterAxisLabelsEnabled


### PR DESCRIPTION
## Description
- Step 2 of 2 for fixing the bug detailed at https://cha-ching.atlassian.net/browse/DEV-4680

> When `floor(10.0 * intervalMagnitude)` is 0.0, we use the old value to avoid crash at `axis.decimals = Int(ceil(-log10(interval)))`

https://github.com/danielgindi/Charts/pull/2377

