### PR TITLE
Conform to macOS api changes in swift 3.2

### DIFF
--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -550,7 +550,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 		image.lockFocus()
 		let rep = NSBitmapImageRep(focusedViewRect: NSMakeRect(0, 0, image.size.width, image.size.height))
 		image.unlockFocus()
-		return rep?.representation(using: NSPNGFileType, properties: [:])
+		return rep?.representation(using: .PNG, properties: [:])
 	}
 
 	func NSUIImageJPEGRepresentation(_ image: NSUIImage, _ quality: CGFloat = 0.9) -> Data?
@@ -558,7 +558,7 @@ types are aliased to either their UI* implementation (on iOS) or their NS* imple
 		image.lockFocus()
 		let rep = NSBitmapImageRep(focusedViewRect: NSMakeRect(0, 0, image.size.width, image.size.height))
 		image.unlockFocus()
-        return rep?.representation(using: NSJPEGFileType, properties: [NSImageCompressionFactor: quality])
+        return rep?.representation(using: .JPEG, properties: [NSImageCompressionFactor: quality])
 	}
 
 	private var imageContextStack: [CGFloat] = []


### PR DESCRIPTION
Compiling the framework with Xcode 9 beta 4 results in error due to macOS Swift api changes.
This pull request resolves that. 