### PR TITLE
Add Objective-c compatible for turning off drag in X and Y Axis separately

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -1537,7 +1537,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// is dragging on the X axis enabled?
-    open var dragXEnabled: Bool 
+    @objc open var dragXEnabled: Bool
     {
         get
         {
@@ -1550,7 +1550,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     }
     
     /// is dragging on the Y axis enabled?
-    open var dragYEnabled: Bool
+    @objc open var dragYEnabled: Bool
     {
         get
         {


### PR DESCRIPTION
### Goals :soccer:
Currently, turning off drag in X and Y Axis separately is only available for Swift.
This PR adds objective-c compatible for enabling/disabling drag in either axis separately.

### Implementation Details :construction:
Add `@objc` tag for `dragXEnabled`, `dragYEnabled` properties.