### PR TITLE
Fix broken demo link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Documentation
 Currently there's no need for documentation for the iOS/tvOS/macOS version, as the API is **95% the same** as on Android.  
 You can read the official [MPAndroidChart](https://github.com/PhilJay/MPAndroidChart) documentation here: [**Wiki**](https://github.com/PhilJay/MPAndroidChart/wiki)
 
-Or you can see the [**ChartsDemo**](https://github.com/danielgindi/Charts/tree/master/ChartsDemo) project and learn the how-tos from it.
+Or you can see the Charts Demo project ([**ChartsDemo-iOS**](https://github.com/danielgindi/Charts/tree/master/ChartsDemo-iOS), [**ChartsDemo-macOS**](https://github.com/danielgindi/Charts/tree/master/ChartsDemo-macOS)) and learn the how-tos from it.
 
 
 Special Thanks


### PR DESCRIPTION
### Issue Link https://github.com/danielgindi/Charts/tree/master/ChartsDemo
The link to ChartsDemo is outdated as there is now separate demos for macOS and iOS, current PR adds separate links to 2 demos for iOS and macOS