### PR TITLE
Fix for candle chart bar width (#3590)

### DIFF
--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -169,7 +169,10 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                 trans.rectValueToPixel(&_bodyRect)
                 
                 // draw body differently for increasing and decreasing entry
-
+                let strokeRect = CGRect(x:_bodyRect.origin.x+0.5,
+                                        y:_bodyRect.origin.y+0.5,
+                                        width:_bodyRect.size.width-1,
+                                        height:_bodyRect.size.height-1)
                 if open > close
                 {
                     accessibilityMovementDescription = "decreasing"
@@ -183,6 +186,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     }
                     else
                     {
+                        _bodyRect = strokeRect
                         context.setStrokeColor(color.cgColor)
                         context.stroke(_bodyRect)
                     }
@@ -200,6 +204,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     }
                     else
                     {
+                        _bodyRect = strokeRect
                         context.setStrokeColor(color.cgColor)
                         context.stroke(_bodyRect)
                     }


### PR DESCRIPTION
### Issue Link :link:
Fix for #3590

### Goals :soccer:
It will make width of candle chart bars equal

### Implementation Details :construction:
According to documentation of "stroke" method: https://developer.apple.com/documentation/coregraphics/cgcontext/1454679-stroke
"The line straddles the path, with half of the total width on either side." It makes stroked bars 1 pixel (half of pixel on both sides) wider, and it is visible on iPhone if bars count is 30+.

### Testing Details :mag:
Screenshot after fix applied: https://user-images.githubusercontent.com/1306465/43476381-229e4916-9501-11e8-966f-79f676822e3e.png