### PR TITLE
Min and Max reset when clearing ChartDataSet (Fixes #3260)

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -86,22 +86,22 @@ open class ChartDataSet: ChartBaseDataSet
     
     open override func calcMinMax()
     {
-        guard !values.isEmpty else { return }
-
         _yMax = -Double.greatestFiniteMagnitude
         _yMin = Double.greatestFiniteMagnitude
         _xMax = -Double.greatestFiniteMagnitude
         _xMin = Double.greatestFiniteMagnitude
+
+        guard !values.isEmpty else { return }
 
         values.forEach { calcMinMax(entry: $0) }
     }
     
     open override func calcMinMaxY(fromX: Double, toX: Double)
     {
-        guard !values.isEmpty else { return }
-
         _yMax = -Double.greatestFiniteMagnitude
         _yMin = Double.greatestFiniteMagnitude
+
+        guard !values.isEmpty else { return }
         
         let indexFrom = entryIndex(x: fromX, closestToY: Double.nan, rounding: .down)
         let indexTo = entryIndex(x: toX, closestToY: Double.nan, rounding: .up)


### PR DESCRIPTION
Fixes issue #3260 
The min and max values of `ChartDataSet` should always be reset to their default values when `clear()` is called. Since `clear()` removes all items from `values`, the guard statement prevents this reset from happening. Moving the guard statement won't have any impact on the rest of the project.