### PR TITLE
Removes comment about non-existent method

### DIFF
--- a/Source/Charts/Formatters/IValueFormatter.swift
+++ b/Source/Charts/Formatters/IValueFormatter.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 /// Simply create your own formatting class and let it implement ValueFormatter.
 ///
-/// Then override the getFormattedValue(...) method and return whatever you want.
+
 @objc(IChartValueFormatter)
 public protocol IValueFormatter: class
 {


### PR DESCRIPTION
IValueFormatter had a comment suggesting that you can override the getFormattedValue(…) method but that method doesn’t exist. The comment has been removed.

### Issue Link :link:
#3506 
