### PR TITLE
update barRect.size.height calculation

### DIFF
--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -159,7 +159,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 barRect.origin.x = left
                 barRect.size.width = right - left
                 barRect.origin.y = top
-                barRect.size.height = bottom - top + offset
+                barRect.size.height = bottom == top ? 0 : bottom - top + offset
 
                 buffer.rects[bufferIndex] = barRect
                 bufferIndex += 1


### PR DESCRIPTION
when bottom equals top, offset is not necessary
fix  #3586 