### PR TITLE
Replaced unnecessary NSObjectProtocol

### DIFF
--- a/Source/Charts/Components/IMarker.swift
+++ b/Source/Charts/Components/IMarker.swift
@@ -13,7 +13,7 @@ import Foundation
 import CoreGraphics
 
 @objc(IChartMarker)
-public protocol IMarker: NSObjectProtocol
+public protocol IMarker: class
 {
     /// - returns: The desired (general) offset you wish the IMarker to have on the x-axis.
     ///

--- a/Source/Charts/Formatters/IAxisValueFormatter.swift
+++ b/Source/Charts/Formatters/IAxisValueFormatter.swift
@@ -13,7 +13,7 @@ import Foundation
 
 /// An interface for providing custom axis Strings.
 @objc(IChartAxisValueFormatter)
-public protocol IAxisValueFormatter : NSObjectProtocol
+public protocol IAxisValueFormatter: class
 {
     
     /// Called when a value from an axis is formatted before being drawn.

--- a/Source/Charts/Formatters/IValueFormatter.swift
+++ b/Source/Charts/Formatters/IValueFormatter.swift
@@ -17,7 +17,7 @@ import Foundation
 ///
 /// Then override the getFormattedValue(...) method and return whatever you want.
 @objc(IChartValueFormatter)
-public protocol IValueFormatter : NSObjectProtocol
+public protocol IValueFormatter: class
 {
     
     /// Called when a value (from labels inside the chart) is formatted before being drawn.

--- a/Source/Charts/Highlight/IHighlighter.swift
+++ b/Source/Charts/Highlight/IHighlighter.swift
@@ -13,7 +13,7 @@ import Foundation
 import CoreGraphics
 
 @objc(IChartHighlighter)
-public protocol IHighlighter : NSObjectProtocol
+public protocol IHighlighter: class
 {
     /// - returns: A Highlight object corresponding to the given x- and y- touch positions in pixels.
     /// - parameter x:

--- a/Source/Charts/Renderers/Scatter/IShapeRenderer.swift
+++ b/Source/Charts/Renderers/Scatter/IShapeRenderer.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 @objc
-public protocol IShapeRenderer : NSObjectProtocol
+public protocol IShapeRenderer: class
 {
     /// Renders the provided ScatterDataSet with a shape.
     ///


### PR DESCRIPTION
`class` is better as it allows Swift classes to avoid the `NSObject` overhead.
the @objc tag on any classes that may adopt the protocol enforces `NSObject` adoption.