### PR TITLE
#3457 fixed by picking entry by its X value instead of array index. T…

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartData.swift
@@ -65,12 +65,8 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
                 fromX += barSpaceHalf
                 fromX += barWidthHalf
                 
-                if i < set.entryCount
-                {
-                    if let entry = set.entryForIndex(i)
-                    {
-                        entry.x = fromX
-                    }
+                for entry in set.entriesForXValue(Double(i)) {
+                    entry.x = fromX
                 }
                 
                 fromX += barWidthHalf


### PR DESCRIPTION
…his will avoid setting x offset on a wrong data entry

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/3457

### Implementation Details :construction:
#3457 fixed by picking entry by its X value instead of array index in BarChartData class . This will avoid setting x offset on a wrong data entry