### PR TITLE
Revert "fix programatical unhighlighting for BarCharView"

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -533,13 +533,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             
             if h === nil || h == self.lastHighlighted
             {
-                lastHighlighted = nil
                 highlightValue(nil, callDelegate: true)
+                lastHighlighted = nil
             }
             else
             {
-                lastHighlighted = h
                 highlightValue(h, callDelegate: true)
+                lastHighlighted = h
             }
         }
     }

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -480,7 +480,6 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         
         if h == nil
         {
-            self.lastHighlighted = nil
             _indicesToHighlight.removeAll(keepingCapacity: false)
         }
         else


### PR DESCRIPTION
Reverts danielgindi/Charts#3159

This was mistakenly merged. The order does not matter, and `lastHighlighted = nil` should be removed as this is taken care of in `highlightValue(_:callDelegate:)`