### PR TITLE
Feature - ChartView Pan Ended Delegate Call

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -779,6 +779,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 }
                 
                 _isDragging = false
+            
+                delegate?.chartViewDidEndPanning?(self)
             }
             
             if _outerScrollView !== nil

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -779,8 +779,6 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 }
                 
                 _isDragging = false
-            
-                delegate?.chartViewDidEndPanning?(self)
             }
             
             if _outerScrollView !== nil
@@ -788,6 +786,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 _outerScrollView?.nsuiIsScrollEnabled = true
                 _outerScrollView = nil
             }
+            
+            delegate?.chartViewDidEndPanning?(self)
         }
     }
     

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -25,6 +25,9 @@ public protocol ChartViewDelegate
     /// - parameter highlight: The corresponding highlight object that contains information about the highlighted position such as dataSetIndex etc.
     @objc optional func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight)
     
+    /// Called when a user stop highlighting values while panning
+    @objc optional func chartViewDidEndPanning(_ chartView: ChartViewBase)
+    
     // Called when nothing has been selected or an "un-select" has been made.
     @objc optional func chartValueNothingSelected(_ chartView: ChartViewBase)
     

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -25,7 +25,7 @@ public protocol ChartViewDelegate
     /// - parameter highlight: The corresponding highlight object that contains information about the highlighted position such as dataSetIndex etc.
     @objc optional func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight)
     
-    /// Called when a user stop highlighting values while panning
+    /// Called when a user stops panning between values on the chart
     @objc optional func chartViewDidEndPanning(_ chartView: ChartViewBase)
     
     // Called when nothing has been selected or an "un-select" has been made.


### PR DESCRIPTION
### Issue Link :link:

Over the years, every I have come to implement this library, i have found that 1 feature for me has always been missing which is the ability to know when the user stopped panning across a chart to display values on the fly, and have it reset once the user lets go. I've yet to find a clean solution other than modifying the library, and I have added some callback logic to the ChartViewDelegate

### Goals :soccer:
To be able to install this from the master repo, and not always have to fork it to add this exact feature./

### Implementation Details :construction:

Added and optional method to the  ChartViewDelegate to tell the delegate that the pan gesture has reached a cancelled / ended state

```
public protocol ChartViewDelegate
{
     ...

    /// Called when a user stop highlighting values while panning
    @objc optional func chartViewDidEndPanning(_ chartView: ChartViewBase)
}
```

### Testing Details :mag:
None, there are no specific tests. This should not effect the snapshotting at all, and has no effect on the existing codebase other than an optional callback.