### PR TITLE
Make legendRenderer property public in order to be externally customizable

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -102,7 +102,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     open var noDataTextAlignment: NSTextAlignment = .left
 
     /// The renderer object responsible for rendering / drawing the Legend.
-    @objc open internal(set) lazy var legendRenderer = LegendRenderer(viewPortHandler: viewPortHandler, legend: legend)
+    @objc open lazy var legendRenderer = LegendRenderer(viewPortHandler: viewPortHandler, legend: legend)
 
     /// object responsible for rendering the data
     @objc open var renderer: DataRenderer?


### PR DESCRIPTION
### Goals :soccer:
The main idea behind this pull request is to make the legend renderer externally customizable and overridable.

Our customer's request was to detect when the user's clicks on a legend and to highlight corresponding line on the chart.

### Implementation Details :construction:
By making public the legendRenderer property (similarly to the renderer property) we would like to use our own legend renderer class which stores the exact location of the labels and in this way we can detect if the user clicked on a label or not.