### PR TITLE
Add minimum slice angle for value labels to PieChartView

### DIFF
--- a/ChartsDemo/Objective-C/Demos/PieChartViewController.m
+++ b/ChartsDemo/Objective-C/Demos/PieChartViewController.m
@@ -36,6 +36,7 @@
                      @{@"key": @"togglePercent", @"label": @"Toggle Percent"},
                      @{@"key": @"toggleHole", @"label": @"Toggle Hole"},
                      @{@"key": @"toggleIcons", @"label": @"Toggle Icons"},
+                     @{@"key": @"toggleLabelsMinimumAngle", @"label": @"Toggle Labels Minimum Angle"},
                      @{@"key": @"animateX", @"label": @"Animate X"},
                      @{@"key": @"animateY", @"label": @"Animate Y"},
                      @{@"key": @"animateXY", @"label": @"Animate XY"},
@@ -59,7 +60,7 @@
     l.yOffset = 0.0;
     
     // entry label styling
-    _chartView.entryLabelColor = UIColor.whiteColor;
+    _chartView.entryLabelColor = UIColor.blackColor;
     _chartView.entryLabelFont = [UIFont fontWithName:@"HelveticaNeue-Light" size:12.f];
     
     _sliderX.value = 4.0;
@@ -125,7 +126,7 @@
     pFormatter.percentSymbol = @" %";
     [data setValueFormatter:[[ChartDefaultValueFormatter alloc] initWithFormatter:pFormatter]];
     [data setValueFont:[UIFont fontWithName:@"HelveticaNeue-Light" size:11.f]];
-    [data setValueTextColor:UIColor.whiteColor];
+    [data setValueTextColor:UIColor.blackColor];
     
     _chartView.data = data;
     [_chartView highlightValues:nil];
@@ -157,6 +158,12 @@
         return;
     }
     
+    if ([key isEqualToString:@"toggleLabelsMinimumAngle"])
+    {
+        CGFloat newMinimum = _chartView.drawSliceTextMinimumAngle == 20.0 ? 0.0 : 20.0;
+        _chartView.drawSliceTextMinimumAngle = newMinimum;
+    }
+
     if ([key isEqualToString:@"drawCenter"])
     {
         _chartView.drawCenterTextEnabled = !_chartView.isDrawCenterTextEnabled;

--- a/ChartsDemo/Objective-C/Demos/PiePolylineChartViewController.m
+++ b/ChartsDemo/Objective-C/Demos/PiePolylineChartViewController.m
@@ -31,6 +31,7 @@
                      @{@"key": @"toggleXValues", @"label": @"Toggle X-Values"},
                      @{@"key": @"togglePercent", @"label": @"Toggle Percent"},
                      @{@"key": @"toggleHole", @"label": @"Toggle Hole"},
+                     @{@"key": @"toggleLabelsMinimumAngle", @"label": @"Toggle Labels Minimum Angle"},
                      @{@"key": @"animateX", @"label": @"Animate X"},
                      @{@"key": @"animateY", @"label": @"Animate Y"},
                      @{@"key": @"animateXY", @"label": @"Animate XY"},
@@ -144,6 +145,12 @@
         return;
     }
     
+    if ([key isEqualToString:@"toggleLabelsMinimumAngle"])
+    {
+        CGFloat newMinimum = _chartView.drawSliceTextMinimumAngle == 20.0 ? 0.0 : 20.0;
+        _chartView.drawSliceTextMinimumAngle = newMinimum;
+    }
+
     if ([key isEqualToString:@"drawCenter"])
     {
         _chartView.drawCenterTextEnabled = !_chartView.isDrawCenterTextEnabled;

--- a/ChartsDemo/Swift/DemoBaseViewController.swift
+++ b/ChartsDemo/Swift/DemoBaseViewController.swift
@@ -39,6 +39,7 @@ enum Option {
     case toggleHole
     case spin
     case drawCenter
+    case toggleLabelsMinimumAngle
     // RadarChart
     case toggleXLabels
     case toggleYLabels
@@ -76,6 +77,7 @@ enum Option {
         case .toggleHole: return "Toggle Hole"
         case .spin: return "Spin"
         case .drawCenter: return "Draw CenterText"
+        case .toggleLabelsMinimumAngle: return "Toggle Labels Minimum Angle"
         // RadarChart
         case .toggleXLabels: return "Toggle X-Labels"
         case .toggleYLabels: return "Toggle Y-Labels"

--- a/ChartsDemo/Swift/Demos/PieChartViewController.swift
+++ b/ChartsDemo/Swift/Demos/PieChartViewController.swift
@@ -21,13 +21,14 @@ class PieChartViewController: DemoBaseViewController {
         super.viewDidLoad()
         
         // Do any additional setup after loading the view.
-        self.title = "Half Pie Bar Chart"
+        self.title = "Pie Chart"
         
         self.options = [.toggleValues,
                         .toggleXValues,
                         .togglePercent, 
                         .toggleHole,
                         .toggleIcons,
+                        .toggleLabelsMinimumAngle,
                         .animateX,
                         .animateY,
                         .animateXY,
@@ -99,7 +100,7 @@ class PieChartViewController: DemoBaseViewController {
         data.setValueFormatter(DefaultValueFormatter(formatter: pFormatter))
         
         data.setValueFont(.systemFont(ofSize: 11, weight: .light))
-        data.setValueTextColor(.white)
+        data.setValueTextColor(.black)
         
         chartView.data = data
         chartView.highlightValues(nil)
@@ -119,6 +120,10 @@ class PieChartViewController: DemoBaseViewController {
             chartView.drawHoleEnabled = !chartView.drawHoleEnabled
             chartView.setNeedsDisplay()
             
+        case .toggleLabelsMinimumAngle:
+            chartView.drawSliceTextMinimumAngle = chartView.drawSliceTextMinimumAngle == 0.0 ? 20.0 : 0.0
+            chartView.setNeedsDisplay()
+
         case .drawCenter:
             chartView.drawCenterTextEnabled = !chartView.drawCenterTextEnabled
             chartView.setNeedsDisplay()

--- a/ChartsDemo/Swift/Demos/PieChartViewController.swift
+++ b/ChartsDemo/Swift/Demos/PieChartViewController.swift
@@ -121,7 +121,7 @@ class PieChartViewController: DemoBaseViewController {
             chartView.setNeedsDisplay()
             
         case .toggleLabelsMinimumAngle:
-            chartView.drawSliceTextMinimumAngle = chartView.drawSliceTextMinimumAngle == 0.0 ? 20.0 : 0.0
+            chartView.sliceTextDrawingThreshold = chartView.sliceTextDrawingThreshold == 0.0 ? 20.0 : 0.0
             chartView.setNeedsDisplay()
 
         case .drawCenter:

--- a/ChartsDemo/Swift/Demos/PiePolylineChartViewController.swift
+++ b/ChartsDemo/Swift/Demos/PiePolylineChartViewController.swift
@@ -27,6 +27,7 @@ class PiePolylineChartViewController: DemoBaseViewController {
                         .toggleXValues,
                         .togglePercent,
                         .toggleHole,
+                        .toggleLabelsMinimumAngle,
                         .animateX,
                         .animateY,
                         .animateXY,
@@ -111,6 +112,10 @@ class PiePolylineChartViewController: DemoBaseViewController {
             chartView.drawHoleEnabled = !chartView.drawHoleEnabled
             chartView.setNeedsDisplay()
             
+        case .toggleLabelsMinimumAngle:
+            chartView.drawSliceTextMinimumAngle = chartView.drawSliceTextMinimumAngle == 0.0 ? 20.0 : 0.0
+            chartView.setNeedsDisplay()
+
         case .drawCenter:
             chartView.drawCenterTextEnabled = !chartView.drawCenterTextEnabled
             chartView.setNeedsDisplay()

--- a/ChartsDemo/Swift/Demos/PiePolylineChartViewController.swift
+++ b/ChartsDemo/Swift/Demos/PiePolylineChartViewController.swift
@@ -113,7 +113,7 @@ class PiePolylineChartViewController: DemoBaseViewController {
             chartView.setNeedsDisplay()
             
         case .toggleLabelsMinimumAngle:
-            chartView.drawSliceTextMinimumAngle = chartView.drawSliceTextMinimumAngle == 0.0 ? 20.0 : 0.0
+            chartView.sliceTextDrawingThreshold = chartView.sliceTextDrawingThreshold == 0.0 ? 20.0 : 0.0
             chartView.setNeedsDisplay()
 
         case .drawCenter:

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -72,8 +72,6 @@ open class PieChartView: PieRadarChartViewBase
     /// maximum angle for this pie
     private var _maxAngle: CGFloat = 360.0
 
-    private var _drawSliceTextMinimumAngle: CGFloat = 0.0
-
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
@@ -641,16 +639,10 @@ open class PieChartView: PieRadarChartViewBase
         }
     }
     
-    /// smallest pie slice angle that will have a label drawn
-    @objc open var drawSliceTextMinimumAngle: CGFloat
+    /// smallest pie slice angle that will have a label drawn in degrees, 0 by default
+    @objc open var sliceTextDrawingThreshold: CGFloat = 0.0
     {
-        get
-        {
-            return _drawSliceTextMinimumAngle
-        }
-        set
-        {
-            _drawSliceTextMinimumAngle = newValue
+        didSet {
             setNeedsDisplay()
         }
     }

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -72,6 +72,8 @@ open class PieChartView: PieRadarChartViewBase
     /// maximum angle for this pie
     private var _maxAngle: CGFloat = 360.0
 
+    private var _drawSliceTextMinimumAngle: CGFloat = 0.0
+
     public override init(frame: CGRect)
     {
         super.init(frame: frame)
@@ -636,6 +638,20 @@ open class PieChartView: PieRadarChartViewBase
             {
                 _maxAngle = 90.0
             }
+        }
+    }
+    
+    /// smallest pie slice angle that will have a label drawn
+    @objc open var drawSliceTextMinimumAngle: CGFloat
+    {
+        get
+        {
+            return _drawSliceTextMinimumAngle
+        }
+        set
+        {
+            _drawSliceTextMinimumAngle = newValue
+            setNeedsDisplay()
         }
     }
 }

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -292,7 +292,7 @@ open class PieChartRenderer: NSObject, DataRenderer
         
         let drawEntryLabels = chart.isDrawEntryLabelsEnabled
         let usePercentValuesEnabled = chart.usePercentValuesEnabled
-        let drawSliceTextMinimumAngle = chart.drawSliceTextMinimumAngle
+        let sliceTextDrawingThreshold = chart.sliceTextDrawingThreshold
         let entryLabelColor = chart.entryLabelColor
         let entryLabelFont = chart.entryLabelFont
         
@@ -359,10 +359,10 @@ open class PieChartRenderer: NSObject, DataRenderer
                 let sliceXBase = cos(transformedAngle.DEG2RAD)
                 let sliceYBase = sin(transformedAngle.DEG2RAD)
                 
-                let drawXOutside = sliceAngle > drawSliceTextMinimumAngle && drawEntryLabels && xValuePosition == .outsideSlice
-                let drawYOutside = sliceAngle > drawSliceTextMinimumAngle && drawValues && yValuePosition == .outsideSlice
-                let drawXInside = sliceAngle > drawSliceTextMinimumAngle && drawEntryLabels && xValuePosition == .insideSlice
-                let drawYInside = sliceAngle > drawSliceTextMinimumAngle && drawValues && yValuePosition == .insideSlice
+                let drawXOutside = sliceAngle > sliceTextDrawingThreshold && drawEntryLabels && xValuePosition == .outsideSlice
+                let drawYOutside = sliceAngle > sliceTextDrawingThreshold && drawValues && yValuePosition == .outsideSlice
+                let drawXInside = sliceAngle > sliceTextDrawingThreshold && drawEntryLabels && xValuePosition == .insideSlice
+                let drawYInside = sliceAngle > sliceTextDrawingThreshold && drawValues && yValuePosition == .insideSlice
                 
                 let valueTextColor = dataSet.valueTextColorAt(j)
                 let entryLabelColor = dataSet.entryLabelColor

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -292,6 +292,7 @@ open class PieChartRenderer: NSObject, DataRenderer
         
         let drawEntryLabels = chart.isDrawEntryLabelsEnabled
         let usePercentValuesEnabled = chart.usePercentValuesEnabled
+        let drawSliceTextMinimumAngle = chart.drawSliceTextMinimumAngle
         let entryLabelColor = chart.entryLabelColor
         let entryLabelFont = chart.entryLabelFont
         
@@ -358,10 +359,10 @@ open class PieChartRenderer: NSObject, DataRenderer
                 let sliceXBase = cos(transformedAngle.DEG2RAD)
                 let sliceYBase = sin(transformedAngle.DEG2RAD)
                 
-                let drawXOutside = drawEntryLabels && xValuePosition == .outsideSlice
-                let drawYOutside = drawValues && yValuePosition == .outsideSlice
-                let drawXInside = drawEntryLabels && xValuePosition == .insideSlice
-                let drawYInside = drawValues && yValuePosition == .insideSlice
+                let drawXOutside = sliceAngle > drawSliceTextMinimumAngle && drawEntryLabels && xValuePosition == .outsideSlice
+                let drawYOutside = sliceAngle > drawSliceTextMinimumAngle && drawValues && yValuePosition == .outsideSlice
+                let drawXInside = sliceAngle > drawSliceTextMinimumAngle && drawEntryLabels && xValuePosition == .insideSlice
+                let drawYInside = sliceAngle > drawSliceTextMinimumAngle && drawValues && yValuePosition == .insideSlice
                 
                 let valueTextColor = dataSet.valueTextColorAt(j)
                 let entryLabelColor = dataSet.entryLabelColor


### PR DESCRIPTION
Allow hiding labels for small slices in pie charts. Based on #944, also addresses #3182 and #2062, but with a slightly different implementation.

This adds a property `drawSliceTextMinimumAngle` to the pie chart. Any slices smaller than that angle will not be drawn.

Also tweaked a few values in the pie charts demos to make them a little easier to read.