### PR TITLE
Reduce build time with minor reference refactor

### DIFF
--- a/Source/Charts/Renderers/ChartDataRendererBase.swift
+++ b/Source/Charts/Renderers/ChartDataRendererBase.swift
@@ -55,7 +55,6 @@ open class DataRenderer: Renderer
     {
         guard let data = dataProvider?.data
             else { return false }
-        
-        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * (viewPortHandler?.scaleX ?? 1.0))
+        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * (self.viewPortHandler?.scaleX ?? 1.0))
     }
 }

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -610,8 +610,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
     {
         guard let data = dataProvider?.data
             else { return false }
-        
-        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * (viewPortHandler?.scaleY ?? 1.0))
+        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * (self.viewPortHandler?.scaleY ?? 1.0))
     }
     
     /// Sets the drawing position of the highlight object based on the riven bar-rect.


### PR DESCRIPTION
Adding a `self.` reference to a instance variable reduced the compile
time significantly (over 10x improvement). A single line evaluation of a
variable was further broken out into separate steps to reduce the
compile time as well.

This cuts at least 2 seconds from the build time

Compile times were analyzed with the following bash command:
`xcodebuild -scheme Charts -sdk iphonesimulator PLATFORM_NAME=iphonesimulator clean build OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" 2>&1 | grep -e [0-9][0-9].[0-9].ms | sort -nr`

Compile times before the change:
![before-change](https://user-images.githubusercontent.com/1574729/28984916-36ac749a-792e-11e7-847c-b9a598163306.png)

Compile times after the change:
![after-change](https://user-images.githubusercontent.com/1574729/28984914-343980a4-792e-11e7-9bb6-74169fb9cb80.png)

