### PR TITLE
Changed comment that referenced getFormattedValue() method in IValueFormatter

### DIFF
--- a/Source/Charts/Formatters/IValueFormatter.swift
+++ b/Source/Charts/Formatters/IValueFormatter.swift
@@ -11,10 +11,10 @@
 
 import Foundation
 
-/// Interface that allows custom formatting of all values inside the chart before they are being drawn to the screen.
+/// Interface that allows custom formatting of all values inside the chart before they are drawn to the screen.
 ///
-/// Simply create your own formatting class and let it implement ValueFormatter.
-///
+/// Simply create your own formatting class and let it implement ValueFormatter. Then override the stringForValue()
+/// method and return whatever you want.
 
 @objc(IChartValueFormatter)
 public protocol IValueFormatter: class
@@ -24,11 +24,9 @@ public protocol IValueFormatter: class
     ///
     /// For performance reasons, avoid excessive calculations and memory allocations inside this method.
     ///
-    /// - returns: The formatted label ready for being drawn
+    /// - returns:                   The formatted label ready to be drawn
     ///
     /// - parameter value:           The value to be formatted
-    ///
-    /// - parameter axis:            The entry the value belongs to - in e.g. BarChart, this is of class BarEntry
     ///
     /// - parameter dataSetIndex:    The index of the DataSet the entry in focus belongs to
     ///

--- a/Source/Charts/Formatters/IValueFormatter.swift
+++ b/Source/Charts/Formatters/IValueFormatter.swift
@@ -15,7 +15,7 @@ import Foundation
 ///
 /// Simply create your own formatting class and let it implement ValueFormatter.
 ///
-/// Then override the getFormattedValue(...) method and return whatever you want.
+
 @objc(IChartValueFormatter)
 public protocol IValueFormatter: class
 {


### PR DESCRIPTION
Updated the documentation markup in the IValueFormatter protocol by changing the reference to getFormattedValue() to the newer stringForValue() method.