### PR TITLE
fix programatical unhighlighting for BarCharView

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -533,13 +533,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             
             if h === nil || h == self.lastHighlighted
             {
-                highlightValue(nil, callDelegate: true)
                 lastHighlighted = nil
+                highlightValue(nil, callDelegate: true)
             }
             else
             {
-                highlightValue(h, callDelegate: true)
                 lastHighlighted = h
+                highlightValue(h, callDelegate: true)
             }
         }
     }

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -480,6 +480,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         
         if h == nil
         {
+            self.lastHighlighted = nil
             _indicesToHighlight.removeAll(keepingCapacity: false)
         }
         else


### PR DESCRIPTION
There was an issue with reseting the _highlight_ manually from code. The _lastHighlighted_ property of **ChartViewBase** was not set to nil. Thus, calling  **chartView.highlightValue(nil)** in the delegate method  _chartValueSelected(_ chartView: entry: highlight:)_ did not do anything, and the next time user tapped a bar the chartValueNothingSelected method was called instead of the intended chartValueSelected. 

