### PR TITLE
Add flag to render Bar chart with rounded Bars

### DIFF
--- a/Source/Charts/Charts/BarChartView.swift
+++ b/Source/Charts/Charts/BarChartView.swift
@@ -20,6 +20,9 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
 
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
     private var _drawBarShadowEnabled = false
+
+    /// if set to true, bars will be drawn with rounded ends
+    private var _drawRoundedBarsEnabled = false
     
     internal override func initialize()
     {
@@ -159,6 +162,17 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
             setNeedsDisplay()
         }
     }
+
+    /// if set to true, bars will be drawn with rounded ends
+    @objc open var drawRoundedBarsEnabled: Bool
+        {
+        get { return _drawRoundedBarsEnabled }
+        set
+        {
+            _drawRoundedBarsEnabled = newValue
+            setNeedsDisplay()
+        }
+    }
     
     /// Adds half of the bar width to each side of the x-axis range in order to allow the bars of the barchart to be fully displayed.
     /// **default**: false
@@ -180,4 +194,7 @@ open class BarChartView: BarLineChartViewBase, BarChartDataProvider
     
     /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
     open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
+
+    /// - returns: `true` if drawing each bar as rounded is enabled, `false` if not
+    open var isDrawRoundedBarsEnabled: Bool { return drawRoundedBarsEnabled }
 }

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -160,11 +160,11 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
         }
     }
     
-    // MARK: - Accessors
+    // MARK: - BarChartDataProvider
     
     /// if set to true, all values are drawn above their bars, instead of below their top
     @objc open var drawValueAboveBarEnabled: Bool
-        {
+    {
         get { return (renderer as! CombinedChartRenderer).drawValueAboveBarEnabled }
         set { (renderer as! CombinedChartRenderer).drawValueAboveBarEnabled = newValue }
     }
@@ -175,13 +175,31 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
         get { return (renderer as! CombinedChartRenderer).drawBarShadowEnabled }
         set { (renderer as! CombinedChartRenderer).drawBarShadowEnabled = newValue }
     }
+
+    @objc open var drawRoundedBarsEnabled: Bool
+    {
+        get { return (renderer as! CombinedChartRenderer).drawRoundedBarsEnabled }
+        set { (renderer as! CombinedChartRenderer).drawRoundedBarsEnabled = newValue }
+    }
     
     /// - returns: `true` if drawing values above bars is enabled, `false` ifnot
-    open var isDrawValueAboveBarEnabled: Bool { return (renderer as! CombinedChartRenderer).drawValueAboveBarEnabled }
+    open var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
     
     /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
-    open var isDrawBarShadowEnabled: Bool { return (renderer as! CombinedChartRenderer).drawBarShadowEnabled }
-    
+    open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
+
+    /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values
+    @objc open var highlightFullBarEnabled: Bool = false
+
+    /// - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
+    open var isHighlightFullBarEnabled: Bool { return highlightFullBarEnabled }
+
+    /// - returns: `true` if drawing each bar as rounded is enabled, `false` if not
+    open var isDrawRoundedBarsEnabled: Bool { return drawRoundedBarsEnabled }
+
+
+    // MARK: CombinedChartViewRenderer
+
     /// the order in which the provided data objects should be drawn.
     /// The earlier you place them in the provided array, the further they will be in the background. 
     /// e.g. if you provide [DrawOrder.Bar, DrawOrder.Line], the bars will be drawn behind the lines.
@@ -196,12 +214,6 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             (renderer as! CombinedChartRenderer).drawOrder = newValue.map { DrawOrder(rawValue: $0)! }
         }
     }
-    
-    /// Set this to `true` to make the highlight operation full-bar oriented, `false` to make it highlight single values
-    @objc open var highlightFullBarEnabled: Bool = false
-    
-    /// - returns: `true` the highlight is be full-bar oriented, `false` ifsingle-value
-    open var isHighlightFullBarEnabled: Bool { return highlightFullBarEnabled }
     
     // MARK: - ChartViewBase
     

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -197,7 +197,6 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
     /// - returns: `true` if drawing each bar as rounded is enabled, `false` if not
     open var isDrawRoundedBarsEnabled: Bool { return drawRoundedBarsEnabled }
 
-
     // MARK: CombinedChartViewRenderer
 
     /// the order in which the provided data objects should be drawn.

--- a/Source/Charts/Interfaces/BarChartDataProvider.swift
+++ b/Source/Charts/Interfaces/BarChartDataProvider.swift
@@ -20,4 +20,5 @@ public protocol BarChartDataProvider: BarLineScatterCandleBubbleChartDataProvide
     var isDrawBarShadowEnabled: Bool { get }
     var isDrawValueAboveBarEnabled: Bool { get }
     var isHighlightFullBarEnabled: Bool { get }
+    var isDrawRoundedBarsEnabled: Bool { get }
 }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -309,13 +309,26 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            context.fill(barRect)
-            
+            if dataProvider.isDrawRoundedBarsEnabled {
+                var roundedRect = barRect
+                roundedRect.size.height = roundedRect.size.height - 10
+                UIBezierPath(roundedRect: roundedRect, cornerRadius: floor(barRect.size.width / 2)).fill()
+            } else {
+                context.fill(barRect)
+            }
+
             if drawBorder
             {
                 context.setStrokeColor(borderColor.cgColor)
                 context.setLineWidth(borderWidth)
-                context.stroke(barRect)
+
+                if dataProvider.isDrawRoundedBarsEnabled {
+                    var roundedRect = barRect
+                    roundedRect.size.height = roundedRect.size.height - 10
+                    UIBezierPath(roundedRect: roundedRect, cornerRadius: floor(barRect.size.width / 2)).fill()
+                } else {
+                    context.stroke(barRect)
+                }
             }
         }
         

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -21,6 +21,9 @@ open class CombinedChartRenderer: DataRenderer
     
     /// if set to true, a grey area is drawn behind each bar that indicates the maximum value
     @objc open var drawBarShadowEnabled = false
+
+    /// if set to true, bars will be drawn with rounded ends
+    @objc open var drawRoundedBarsEnabled = false
     
     internal var _renderers = [DataRenderer]()
     
@@ -172,13 +175,16 @@ open class CombinedChartRenderer: DataRenderer
         set { _renderers = newValue }
     }
     
-    // MARK: Accessors
+    // MARK: BarChartDataProvider
     
-    /// - returns: `true` if drawing values above bars is enabled, `false` ifnot
+    /// - returns: `true` if drawing values above bars is enabled, `false` if not
     @objc open var isDrawValueAboveBarEnabled: Bool { return drawValueAboveBarEnabled }
     
-    /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` ifnot
+    /// - returns: `true` if drawing shadows (maxvalue) for each bar is enabled, `false` if not
     @objc open var isDrawBarShadowEnabled: Bool { return drawBarShadowEnabled }
+
+    /// - returns: `true` if drawing each bar as rounded is enabled, `false` if not
+    @objc open var isDrawRoundedBarsEnabled: Bool { return drawRoundedBarsEnabled }
     
     /// the order in which the provided data objects should be drawn.
     /// The earlier you place them in the provided array, the further they will be in the background.


### PR DESCRIPTION
### Goals :soccer:
Wanted to be able to render a vertical bar chart with a nice rounded bar look as opposed to a simple rectangle.

### Implementation Details :construction:
 - Add a flag (`isDrawRoundedBarsEnabled`) to existing `BarChartDataProvider` (and associated classes) to denote whether bars will be rendered as rounded
 - Update `BarChartRenderer` to render a rounded rectangle (using UIBezierPath) when the `dataProvider` has its `isDrawRoundedBarsEnabled` property set to `true`
- Also updated rendering of borders to ensure they match the filled space.

### Todo:
 - [ ] Add support for macOS (need to use NSBezierPath or similar)