### PR TITLE
for #3061 fix animation crash

### DIFF
--- a/Source/Charts/Jobs/AnimatedViewPortJob.swift
+++ b/Source/Charts/Jobs/AnimatedViewPortJob.swift
@@ -120,11 +120,11 @@ open class AnimatedViewPortJob: ViewPortJob
     
     internal func animationUpdate()
     {
-        fatalError("`animationUpdate()` must be overriden by subclasses")
+       // Override this
     }
     
     internal func animationEnd()
     {
-        fatalError("`animationEnd()` must be overriden by subclasses")
+        // Override this
     }
 }


### PR DESCRIPTION
for #3061
revert animationUpdate() and animationEnd()
not trigger crash if subclass does nothing