### PR TITLE
for #3146. add a warning message if pie chart has more than one data set

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/PieChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartData.swift
@@ -23,6 +23,20 @@ open class PieChartData: ChartData
         super.init(dataSets: dataSets)
     }
 
+    /// - returns: All DataSet objects this ChartData object holds.
+    @objc open override var dataSets: [IChartDataSet]
+    {
+        get
+        {
+            assert(super.dataSets.count <= 1, "Found multiple data sets while pie chart only allows one")
+            return super.dataSets
+        }
+        set
+        {
+            super.dataSets = newValue
+        }
+    }
+
     @objc var dataSet: IPieChartDataSet?
     {
         get


### PR DESCRIPTION
fix #3146. add a warning message if pie chart has more than one data set

I specifically call super because we actually did nothing in pie chart.