### PR TITLE
Rename notifyDataSetChanged() to reloadData()

### DIFF
--- a/Source/Charts/Charts/BarChartView.swift
+++ b/Source/Charts/Charts/BarChartView.swift
@@ -109,7 +109,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     
     /// Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
     /// Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
-    /// Calls `notifyDataSetChanged()` afterwards.
+    /// Calls `reloadData()` afterwards.
     ///
     /// - parameter fromX: the starting point on the x-axis where the grouping should begin
     /// - parameter groupSpace: the space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f
@@ -124,7 +124,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
         }
         
         barData.groupBars(fromX: fromX, groupSpace: groupSpace, barSpace: barSpace)
-        notifyDataSetChanged()
+        reloadData()
     }
     
     /// Highlights the value at the given x-value in the given DataSet. Provide -1 as the dataSetIndex to undo all highlighting.

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -312,7 +312,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         _leftAxisTransformer.prepareMatrixOffset(inverted: _leftAxis.isInverted)
     }
     
-    open override func notifyDataSetChanged()
+    open override func reloadData()
     {
         renderer?.initBuffers()
         

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -265,7 +265,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             }
             
             // let the chart know there is new data
-            notifyDataSetChanged()
+            reloadData()
         }
     }
     
@@ -304,9 +304,9 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     
     /// Lets the chart know its underlying data has changed and should perform all necessary recalculations.
     /// It is crucial that this method is called everytime data is changed dynamically. Not calling this method can lead to crashes or unexpected behaviour.
-    @objc open func notifyDataSetChanged()
+    @objc open func reloadData()
     {
-        fatalError("notifyDataSetChanged() cannot be called on ChartViewBase")
+        fatalError("reloadData() cannot be called on ChartViewBase")
     }
     
     /// Calculates the offsets of the chart to the border depending on the position of an eventual legend or depending on the length of the y-axis and x-axis labels and their position
@@ -901,7 +901,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
                 
                 // This may cause the chart view to mutate properties affecting the view port -- lets do this
                 // before we try to run any pending jobs on the view port itself
-                notifyDataSetChanged()
+                reloadData()
 
                 // Finish any pending viewport changes
                 while (!_viewportJobs.isEmpty)

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -82,7 +82,7 @@ open class PieRadarChartViewBase: ChartViewBase
         }
     }
     
-    open override func notifyDataSetChanged()
+    open override func reloadData()
     {
         calcMinMax()
         

--- a/Source/Charts/Charts/RadarChartView.swift
+++ b/Source/Charts/Charts/RadarChartView.swift
@@ -78,7 +78,7 @@ open class RadarChartView: PieRadarChartViewBase
         _xAxis.calculate(min: 0.0, max: Double(data.maxEntryCountSet?.entryCount ?? 0))
     }
     
-    open override func notifyDataSetChanged()
+    open override func reloadData()
     {
         calcMinMax()
         

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -95,7 +95,7 @@ open class Legend: ComponentBase
     @objc open var entries = [LegendEntry]()
     
     /// Entries that will be appended to the end of the auto calculated entries after calculating the legend.
-    /// (if the legend has already been calculated, you will need to call notifyDataSetChanged() to let the changes take effect)
+    /// (if the legend has already been calculated, you will need to call reloadData() to let the changes take effect)
     @objc open var extraEntries = [LegendEntry]()
     
     /// Are the legend labels/colors a custom value or auto calculated? If false, then it's auto, if true, then custom.
@@ -501,14 +501,14 @@ open class Legend: ComponentBase
     /// Sets a custom legend's entries array.
     /// * A nil label will start a group.
     /// This will disable the feature that automatically calculates the legend entries from the datasets.
-    /// Call `resetCustom(...)` to re-enable automatic calculation (and then `notifyDataSetChanged()` is needed).
+    /// Call `resetCustom(...)` to re-enable automatic calculation (and then `reloadData()` is needed).
     @objc open func setCustom(entries: [LegendEntry])
     {
         self.entries = entries
         _isLegendCustom = true
     }
     
-    /// Calling this will disable the custom legend entries (set by `setLegend(...)`). Instead, the entries will again be calculated automatically (after `notifyDataSetChanged()` is called).
+    /// Calling this will disable the custom legend entries (set by `setLegend(...)`). Instead, the entries will again be calculated automatically (after `reloadData()` is called).
     @objc open func resetCustom()
     {
         _isLegendCustom = false

--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -38,7 +38,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet
     // MARK: - Data functions and accessors
     
     /// Use this method to tell the data set that the underlying data has changed
-    open func notifyDataSetChanged()
+    open func reloadData()
     {
         calcMinMax()
     }

--- a/Source/Charts/Data/Implementations/Standard/BarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartData.swift
@@ -31,7 +31,7 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
     
     /// Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
     /// Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.
-    /// Do not forget to call notifyDataSetChanged() on your BarChart object after calling this method.
+    /// Do not forget to call reloadData() on your BarChart object after calling this method.
     ///
     /// - parameter the starting point on the x-axis where the grouping should begin
     /// - parameter groupSpace: The space between groups of bars in values (not pixels) e.g. 0.8f for bar width 1f

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -70,7 +70,7 @@ open class ChartDataSet: ChartBaseDataSet
     internal var _xMin: Double = Double.greatestFiniteMagnitude
     
     /// *
-    /// - note: Calls `notifyDataSetChanged()` after setting a new value.
+    /// - note: Calls `reloadData()` after setting a new value.
     /// - returns: The array of y-values that this DataSet represents.
     @objc open var values: [ChartDataEntry]
     {
@@ -81,12 +81,12 @@ open class ChartDataSet: ChartBaseDataSet
         set
         {
             _values = newValue
-            notifyDataSetChanged()
+            reloadData()
         }
     }
     
     /// Use this method to tell the data set that the underlying data has changed
-    open override func notifyDataSetChanged()
+    open override func reloadData()
     {
         calcMinMax()
     }
@@ -532,7 +532,7 @@ open class ChartDataSet: ChartBaseDataSet
     open override func clear()
     {
         _values.removeAll(keepingCapacity: true)
-        notifyDataSetChanged()
+        reloadData()
     }
     
     // MARK: - Data functions and accessors

--- a/Source/Charts/Data/Interfaces/IChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IChartDataSet.swift
@@ -18,7 +18,7 @@ public protocol IChartDataSet
     // MARK: - Data functions and accessors
     
     /// Use this method to tell the data set that the underlying data has changed
-    func notifyDataSetChanged()
+    func reloadData()
     
     /// Calculates the minimum and maximum x and y values (_xMin, _xMax, _yMin, _yMax).
     func calcMinMax()


### PR DESCRIPTION
As `notifyDataSetChanged()` is a Java thing, I changed the method to `reloadData()`. This improves the API for Swift users, as this feels more natural to them.