### PR TITLE
Call setNeedsDisplay() to trigger render noDataText

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -198,6 +198,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             
             guard let _data = _data else
             {
+                setNeedsDisplay()
                 return
             }
             


### PR DESCRIPTION
when chart view already rendered, if updating the chartData with nil, it will not rerender, and display the old content
call setNeedsDisplay() here to trigger render noDataText