### PR TITLE
Removed @objc from internal properties

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -21,7 +21,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 {
     /// the maximum number of entries to which values will be drawn
     /// (entry numbers greater than this value will cause value-labels to disappear)
-    @objc internal var _maxVisibleCount = 100
+    internal var _maxVisibleCount = 100
     
     /// flag that indicates if auto scaling on the y axis is enabled
     fileprivate var _autoScaleMinMaxEnabled = false
@@ -58,25 +58,25 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     @objc open var keepPositionOnRotation: Bool = false
     
     /// the object representing the left y-axis
-    @objc internal var _leftAxis: YAxis!
+    internal var _leftAxis: YAxis!
     
     /// the object representing the right y-axis
-    @objc internal var _rightAxis: YAxis!
+    internal var _rightAxis: YAxis!
 
-    @objc internal var _leftYAxisRenderer: YAxisRenderer!
-    @objc internal var _rightYAxisRenderer: YAxisRenderer!
+    internal var _leftYAxisRenderer: YAxisRenderer!
+    internal var _rightYAxisRenderer: YAxisRenderer!
     
-    @objc internal var _leftAxisTransformer: Transformer!
-    @objc internal var _rightAxisTransformer: Transformer!
+    internal var _leftAxisTransformer: Transformer!
+    internal var _rightAxisTransformer: Transformer!
     
-    @objc internal var _xAxisRenderer: XAxisRenderer!
+    internal var _xAxisRenderer: XAxisRenderer!
     
-    @objc internal var _tapGestureRecognizer: NSUITapGestureRecognizer!
-    @objc internal var _doubleTapGestureRecognizer: NSUITapGestureRecognizer!
+    internal var _tapGestureRecognizer: NSUITapGestureRecognizer!
+    internal var _doubleTapGestureRecognizer: NSUITapGestureRecognizer!
     #if !os(tvOS)
-    @objc internal var _pinchGestureRecognizer: NSUIPinchGestureRecognizer!
+    internal var _pinchGestureRecognizer: NSUIPinchGestureRecognizer!
     #endif
-    @objc internal var _panGestureRecognizer: NSUIPanGestureRecognizer!
+    internal var _panGestureRecognizer: NSUIPanGestureRecognizer!
     
     /// flag that indicates if a custom viewport offset has been set
     fileprivate var _customViewPortEnabled = false
@@ -276,7 +276,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     fileprivate var _autoScaleLastHighestVisibleX: Double?
     
     /// Performs auto scaling of the axis by recalculating the minimum and maximum y-values based on the entries currently in view.
-    @objc internal func autoScale()
+    internal func autoScale()
     {
         guard let data = _data
             else { return }
@@ -300,13 +300,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         calculateOffsets()
     }
     
-    @objc internal func prepareValuePxMatrix()
+    internal func prepareValuePxMatrix()
     {
         _rightAxisTransformer.prepareMatrixValuePx(chartXMin: _xAxis._axisMinimum, deltaX: CGFloat(xAxis.axisRange), deltaY: CGFloat(_rightAxis.axisRange), chartYMin: _rightAxis._axisMinimum)
         _leftAxisTransformer.prepareMatrixValuePx(chartXMin: xAxis._axisMinimum, deltaX: CGFloat(xAxis.axisRange), deltaY: CGFloat(_leftAxis.axisRange), chartYMin: _leftAxis._axisMinimum)
     }
     
-    @objc internal func prepareOffsetMatrix()
+    internal func prepareOffsetMatrix()
     {
         _rightAxisTransformer.prepareMatrixOffset(inverted: _rightAxis.isInverted)
         _leftAxisTransformer.prepareMatrixOffset(inverted: _leftAxis.isInverted)
@@ -468,7 +468,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// draws the grid background
-    @objc internal func drawGridBackground(context: CGContext)
+    internal func drawGridBackground(context: CGContext)
     {
         if drawGridBackgroundEnabled || drawBordersEnabled
         {

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -48,10 +48,10 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// The default IValueFormatter that has been determined by the chart considering the provided minimum and maximum values.
-    @objc internal var _defaultValueFormatter: IValueFormatter? = DefaultValueFormatter(decimals: 0)
+    internal var _defaultValueFormatter: IValueFormatter? = DefaultValueFormatter(decimals: 0)
     
     /// object that holds all data that was originally set for the chart, before it was modified or any filtering algorithms had been applied
-    @objc internal var _data: ChartData?
+    internal var _data: ChartData?
     
     /// Flag that indicates if highlighting per tap (touch) is enabled
     fileprivate var _highlightPerTapEnabled = true
@@ -64,10 +64,10 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     fileprivate var _dragDecelerationFrictionCoef: CGFloat = 0.9
     
     /// if true, units are drawn next to the values in the chart
-    @objc internal var _drawUnitInChart = false
+    internal var _drawUnitInChart = false
     
     /// The object representing the labels on the x-axis
-    @objc internal var _xAxis: XAxis!
+    internal var _xAxis: XAxis!
     
     /// The `Description` object of the chart.
     /// This should have been called just "description", but
@@ -126,7 +126,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// The legend object containing all data associated with the legend
-    @objc internal var _legend: Legend!
+    internal var _legend: Legend!
     
     /// delegate to receive chart events
     @objc open weak var delegate: ChartViewDelegate?
@@ -140,7 +140,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// color of the no data text
     @objc open var noDataTextColor: NSUIColor = NSUIColor.black
     
-    @objc internal var _legendRenderer: LegendRenderer!
+    internal var _legendRenderer: LegendRenderer!
     
     /// object responsible for rendering the data
     @objc open var renderer: DataRenderer?
@@ -148,16 +148,16 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     @objc open var highlighter: IHighlighter?
     
     /// object that manages the bounds and drawing constraints of the chart
-    @objc internal var _viewPortHandler: ViewPortHandler!
+    internal var _viewPortHandler: ViewPortHandler!
     
     /// object responsible for animations
-    @objc internal var _animator: Animator!
+    internal var _animator: Animator!
     
     /// flag that indicates if offsets calculation has already been done or not
     fileprivate var _offsetsCalculated = false
 	
     /// array of Highlight objects that reference the highlighted slices in the chart
-    @objc internal var _indicesToHighlight = [Highlight]()
+    internal var _indicesToHighlight = [Highlight]()
     
     /// `true` if drawing the marker is enabled when tapping on values
     /// (use the `marker` property to specify a marker)
@@ -212,7 +212,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         self.removeObserver(self, forKeyPath: "frame")
     }
     
-    @objc internal func initialize()
+    internal func initialize()
     {
         #if os(iOS)
             self.backgroundColor = NSUIColor.clear
@@ -311,19 +311,19 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// Calculates the offsets of the chart to the border depending on the position of an eventual legend or depending on the length of the y-axis and x-axis labels and their position
-    @objc internal func calculateOffsets()
+    internal func calculateOffsets()
     {
         fatalError("calculateOffsets() cannot be called on ChartViewBase")
     }
     
     /// calcualtes the y-min and y-max value and the y-delta and x-delta value
-    @objc internal func calcMinMax()
+    internal func calcMinMax()
     {
         fatalError("calcMinMax() cannot be called on ChartViewBase")
     }
     
     /// calculates the required number of digits for the values that might be drawn in the chart (if enabled), and creates the default value formatter
-    @objc internal func setupDefaultFormatter(min: Double, max: Double)
+    internal func setupDefaultFormatter(min: Double, max: Double)
     {
         // check if a custom formatter is set or not
         var reference = Double(0.0)
@@ -384,7 +384,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     }
     
     /// Draws the description text in the bottom right corner of the chart (per default)
-    @objc internal func drawDescription(context: CGContext)
+    internal func drawDescription(context: CGContext)
     {
         // check if description should be drawn
         guard
@@ -587,7 +587,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     // MARK: - Markers
 
     /// draws all MarkerViews on the highlighted positions
-    @objc internal func drawMarkers(context: CGContext)
+    internal func drawMarkers(context: CGContext)
     {
         // if there is no marker view or drawing marker is disabled
         guard
@@ -886,7 +886,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
 		return true
     }
     
-    @objc internal var _viewportJobs = [ViewPortJob]()
+    internal var _viewportJobs = [ViewPortJob]()
     
     open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?)
     {

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -16,7 +16,7 @@ import CoreGraphics
 open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
 {
     /// the fill-formatter used for determining the position of the fill-line
-    @objc internal var _fillFormatter: IFillFormatter!
+    internal var _fillFormatter: IFillFormatter!
     
     /// enum that allows to specify the order in which the different data objects for the combined-chart are drawn
     @objc(CombinedChartDrawOrder)

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -366,14 +366,14 @@ open class PieRadarChartViewBase: ChartViewBase
     }
 
     /// - returns: The required offset for the chart legend.
-    @objc internal var requiredLegendOffset: CGFloat
+    internal var requiredLegendOffset: CGFloat
     {
         fatalError("requiredLegendOffset cannot be called on PieRadarChartViewBase")
     }
 
     /// - returns: The base offset needed for the chart without calculating the
     /// legend size.
-    @objc internal var requiredBaseOffset: CGFloat
+    internal var requiredBaseOffset: CGFloat
     {
         fatalError("requiredBaseOffset cannot be called on PieRadarChartViewBase")
     }
@@ -481,7 +481,7 @@ open class PieRadarChartViewBase: ChartViewBase
     fileprivate var _decelerationDisplayLink: NSUIDisplayLink!
     fileprivate var _decelerationAngularVelocity: CGFloat = 0.0
     
-    @objc internal final func processRotationGestureBegan(location: CGPoint)
+    internal final func processRotationGestureBegan(location: CGPoint)
     {
         self.resetVelocity()
         
@@ -495,7 +495,7 @@ open class PieRadarChartViewBase: ChartViewBase
         _rotationGestureStartPoint = location
     }
     
-    @objc internal final func processRotationGestureMoved(location: CGPoint)
+    internal final func processRotationGestureMoved(location: CGPoint)
     {
         if isDragDecelerationEnabled
         {
@@ -518,7 +518,7 @@ open class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    @objc internal final func processRotationGestureEnded(location: CGPoint)
+    internal final func processRotationGestureEnded(location: CGPoint)
     {
         if isDragDecelerationEnabled
         {
@@ -537,7 +537,7 @@ open class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    @objc internal final func processRotationGestureCancelled()
+    internal final func processRotationGestureCancelled()
     {
         if _isRotating
         {

--- a/Source/Charts/Charts/RadarChartView.swift
+++ b/Source/Charts/Charts/RadarChartView.swift
@@ -41,8 +41,8 @@ open class RadarChartView: PieRadarChartViewBase
     /// the object reprsenting the y-axis labels
     fileprivate var _yAxis: YAxis!
     
-    @objc internal var _yAxisRenderer: YAxisRendererRadarChart!
-    @objc internal var _xAxisRenderer: XAxisRendererRadarChart!
+    internal var _yAxisRenderer: YAxisRendererRadarChart!
+    internal var _xAxisRenderer: XAxisRendererRadarChart!
     
     public override init(frame: CGRect)
     {

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -195,20 +195,20 @@ open class AxisBase: ComponentBase
     @objc open var spaceMax: Double = 0.0
     
     /// Flag indicating that the axis-min value has been customized
-    @objc internal var _customAxisMin: Bool = false
+    internal var _customAxisMin: Bool = false
     
     /// Flag indicating that the axis-max value has been customized
-    @objc internal var _customAxisMax: Bool = false
+    internal var _customAxisMax: Bool = false
     
     /// Do not touch this directly, instead, use axisMinimum.
     /// This is automatically calculated to represent the real min value,
     /// and is used when calculating the effective minimum.
-    @objc internal var _axisMinimum = Double(0)
+    internal var _axisMinimum = Double(0)
     
     /// Do not touch this directly, instead, use axisMaximum.
     /// This is automatically calculated to represent the real max value,
     /// and is used when calculating the effective maximum.
-    @objc internal var _axisMaximum = Double(0)
+    internal var _axisMaximum = Double(0)
     
     /// the total range of values this axis covers
     @objc open var axisRange = Double(0)

--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -270,7 +270,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     open var isHighlightEnabled: Bool { return highlightEnabled }
     
     /// Custom formatter that is used instead of the auto-formatter if set
-    @objc internal var _valueFormatter: IValueFormatter?
+    internal var _valueFormatter: IValueFormatter?
     
     /// Custom formatter that is used instead of the auto-formatter if set
     open var valueFormatter: IValueFormatter?

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataSet.swift
@@ -17,7 +17,7 @@ open class BubbleChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBubbleCh
 {
     // MARK: - Data functions and accessors
     
-    @objc internal var _maxSize = CGFloat(0.0)
+    internal var _maxSize = CGFloat(0.0)
     
     open var maxSize: CGFloat { return _maxSize }
     @objc open var normalizeSizeEnabled: Bool = true

--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -13,16 +13,16 @@ import Foundation
 
 open class ChartData: NSObject
 {
-    @objc internal var _yMax: Double = -Double.greatestFiniteMagnitude
-    @objc internal var _yMin: Double = Double.greatestFiniteMagnitude
-    @objc internal var _xMax: Double = -Double.greatestFiniteMagnitude
-    @objc internal var _xMin: Double = Double.greatestFiniteMagnitude
-    @objc internal var _leftAxisMax: Double = -Double.greatestFiniteMagnitude
-    @objc internal var _leftAxisMin: Double = Double.greatestFiniteMagnitude
-    @objc internal var _rightAxisMax: Double = -Double.greatestFiniteMagnitude
-    @objc internal var _rightAxisMin: Double = Double.greatestFiniteMagnitude
+    internal var _yMax: Double = -Double.greatestFiniteMagnitude
+    internal var _yMin: Double = Double.greatestFiniteMagnitude
+    internal var _xMax: Double = -Double.greatestFiniteMagnitude
+    internal var _xMin: Double = Double.greatestFiniteMagnitude
+    internal var _leftAxisMax: Double = -Double.greatestFiniteMagnitude
+    internal var _leftAxisMin: Double = Double.greatestFiniteMagnitude
+    internal var _rightAxisMax: Double = -Double.greatestFiniteMagnitude
+    internal var _rightAxisMin: Double = Double.greatestFiniteMagnitude
     
-    @objc internal var _dataSets = [IChartDataSet]()
+    internal var _dataSets = [IChartDataSet]()
     
     public override init()
     {
@@ -45,7 +45,7 @@ open class ChartData: NSObject
         self.init(dataSets: dataSet === nil ? nil : [dataSet!])
     }
     
-    @objc internal func initialize(dataSets: [IChartDataSet])
+    internal func initialize(dataSets: [IChartDataSet])
     {
         notifyDataChanged()
     }
@@ -350,7 +350,7 @@ open class ChartData: NSObject
     /// - parameter type:
     /// - parameter ignorecase: if true, the search is not case-sensitive
     /// - returns: The index of the DataSet Object with the given label. Sensitive or not.
-    @objc internal func getDataSetIndexByLabel(_ label: String, ignorecase: Bool) -> Int
+    internal func getDataSetIndexByLabel(_ label: String, ignorecase: Bool) -> Int
     {
         if ignorecase
         {
@@ -381,7 +381,7 @@ open class ChartData: NSObject
     }
     
     /// - returns: The labels of all DataSets as a string array.
-    @objc internal func dataSetLabels() -> [String]
+    internal func dataSetLabels() -> [String]
     {
         var types = [String]()
         

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -55,19 +55,19 @@ open class ChartDataSet: ChartBaseDataSet
     // MARK: - Data functions and accessors
     
     /// the entries that this dataset represents / holds together
-    @objc internal var _values: [ChartDataEntry]!
+    internal var _values: [ChartDataEntry]!
     
     /// maximum y-value in the value array
-    @objc internal var _yMax: Double = -Double.greatestFiniteMagnitude
+    internal var _yMax: Double = -Double.greatestFiniteMagnitude
     
     /// minimum y-value in the value array
-    @objc internal var _yMin: Double = Double.greatestFiniteMagnitude
+    internal var _yMin: Double = Double.greatestFiniteMagnitude
     
     /// maximum x-value in the value array
-    @objc internal var _xMax: Double = -Double.greatestFiniteMagnitude
+    internal var _xMax: Double = -Double.greatestFiniteMagnitude
     
     /// minimum x-value in the value array
-    @objc internal var _xMin: Double = Double.greatestFiniteMagnitude
+    internal var _xMin: Double = Double.greatestFiniteMagnitude
     
     /// *
     /// - note: Calls `notifyDataSetChanged()` after setting a new value.
@@ -158,7 +158,7 @@ open class ChartDataSet: ChartBaseDataSet
     /// Updates the min and max x and y value of this DataSet based on the given Entry.
     ///
     /// - parameter e:
-    @objc internal func calcMinMax(entry e: ChartDataEntry)
+    internal func calcMinMax(entry e: ChartDataEntry)
     {
         calcMinMaxX(entry: e)
         calcMinMaxY(entry: e)

--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -102,7 +102,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     }
     
     /// - returns: An array of `Highlight` objects corresponding to the selected xValue and dataSetIndex.
-    @objc internal func buildHighlights(
+    internal func buildHighlights(
         dataSet set: IChartDataSet,
         dataSetIndex: Int,
         xValue: Double,
@@ -166,7 +166,7 @@ open class ChartHighlighter : NSObject, IHighlighter
     }
     
     /// - returns: The minimum distance from a touch-y-value (in pixels) to the closest y-value (in pixels) that is displayed in the chart.
-    @objc internal func getMinimumDistance(
+    internal func getMinimumDistance(
         closestValues: [Highlight],
         y: CGFloat,
         axis: YAxis.AxisDependency) -> CGFloat
@@ -190,17 +190,17 @@ open class ChartHighlighter : NSObject, IHighlighter
         return distance
     }
     
-    @objc internal func getHighlightPos(high: Highlight) -> CGFloat
+    internal func getHighlightPos(high: Highlight) -> CGFloat
     {
         return high.yPx
     }
     
-    @objc internal func getDistance(x1: CGFloat, y1: CGFloat, x2: CGFloat, y2: CGFloat) -> CGFloat
+    internal func getDistance(x1: CGFloat, y1: CGFloat, x2: CGFloat, y2: CGFloat) -> CGFloat
     {
         return hypot(x1 - x2, y1 - y2)
     }
     
-    @objc internal var data: ChartData?
+    internal var data: ChartData?
     {
         return chart?.data
     }

--- a/Source/Charts/Highlight/RadarHighlighter.swift
+++ b/Source/Charts/Highlight/RadarHighlighter.swift
@@ -44,7 +44,7 @@ open class RadarHighlighter: PieRadarHighlighter
     /// The Highlight objects give information about the value at the selected index and DataSet it belongs to.
     ///
     /// - parameter index:
-    @objc internal func getHighlights(forIndex index: Int) -> [Highlight]
+    internal func getHighlights(forIndex index: Int) -> [Highlight]
     {
         var vals = [Highlight]()
         

--- a/Source/Charts/Jobs/AnimatedViewPortJob.swift
+++ b/Source/Charts/Jobs/AnimatedViewPortJob.swift
@@ -18,9 +18,9 @@ import CoreGraphics
 
 open class AnimatedViewPortJob: ViewPortJob
 {
-    @objc internal var phase: CGFloat = 1.0
-    @objc internal var xOrigin: CGFloat = 0.0
-    @objc internal var yOrigin: CGFloat = 0.0
+    internal var phase: CGFloat = 1.0
+    internal var xOrigin: CGFloat = 0.0
+    internal var yOrigin: CGFloat = 0.0
     
     fileprivate var _startTime: TimeInterval = 0.0
     fileprivate var _displayLink: NSUIDisplayLink!
@@ -130,12 +130,12 @@ open class AnimatedViewPortJob: ViewPortJob
         }
     }
     
-    @objc internal func animationUpdate()
+    internal func animationUpdate()
     {
         // Override this
     }
     
-    @objc internal func animationEnd()
+    internal func animationEnd()
     {
         // Override this
     }

--- a/Source/Charts/Jobs/AnimatedZoomViewJob.swift
+++ b/Source/Charts/Jobs/AnimatedZoomViewJob.swift
@@ -14,14 +14,14 @@ import CoreGraphics
 
 open class AnimatedZoomViewJob: AnimatedViewPortJob
 {
-    @objc internal var yAxis: YAxis?
-    @objc internal var xAxisRange: Double = 0.0
-    @objc internal var scaleX: CGFloat = 0.0
-    @objc internal var scaleY: CGFloat = 0.0
-    @objc internal var zoomOriginX: CGFloat = 0.0
-    @objc internal var zoomOriginY: CGFloat = 0.0
-    @objc internal var zoomCenterX: CGFloat = 0.0
-    @objc internal var zoomCenterY: CGFloat = 0.0
+    internal var yAxis: YAxis?
+    internal var xAxisRange: Double = 0.0
+    internal var scaleX: CGFloat = 0.0
+    internal var scaleY: CGFloat = 0.0
+    internal var zoomOriginX: CGFloat = 0.0
+    internal var zoomOriginY: CGFloat = 0.0
+    internal var zoomCenterX: CGFloat = 0.0
+    internal var zoomCenterY: CGFloat = 0.0
 
     @objc public init(
         viewPortHandler: ViewPortHandler,

--- a/Source/Charts/Jobs/ViewPortJob.swift
+++ b/Source/Charts/Jobs/ViewPortJob.swift
@@ -16,12 +16,12 @@ import CoreGraphics
 @objc(ChartViewPortJob)
 open class ViewPortJob: NSObject
 {
-    @objc internal var point: CGPoint = CGPoint()
-    @objc internal weak var viewPortHandler: ViewPortHandler?
-    @objc internal var xValue: Double = 0.0
-    @objc internal var yValue: Double = 0.0
-    @objc internal weak var transformer: Transformer?
-    @objc internal weak var view: ChartViewBase?
+    internal var point: CGPoint = CGPoint()
+    internal weak var viewPortHandler: ViewPortHandler?
+    internal var xValue: Double = 0.0
+    internal var yValue: Double = 0.0
+    internal weak var transformer: Transformer?
+    internal weak var view: ChartViewBase?
     
     @objc public init(
         viewPortHandler: ViewPortHandler,

--- a/Source/Charts/Jobs/ZoomViewJob.swift
+++ b/Source/Charts/Jobs/ZoomViewJob.swift
@@ -19,9 +19,9 @@ import CoreGraphics
 @objc(ZoomChartViewJob)
 open class ZoomViewJob: ViewPortJob
 {
-    @objc internal var scaleX: CGFloat = 0.0
-    @objc internal var scaleY: CGFloat = 0.0
-    @objc internal var axisDependency: YAxis.AxisDependency = YAxis.AxisDependency.left
+    internal var scaleX: CGFloat = 0.0
+    internal var scaleY: CGFloat = 0.0
+    internal var axisDependency: YAxis.AxisDependency = YAxis.AxisDependency.left
     
     @objc public init(
         viewPortHandler: ViewPortHandler,

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -693,7 +693,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
     }
     
     /// Sets the drawing position of the highlight object based on the riven bar-rect.
-    @objc internal func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
+    internal func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
     {
         high.setDraw(x: barRect.midX, y: barRect.origin.y)
     }

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -23,7 +23,7 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
     }
     
     /// Checks if the provided entry object is in bounds for drawing considering the current animation phase.
-    @objc internal func isInBoundsX(entry e: ChartDataEntry, dataSet: IBarLineScatterCandleBubbleChartDataSet) -> Bool
+    internal func isInBoundsX(entry e: ChartDataEntry, dataSet: IBarLineScatterCandleBubbleChartDataSet) -> Bool
     {
         let entryIndex = dataSet.entryIndex(entry: e)
         return Double(entryIndex) < Double(dataSet.entryCount) * (animator?.phaseX ?? 1.0)
@@ -39,7 +39,7 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
     }
     
     /// - returns: `true` if the DataSet values should be drawn, `false` if not.
-    @objc internal func shouldDrawValues(forDataSet set: IChartDataSet) -> Bool
+    internal func shouldDrawValues(forDataSet set: IChartDataSet) -> Bool
     {
         return set.isVisible && (set.isDrawValuesEnabled || set.isDrawIconsEnabled)
     }

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -22,7 +22,7 @@ open class CombinedChartRenderer: DataRenderer
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
     @objc open var drawBarShadowEnabled = false
     
-    @objc internal var _renderers = [DataRenderer]()
+    internal var _renderers = [DataRenderer]()
     
     internal var _drawOrder: [CombinedChartView.DrawOrder] = [.bar, .bubble, .line, .candle, .scatter]
     
@@ -36,7 +36,7 @@ open class CombinedChartRenderer: DataRenderer
     }
     
     /// Creates the renderers needed for this combined-renderer in the required order. Also takes the DrawOrder into consideration.
-    @objc internal func createRenderers()
+    internal func createRenderers()
     {
         _renderers = [DataRenderer]()
         

--- a/Source/Charts/Renderers/RadarChartRenderer.swift
+++ b/Source/Charts/Renderers/RadarChartRenderer.swift
@@ -53,7 +53,7 @@ open class RadarChartRenderer: LineRadarRenderer
     /// - parameter context:
     /// - parameter dataSet:
     /// - parameter mostEntries: the entry count of the dataset with the most entries
-    @objc internal func drawDataSet(context: CGContext, dataSet: IRadarChartDataSet, mostEntries: Int)
+    internal func drawDataSet(context: CGContext, dataSet: IRadarChartDataSet, mostEntries: Int)
     {
         guard let
             chart = chart,
@@ -380,7 +380,7 @@ open class RadarChartRenderer: LineRadarRenderer
         context.restoreGState()
     }
     
-    @objc internal func drawHighlightCircle(
+    internal func drawHighlightCircle(
         context: CGContext,
         atPoint point: CGPoint,
         innerRadius: CGFloat,

--- a/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
@@ -18,7 +18,7 @@ import CoreGraphics
 
 open class XAxisRendererHorizontalBarChart: XAxisRenderer
 {
-    @objc internal var chart: BarChartView?
+    internal var chart: BarChartView?
     
     @objc public init(viewPortHandler: ViewPortHandler?, xAxis: XAxis?, transformer: Transformer?, chart: BarChartView?)
     {

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -127,7 +127,7 @@ open class YAxisRenderer: AxisRendererBase
     }
     
     /// draws the y-labels on the specified x-position
-    @objc internal func drawYLabels(
+    internal func drawYLabels(
         context: CGContext,
         fixedPosition: CGFloat,
         positions: [CGPoint],

--- a/Source/Charts/Utils/Transformer.swift
+++ b/Source/Charts/Utils/Transformer.swift
@@ -17,12 +17,12 @@ import CoreGraphics
 open class Transformer: NSObject
 {
     /// matrix to map the values to the screen pixels
-    @objc internal var _matrixValueToPx = CGAffineTransform.identity
+    internal var _matrixValueToPx = CGAffineTransform.identity
 
     /// matrix for handling the different offsets of the chart
-    @objc internal var _matrixOffset = CGAffineTransform.identity
+    internal var _matrixOffset = CGAffineTransform.identity
 
-    @objc internal var _viewPortHandler: ViewPortHandler
+    internal var _viewPortHandler: ViewPortHandler
 
     @objc public init(viewPortHandler: ViewPortHandler)
     {


### PR DESCRIPTION
Since the framework is entirely Swift, internal properties do not need to be marked as @objc