### PR TITLE
Give the users customizable axis label limits (Fixes #2085)

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -213,6 +213,16 @@ open class AxisBase: ComponentBase
     /// the total range of values this axis covers
     @objc open var axisRange = Double(0)
     
+    /// The minumum number of labels on the axis
+    @objc open var axisMinLabels: Int = Int(2) {
+        didSet { axisMinLabels = axisMinLabels > 0 ? axisMinLabels : oldValue }
+    }
+    
+    /// The maximum number of labels on the axis
+    @objc open var axisMaxLabels: Int = Int(25) {
+        didSet { axisMinLabels = axisMaxLabels > 0 ? axisMaxLabels : oldValue }
+    }
+    
     /// the number of label entries the axis should have
     /// max = 25,
     /// min = 2,
@@ -228,13 +238,13 @@ open class AxisBase: ComponentBase
         {
             _labelCount = newValue
             
-            if _labelCount > 25
+            if _labelCount > axisMaxLabels
             {
-                _labelCount = 25
+                _labelCount = axisMaxLabels
             }
-            if _labelCount < 2
+            if _labelCount < axisMinLabels
             {
-                _labelCount = 2
+                _labelCount = axisMinLabels
             }
             
             forceLabelsEnabled = false

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -214,12 +214,12 @@ open class AxisBase: ComponentBase
     @objc open var axisRange = Double(0)
     
     /// The minumum number of labels on the axis
-    @objc open var axisMinLabels: Int = Int(2) {
+    @objc open var axisMinLabels = Int(2) {
         didSet { axisMinLabels = axisMinLabels > 0 ? axisMinLabels : oldValue }
     }
     
     /// The maximum number of labels on the axis
-    @objc open var axisMaxLabels: Int = Int(25) {
+    @objc open var axisMaxLabels = Int(25) {
         didSet { axisMinLabels = axisMaxLabels > 0 ? axisMaxLabels : oldValue }
     }
     


### PR DESCRIPTION
This change adds the ability to users to override the imposed limitation of at least 2 labels per axis and at most 25 labels per axis if they need to and at their own risk. 

By default these customizable limits are hardcoded to the previous limits, at least 2 labels, at most 25.

The rationale for this change is that when coming from previous versions of Charts, users are able to use –at least on the X axis– as many labels as they wish and when they upgrade to a newer version of Charts they find that they have lost functionality, and this change brings that functionality back.