### PR TITLE
Added ability to disable/enable parent scroll view on drag

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -56,6 +56,12 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     /// **default**: false
     open var keepPositionOnRotation: Bool = false
     
+    /// Flag that indicates if parent scroll view should be disabled when dragging to avoid scrolling conflicts.
+    /// If scroll view only pans vertically and dragging pans horizontally or vice versa (if using horizontal bar chart view),
+    /// you can set flag to false to allow scroll view to capture touches.
+    /// **default**: true
+    open var disableParentScrollViewOnDrag = true
+    
     /// the object representing the left y-axis
     internal var _leftAxis: YAxis!
     
@@ -906,7 +912,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         #endif
         
-        if (gestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) &&
+        if (disableParentScrollViewOnDrag && gestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) &&
             otherGestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) && (
                 gestureRecognizer == _panGestureRecognizer
             ))

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -912,7 +912,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             }
         #endif
         
-        if (disableParentScrollViewOnDrag && gestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) &&
+        if (gestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) &&
             otherGestureRecognizer.isKind(of: NSUIPanGestureRecognizer.self) && (
                 gestureRecognizer == _panGestureRecognizer
             ))
@@ -954,8 +954,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             
             if otherGestureRecognizer === scrollViewPanGestureRecognizer
             {
-                _outerScrollView = foundScrollView
-                
+                // If this flag is false, still return true, so that both gesture recognizers
+                // are considered.
+                if disableParentScrollViewOnDrag {
+                    _outerScrollView = foundScrollView
+                }
                 return true
             }
         }


### PR DESCRIPTION
The default behavior was to disable parent scroll view on drag to avoid touch conflicts between chart view and  parent scroll view.

However if your dragging is horizontal and scrolling is vertical only (and vice versa with horizontal bar chart view), it’s desirable to disable this behavior to allow scroll view to scroll in the opposite direction.