### PR TITLE
improvements in barRect height calculation 

### DIFF
--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -150,6 +150,9 @@ open class YAxis: AxisBase
         var min = _customAxisMin ? _axisMinimum : dataMin
         var max = _customAxisMax ? _axisMaximum : dataMax
         
+        min = max < min ? max : min
+        max = min > max ? min : max
+        
         // temporary range (before calculations)
         let range = abs(max - min)
         

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -150,8 +150,19 @@ open class YAxis: AxisBase
         var min = _customAxisMin ? _axisMinimum : dataMin
         var max = _customAxisMax ? _axisMaximum : dataMax
         
-        min = max < min ? max : min
-        max = min > max ? min : max
+        if min > max {
+            if _customAxisMax && _customAxisMin {
+                //both max and min are manullay setted
+                min = max < min ? max : min
+                max = min > max ? min : max
+            } else if _customAxisMax && !_customAxisMin {
+                min = max - 1
+            } else if !_customAxisMax && _customAxisMin {
+                max = min + 1
+            }
+        }
+        
+        
         
         // temporary range (before calculations)
         let range = abs(max - min)

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -150,8 +150,16 @@ open class YAxis: AxisBase
         var min = _customAxisMin ? _axisMinimum : dataMin
         var max = _customAxisMax ? _axisMaximum : dataMax
         
-        min = max < min ? max : min
-        max = min > max ? min : max
+        // Make sure max is greater than min
+        if min > max {
+            if _customAxisMax && _customAxisMin {
+                (min, max) = (max, min)
+            } else if _customAxisMax && !_customAxisMin {
+                min = max - 1
+            } else if !_customAxisMax && _customAxisMin {
+                max = min + 1
+            }
+        }
         
         // temporary range (before calculations)
         let range = abs(max - min)

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -150,19 +150,8 @@ open class YAxis: AxisBase
         var min = _customAxisMin ? _axisMinimum : dataMin
         var max = _customAxisMax ? _axisMaximum : dataMax
         
-        if min > max {
-            if _customAxisMax && _customAxisMin {
-                //both max and min are manullay setted
-                min = max < min ? max : min
-                max = min > max ? min : max
-            } else if _customAxisMax && !_customAxisMin {
-                min = max - 1
-            } else if !_customAxisMax && _customAxisMin {
-                max = min + 1
-            }
-        }
-        
-        
+        min = max < min ? max : min
+        max = min > max ? min : max
         
         // temporary range (before calculations)
         let range = abs(max - min)

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -108,6 +108,28 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         var barRect = CGRect()
         var x: Double
         var y: Double
+
+
+
+        // When drawing with an auto calculated y-axis minimum, the renderer actually draws each bar from 0
+        // to the required value. This drawn bar is then clipped to the visible chart rect in BarLineChartViewBase's draw(rect:) using clipDataToContent.
+        // While this works fine when calculating the bar rects for drawing, it causes the accessibilityFrames to be oversized in some cases.
+        // This offset attempts to undo that unnecessary drawing when calculating barRects, particularly when not using custom axis minima.
+        // This allows the minimum to still be visually non zero, but the rects are only drawn where necessary.
+        // This offset calculation is not necessary when bars won't be clipped (when y-axis minimum <= 0  and y-axis maximum  >= 0)
+        var heightOffset: CGFloat = 0.0
+        var originYOffset: CGFloat = 0.0
+        if let offsetView = dataProvider as? BarChartView {
+            let offsetAxis = offsetView.leftAxis.isEnabled ? offsetView.leftAxis : offsetView.rightAxis
+            if !offsetAxis._customAxisMin {
+                if barData.yMin > 0 {
+                    heightOffset = CGFloat(offsetAxis.axisMinimum)
+                }
+                if barData.yMax < 0 {
+                    originYOffset = CGFloat(offsetAxis.axisMaximum)
+                }         
+            }
+        }
         
         for i in stride(from: 0, to: min(Int(ceil(Double(dataSet.entryCount) * animator.phaseX)), dataSet.entryCount), by: 1)
         {
@@ -139,28 +161,10 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                     bottom *= CGFloat(phaseY)
                 }
 
-                // When drawing with an auto calculated y-axis minimum, the renderer actually draws each bar from 0
-                // to the required value. This drawn bar is then clipped to the visible chart rect in BarLineChartViewBase's draw(rect:) using clipDataToContent.
-                // While this works fine when calculating the bar rects for drawing, it causes the accessibilityFrames to be oversized in some cases.
-                // This offset attempts to undo that unnecessary drawing when calculating barRects, particularly when not using custom axis minima.
-                // This allows the minimum to still be visually non zero, but the rects are only drawn where necessary.
-                // This offset calculation also avoids cases where there are positive/negative values mixed, since those won't need this offset.
-                var offset: CGFloat = 0.0
-                if let offsetView = dataProvider as? BarChartView {
-
-                    let offsetAxis = offsetView.leftAxis.isEnabled ? offsetView.leftAxis : offsetView.rightAxis
-
-                    if barData.yMin.sign != barData.yMax.sign { offset = 0.0 }
-                    else if !offsetAxis._customAxisMin {
-                        offset = CGFloat(offsetAxis.axisMinimum)
-                    }
-                }
-
                 barRect.origin.x = left
+                barRect.origin.y = top + originYOffset
                 barRect.size.width = right - left
-                barRect.origin.y = top
-                barRect.size.height = bottom == top ? 0 : bottom - top + offset
-
+                barRect.size.height = bottom - top + heightOffset - originYOffset
                 buffer.rects[bufferIndex] = barRect
                 bufferIndex += 1
             }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -125,9 +125,11 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 if barData.yMin > 0 {
                     heightOffset = CGFloat(offsetAxis.axisMinimum)
                 }
+            }
+            if !offsetAxis._customAxisMax {
                 if barData.yMax < 0 {
                     originYOffset = CGFloat(offsetAxis.axisMaximum)
-                }         
+                }
             }
         }
         


### PR DESCRIPTION
###  issue
My last PR #3587 fixed bar height calculation when all y values equals 0.
Recently,  I found bars will displayed in an unexpected size when all y values less than 0.
And the black border will be oversized too when voice over is enable. 
![img_0333](https://user-images.githubusercontent.com/2739651/45919561-d66d6e80-bec9-11e8-8e0d-28676ecfb0e4.PNG)


### how to reproduce
replace those codes
https://github.com/danielgindi/Charts/blob/5087a04bbefc9f15995113954ce217bbfb445577/ChartsDemo-iOS/Swift/Demos/AnotherBarChartViewController.swift#L64-L68
with 
``` swift
        let yVals = [
            BarChartDataEntry(x: 0, y: -10),
            BarChartDataEntry(x: 1, y: -20),
            BarChartDataEntry(x: 2, y: -30),
            BarChartDataEntry(x: 3, y: -15)
        ]
```

### other
I moved the offset calculation code out of the loop, calculate once is enough
https://github.com/danielgindi/Charts/blob/5087a04bbefc9f15995113954ce217bbfb445577/Source/Charts/Renderers/BarChartRenderer.swift#L112
