### PR TITLE
Updated LineChart to Support an Array of Colors for CircleHoles - Issue #3694

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
@@ -89,6 +89,19 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
         return circleColors[index]
     }
     
+    open var circleHoleColors = [NSUIColor]()
+    
+    /// - returns: The color at the given index of the DataSet's circle-hole-color array.
+    /// Performs a IndexOutOfBounds check by modulus.
+    open func getCircleHoleColor(atIndex index: Int) -> NSUIColor? {
+        let size = circleHoleColors.count
+        let index = index % size
+        guard size > 0, index < size else {
+            return circleHoleColor // return the default if the array has no values or index out of bounds
+        }
+        return circleHoleColors[index]
+    }
+    
     /// Sets the one and ONLY color that should be used for this DataSet.
     /// Internally, this recreates the colors array and adds the specified color.
     open func setCircleColor(_ color: NSUIColor)

--- a/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
@@ -95,9 +95,12 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     /// Performs a IndexOutOfBounds check by modulus.
     open func getCircleHoleColor(atIndex index: Int) -> NSUIColor? {
         let size = circleHoleColors.count
+        guard size > 0 else {
+            return circleHoleColor // return the default if the array has no values
+        }
         let index = index % size
-        guard size > 0, index < size else {
-            return circleHoleColor // return the default if the array has no values or index out of bounds
+        guard index < size else {
+            return circleHoleColor // return the default if index out of bounds
         }
         return circleHoleColors[index]
     }

--- a/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
@@ -38,9 +38,15 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     
     var circleColors: [NSUIColor] { get set }
     
+    var circleHoleColors: [NSUIColor] { get set }
+    
     /// - returns: The color at the given index of the DataSet's circle-color array.
     /// Performs a IndexOutOfBounds check by modulus.
     func getCircleColor(atIndex: Int) -> NSUIColor?
+    
+    /// - returns: The color at the given index of the DataSet's circle-hole-color array.
+    /// Performs a IndexOutOfBounds check by modulus.
+    func getCircleHoleColor(atIndex: Int) -> NSUIColor?
     
     /// Sets the one and ONLY color that should be used for this DataSet.
     /// Internally, this recreates the colors array and adds the specified color.

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -722,7 +722,7 @@ open class LineChartRenderer: LineRadarRenderer
                     
                     if drawCircleHole
                     {
-                        context.setFillColor(dataSet.circleHoleColor!.cgColor)
+                        context.setFillColor(dataSet.getCircleHoleColor(atIndex: j)!.cgColor)
                      
                         // The hole rect
                         rect.origin.x = pt.x - circleHoleRadius


### PR DESCRIPTION
Fixes Issue #3694 

Changed the LineChartDataSet to support an array of colors for CircleHoles, similar to how CircleColors is done.

* Updated LineChartDataSet Interface to contain an array of colors for circleHoles and a function to get a circleHole color at a given index.
* Updated LineChartDataSet Implementation file to instantiate an empty NSUIColor array for circleHoleColors.
* Added implementation to get a color out of the new circleHoleColors array by index, returning the existing circleHoleColor property if the array is empty or the index is out of bounds.
* Updated the call for drawing a circleHole in the LineChartRenderer to use the new function to get the circleHoleColor by index instead of referencing the property

### Issue Link [:link:](https://github.com/danielgindi/Charts/issues/3694)
Fixes Issue #3694

### Goals :soccer:
The goal of this PR is to allow developers to customize their LineChart's individual circle holes

### Implementation Details :construction:
No new architectural changes
Now an array of circleHoleColors can be defined in the same way circleColors can be. 