### PR TITLE
Fix turning off drag in X and Y axes separately.

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -871,9 +871,11 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     {
         if gestureRecognizer == _panGestureRecognizer
         {
-            if _data === nil ||
-                !isDragEnabled ||
-                (self.hasNoDragOffset && self.isFullyZoomedOut && !self.isHighlightPerDragEnabled)
+            let velocity = _panGestureRecognizer.velocity(in: self)
+            if _data === nil || !isDragEnabled ||
+                (self.hasNoDragOffset && self.isFullyZoomedOut && !self.isHighlightPerDragEnabled) ||
+                (!_dragYEnabled && fabs(velocity.y) > fabs(velocity.x)) ||
+                (!_dragXEnabled && fabs(velocity.y) < fabs(velocity.x))
             {
                 return false
             }


### PR DESCRIPTION
Unfortunately https://github.com/danielgindi/Charts/commit/3c083f32ec7399b7c43647fa305752e370c7e800 broke my change.

The use case when the problem appears is when a chart is embedded in a scroll view. Disabling y axis dragging should enable the scroll view to be used for vertical scrolling with the finger on the chart.

The change in this PR is required for this to work.