### PR TITLE
Subclassing of LegendRenderer didn't take any effect

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -331,7 +331,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 
             if _legend !== nil
             {
-                _legendRenderer?.computeLegend(data: data)
+                legendRenderer?.computeLegend(data: data)
             }
         }
         

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -118,7 +118,7 @@ open class PieChartView: PieRadarChartViewBase
         
         renderer.drawValues(context: context)
         
-        _legendRenderer.renderLegend(context: context)
+        legendRenderer.renderLegend(context: context)
         
         drawDescription(context: context)
         

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -88,7 +88,7 @@ open class PieRadarChartViewBase: ChartViewBase
         
         if let data = _data , _legend !== nil
         {
-            _legendRenderer.computeLegend(data: data)
+            legendRenderer.computeLegend(data: data)
         }
         
         calculateOffsets()

--- a/Source/Charts/Charts/RadarChartView.swift
+++ b/Source/Charts/Charts/RadarChartView.swift
@@ -89,7 +89,7 @@ open class RadarChartView: PieRadarChartViewBase
             let legend = _legend,
             !legend.isLegendCustom
         {
-            _legendRenderer?.computeLegend(data: data)
+            legendRenderer?.computeLegend(data: data)
         }
         
         calculateOffsets()
@@ -139,7 +139,7 @@ open class RadarChartView: PieRadarChartViewBase
 
         renderer.drawValues(context: context)
 
-        _legendRenderer.renderLegend(context: context)
+        legendRenderer.renderLegend(context: context)
 
         drawDescription(context: context)
 


### PR DESCRIPTION
I was trying to subclass the LegendRenderer for a custom pie chart legend, but swapping the `legendRenderer` property didn't take any effect because the internal var was used instead of the open one.