### PR TITLE
Know when user is done interacting with graph

### DIFF
--- a/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
+++ b/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
@@ -305,6 +305,10 @@ class DemoBaseViewController: UIViewController, ChartViewDelegate {
     func chartTranslated(_ chartView: ChartViewBase, dX: CGFloat, dY: CGFloat) {
         
     }
+    
+    func panGestureEnded(_ chartView: ChartViewBase) {
+        NSLog("panGestureEnded")
+    }
 }
 
 extension DemoBaseViewController: UITableViewDelegate, UITableViewDataSource {

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -786,6 +786,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 _outerScrollView?.nsuiIsScrollEnabled = true
                 _outerScrollView = nil
             }
+            delegate?.panGestureEnded?(self)
         }
     }
     

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -33,6 +33,9 @@ public protocol ChartViewDelegate
     
     // Callbacks when the chart is moved / translated via drag gesture.
     @objc optional func chartTranslated(_ chartView: ChartViewBase, dX: CGFloat, dY: CGFloat)
+    
+    // Callbacks when the user stops touching the graph
+    @objc optional func panGestureEnded(_ chartView: ChartViewBase)
 }
 
 open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
Easily be able to determine when a user stops interacting (highlighting) with a chart.
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
I made the delegate method optional because it shouldn't have to be implemented. It's just an additional feature that some developers might find useful.

<!-- Highlight any new functionality. -->
When a user stops a panGesture on a chart the delegate method will call back. This allows for the developer to know when the user stopped highlighting a graph. They can then update the chart accordingly. I used the feature to transition between a cubic (smooth) and linear graph as the user starts and stops highlighting a graph. Similar to the charts in the RobinHood App.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
It's just an optinal callback so didn't add any tests.