### PR TITLE
Fix axis label disappear when zooming in deep enough

### DIFF
--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -163,7 +163,11 @@ open class AxisRendererBase: Renderer
                     n += 1
                 }
             }
-            
+            else if last == first && n == 0
+            {
+                n = 1
+            }
+
             // Ensure stops contains at least n elements.
             axis.entries.removeAll(keepingCapacity: true)
             axis.entries.reserveCapacity(labelCount)


### PR DESCRIPTION
Find another issue when testing  #3114
fix axis label missing when zoom in deep enough, sometimes the label will disappear while scrolling.
Turned out `first` and `last` is equal, so `n` remains 0, and `axis.entries` is empty then.

I do see `var n = axis.centerAxisLabelsEnabled ? 1 : 0` at first, but rather than force setting n = 1, I think checking n == 0 specifically may be better. Welcome suggestions.