### PR TITLE
add option to build demo projects unit tests on iOS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ def type
 end
 
 def project_name
-  'Charts.xcodeproj'
+  'ChartsDemo/ChartsDemo.xcodeproj'
 end
 
 def configuration
@@ -26,6 +26,13 @@ end
 def build_schemes
   %w[
     Charts
+  ]
+end
+
+def build_demo_schemes
+  %i[
+    ChartsDemo
+    ChartsDemo-Swift
   ]
 end
 
@@ -86,13 +93,13 @@ def run_xcodebuild(schemes_to_execute, tasks, destination, is_test, xcprety_args
   end
 end
 
-def execute(tasks, platform, xcprety_args: '')
+def execute(tasks, platform, is_build_demo = false, xcprety_args: '')
   is_test = tasks.include?('test')
 
   # platform specific settings
   destination = devices[platform]
 
-  schemes = is_test ? test_schemes : build_schemes
+  schemes = is_test ? test_schemes : is_build_demo ? build_demo_schemes : build_schemes
 
   # check if xcodebuild needs to be run on multiple devices
   if destination.is_a?(Array)
@@ -124,7 +131,13 @@ task :ci, [:platform] do |_task, args|
   platform = arg_to_key(args[:platform]) if args.key?(:platform)
 
   if test_platforms.include?(platform)
-    execute 'clean test', platform
+    if platform == :iOS
+      execute 'clean', platform, true
+      execute 'build', platform, true
+      execute 'test', platform
+    else
+      execute 'clean test', platform
+    end
   elsif build_platforms.include?(platform)
     execute 'clean build', platform
   else

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,10 @@ def project_name
   'ChartsDemo/ChartsDemo.xcodeproj'
 end
 
+def macos_project_name
+  'ChartsDemo-OSX/ChartsDemo-OSX.xcodeproj'
+end
+
 def configuration
   'Debug'
 end
@@ -33,6 +37,12 @@ def build_demo_schemes
   %i[
     ChartsDemo
     ChartsDemo-Swift
+  ]
+end
+
+def build_macos_demo_schemes
+  [
+    'ChartsDemo-OSX'
   ]
 end
 
@@ -81,33 +91,43 @@ def xcodebuild(type, name, scheme, configuration, sdk, destination, tasks, xcpre
   sh "set -o pipefail && xcodebuild #{project_type} '#{name}' -scheme '#{scheme}' -configuration '#{configuration}' -sdk #{sdk} -destination #{destination} #{tasks} | bundle exec xcpretty -c #{xcprety_args}"
 end
 
-def run_xcodebuild(schemes_to_execute, tasks, destination, is_test, xcprety_args)
+def run_xcodebuild(tasks, destination, is_build_demo, xcprety_args)
   sdk = destination[:sdk]
   device = destination[:device]
   uuid = destination[:uuid]
 
+  is_test = tasks.include?('test')
+  is_macos = sdk == 'macosx'
+
+  project = is_macos ? macos_project_name : project_name
+
+  schemes_to_execute = []
+  if is_test
+    schemes_to_execute = test_schemes
+  elsif is_build_demo
+    schemes_to_execute = is_macos ? build_macos_demo_schemes : build_demo_schemes
+  else
+    schemes_to_execute = build_schemes
+  end
+
   open_simulator_and_sleep uuid if is_test
 
   schemes_to_execute.each do |scheme|
-    xcodebuild type, project_name, scheme, configuration, sdk, device, tasks, xcprety_args
+    xcodebuild type, project, scheme, configuration, sdk, device, tasks, xcprety_args
   end
 end
 
 def execute(tasks, platform, is_build_demo = false, xcprety_args: '')
-  is_test = tasks.include?('test')
-
   # platform specific settings
   destination = devices[platform]
-
-  schemes = is_test ? test_schemes : is_build_demo ? build_demo_schemes : build_schemes
 
   # check if xcodebuild needs to be run on multiple devices
   if destination.is_a?(Array)
     destination.each do |destination|
-      run_xcodebuild schemes, tasks, destination, is_test, xcprety_args
+      run_xcodebuild tasks, destination, is_build_demo, xcprety_args
     end
   else
-    run_xcodebuild schemes, tasks, destination, is_test, xcprety_args
+    run_xcodebuild tasks, destination, is_build_demo, xcprety_args
   end
 end
 
@@ -129,17 +149,18 @@ end
 desc 'Run CI tasks. Build and test or build depending on the platform.'
 task :ci, [:platform] do |_task, args|
   platform = arg_to_key(args[:platform]) if args.key?(:platform)
+  is_build_demo = test_platforms.include?(platform) || build_platforms.include?(platform)
 
-  if test_platforms.include?(platform)
+  if test_platforms.include?(platform)  # iOS and tvOS
     if platform == :iOS
-      execute 'clean', platform, true
-      execute 'build', platform, true
-      execute 'test', platform
+      execute 'clean', platform, is_build_demo
+      execute 'build', platform, is_build_demo
+      execute 'test', platform  # not use demo specifically
     else
       execute 'clean test', platform
     end
-  elsif build_platforms.include?(platform)
-    execute 'clean build', platform
+  elsif build_platforms.include?(platform)  # macOS
+    execute 'clean build', platform, is_build_demo
   else
     test_platforms.each do |platform|
       execute 'clean test', platform


### PR DESCRIPTION
To avoid any refactoring change that will impact demo builds like #3116, I added the build process for ChartsDemo and its swift portion.

Completely new to rake, it's weird google does not give enough tutorials towards rake  basis.

It took me a wild guess what's the difference between `is_build_demo = false` and `is_build_demo: false` as I just follow `xcprety_args: ''` to guess it's the right way to specify default value.

I change to 'ChartsDemo/ChartsDemo.xcodeproj' as umbrella project. 
I specifically put build before test, to list test results at the bottom of the output.

One thing I don't know why is it builds Charts framework triple times, though I don't ask for clean. It's what we could improve, so welcome suggestions.