### PR TITLE
remove max label count

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -214,7 +214,6 @@ open class AxisBase: ComponentBase
     @objc open var axisRange = Double(0)
     
     /// the number of label entries the axis should have
-    /// max = 25,
     /// min = 2,
     /// default = 6,
     /// be aware that this number is not fixed and can only be approximated
@@ -228,10 +227,6 @@ open class AxisBase: ComponentBase
         {
             _labelCount = newValue
             
-            if _labelCount > 25
-            {
-                _labelCount = 25
-            }
             if _labelCount < 2
             {
                 _labelCount = 2


### PR DESCRIPTION
I have to show more than 25 labels. I add chart view as subview to scrollview so I'm sure the labels will not be overlapping.