### PR TITLE
minor bug fix in favor of 3.1 release

### DIFF
--- a/ChartsDemo/Supporting Files/Info.plist
+++ b/ChartsDemo/Supporting Files/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app requires access to the photo library to store shots of charts there.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app requires access to the photo library to store shots of charts there.</string>
 	<key>UILaunchStoryboardName</key>

--- a/Source/Charts/Jobs/ZoomViewJob.swift
+++ b/Source/Charts/Jobs/ZoomViewJob.swift
@@ -60,8 +60,8 @@ open class ZoomViewJob: ViewPortJob
         let xValsInView = (view as! BarLineChartViewBase).xAxis.axisRange / Double(viewPortHandler.scaleX)
         
         var pt = CGPoint(
-            x: CGFloat(xValue - xValsInView) / 2.0,
-            y: CGFloat(yValue + yValsInView) / 2.0
+            x: CGFloat(xValue - xValsInView / 2.0),
+            y: CGFloat(yValue + yValsInView / 2.0)
         )
         
         transformer.pointValueToPixel(&pt)


### PR DESCRIPTION
Will pick a few before releasing 3.1
1. revert a mistake, fix #3299
2. add one more key for iOS 11 camera roll saving. fix #3311 