### PR TITLE
Avoid passing NaN to CoreGraphics API (Fixes #1626)

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -746,8 +746,8 @@ open class LineChartRenderer: LineRadarRenderer
                 context.setLineDash(phase: 0.0, lengths: [])
             }
             
-            let x = high.x // get the x-position
-            let y = high.y * Double(animator.phaseY)
+            let x = e.x // get the x-position
+            let y = e.y * Double(animator.phaseY)
             
             if x > chartXMax * animator.phaseX
             {


### PR DESCRIPTION
Fix issue #1626 
The `Highlight` object generated in the `ChartViewBase` class contains a `Double.NaN` y-value when calling the `highlightValue` functions that does not require a y-value.

In the `LineChartRenderer` class, the `drawHighlighted` function passes the NaN y-value into the `Transformer` `pixelForValues` to apply the `valueToPixelMatrix`, which will result in the x-value being a NaN; therefore, causing the `LineScatterCandleRadarRenderer` `drawHighlightLines` to move to a CGPoint with a NaN x-value.

To fix this, the y-value being passed into `pixelForValues` should be from the `entryForXValue`.