### PR TITLE
Support other bundle than main MarkerView.viewFromXib()

### DIFF
--- a/ChartsDemo/Objective-C/Demos/RadarChartViewController.m
+++ b/ChartsDemo/Objective-C/Demos/RadarChartViewController.m
@@ -59,7 +59,7 @@
     _chartView.innerWebColor = UIColor.lightGrayColor;
     _chartView.webAlpha = 1.0;
     
-    RadarMarkerView *marker = (RadarMarkerView *)[RadarMarkerView viewFromXib];
+    RadarMarkerView *marker = (RadarMarkerView *)[RadarMarkerView viewFromXibIn:[NSBundle mainBundle]];
     marker.chartView = _chartView;
     _chartView.marker = marker;
     

--- a/Source/Charts/Components/MarkerView.swift
+++ b/Source/Charts/Components/MarkerView.swift
@@ -72,12 +72,8 @@ open class MarkerView: NSUIView, IMarker
     }
     
     @objc
-    open class func viewFromXib() -> MarkerView? {
-        return viewFromXib(in: Bundle.main)
-    }
-    
-    @objc
-    open class func viewFromXib(in bundle: Bundle) -> MarkerView? {
+    open class func viewFromXib(in bundle: Bundle = .main) -> MarkerView?
+    {
         #if !os(OSX)
             return bundle.loadNibNamed(
                 String(describing: self),

--- a/Source/Charts/Components/MarkerView.swift
+++ b/Source/Charts/Components/MarkerView.swift
@@ -77,8 +77,7 @@ open class MarkerView: NSUIView, IMarker
     }
     
     @objc
-    open class func viewFromXib(in bundle: Bundle) -> MarkerView?
-    {
+    open class func viewFromXib(in bundle: Bundle) -> MarkerView? {
         #if !os(OSX)
             return bundle.loadNibNamed(
                 String(describing: self),

--- a/Source/Charts/Components/MarkerView.swift
+++ b/Source/Charts/Components/MarkerView.swift
@@ -72,10 +72,15 @@ open class MarkerView: NSUIView, IMarker
     }
     
     @objc
-    open class func viewFromXib() -> MarkerView?
+    open class func viewFromXib() -> MarkerView? {
+        return viewFromXib(in: Bundle.main)
+    }
+    
+    @objc
+    open class func viewFromXib(in bundle: Bundle) -> MarkerView?
     {
         #if !os(OSX)
-            return Bundle.main.loadNibNamed(
+            return bundle.loadNibNamed(
                 String(describing: self),
                 owner: nil,
                 options: nil)?[0] as? MarkerView
@@ -84,7 +89,7 @@ open class MarkerView: NSUIView, IMarker
             var loadedObjects = NSArray()
             let loadedObjectsPointer = AutoreleasingUnsafeMutablePointer<NSArray?>(&loadedObjects)
             
-            if Bundle.main.loadNibNamed(
+            if bundle.loadNibNamed(
                 NSNib.Name(String(describing: self)),
                 owner: nil,
                 topLevelObjects: loadedObjectsPointer)


### PR DESCRIPTION
Hi there;

why this pull request:

If you use the Charts Framework from another Bundle, this method will not find the ressources as this is looking in the main bundle only.

I added a method to be able to load the ressources from a given bundle.

Thanks,

Denis