### PR TITLE
fix for crash when interval is NaN

### DIFF
--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -103,7 +103,7 @@ open class AxisRendererBase: Renderer
         let labelCount = axis.labelCount
         let range = abs(yMax - yMin)
         
-        if labelCount == 0 || range <= 0 || range.isInfinite
+        if labelCount == 0 || range <= 0 || range.isInfinite || range.isNaN
         {
             axis.entries = [Double]()
             axis.centeredEntries = [Double]()


### PR DESCRIPTION
After clearing a working chart and then adding new data (dataset), the chart crashes in AxisRendererBase.swift line 125 with "Double value cannot be converted to Int because it is either infinite or NaN". The reason for that is "min" and "max" are NaN  (because the Transformer._matrixValueToPx is somewhat invalid(?), why does it happen?).

The issue is referenced here: https://stackoverflow.com/questions/45496912/how-to-clear-a-chart-and-then-add-data-to-it-in-swift-3-using-chartview-clear and here: https://github.com/danielgindi/Charts/issues/2168 (josman185hotm's comment from 17 Jun).