### PR TITLE
Multiple colors for valueline (Fixes #3480)

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
@@ -84,6 +84,9 @@ open class PieChartDataSet: ChartDataSet, IPieChartDataSet
     /// When valuePosition is OutsideSlice, indicates line color
     open var valueLineColor: NSUIColor? = NSUIColor.black
 
+    /// When valuePosition is OutsideSlice and enabled, line will have the same color as the slice
+    open var matchValueLineColorToPieSlice: Bool = false
+
     /// When valuePosition is OutsideSlice, indicates line width
     open var valueLineWidth: CGFloat = 1.0
 

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
@@ -85,7 +85,7 @@ open class PieChartDataSet: ChartDataSet, IPieChartDataSet
     open var valueLineColor: NSUIColor? = NSUIColor.black
 
     /// When valuePosition is OutsideSlice and enabled, line will have the same color as the slice
-    open var matchValueLineColorToPieSlice: Bool = false
+    open var valueLineAutoColor: Bool = false
 
     /// When valuePosition is OutsideSlice, indicates line width
     open var valueLineWidth: CGFloat = 1.0

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
@@ -85,7 +85,7 @@ open class PieChartDataSet: ChartDataSet, IPieChartDataSet
     open var valueLineColor: NSUIColor? = NSUIColor.black
 
     /// When valuePosition is OutsideSlice and enabled, line will have the same color as the slice
-    open var valueLineAutoColor: Bool = false
+    open var useValueColorForLine: Bool = false
 
     /// When valuePosition is OutsideSlice, indicates line width
     open var valueLineWidth: CGFloat = 1.0

--- a/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
@@ -39,7 +39,7 @@ public protocol IPieChartDataSet: IChartDataSet
     var valueLineColor: NSUIColor? { get set }
 
     /// When valuePosition is OutsideSlice and enabled, line will have the same color as the slice
-    var matchValueLineColorToPieSlice: Bool { get set }
+    var valueLineAutoColor: Bool { get set }
 
     /// When valuePosition is OutsideSlice, indicates line width
     var valueLineWidth: CGFloat { get set }

--- a/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
@@ -39,7 +39,7 @@ public protocol IPieChartDataSet: IChartDataSet
     var valueLineColor: NSUIColor? { get set }
 
     /// When valuePosition is OutsideSlice and enabled, line will have the same color as the slice
-    var valueLineAutoColor: Bool { get set }
+    var useValueColorForLine: Bool { get set }
 
     /// When valuePosition is OutsideSlice, indicates line width
     var valueLineWidth: CGFloat { get set }

--- a/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
@@ -38,6 +38,9 @@ public protocol IPieChartDataSet: IChartDataSet
     /// When valuePosition is OutsideSlice, indicates line color
     var valueLineColor: NSUIColor? { get set }
 
+    /// When valuePosition is OutsideSlice and enabled, line will have the same color as the slice
+    var matchValueLineColorToPieSlice: Bool { get set }
+
     /// When valuePosition is OutsideSlice, indicates line width
     var valueLineWidth: CGFloat { get set }
 

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -438,15 +438,13 @@ open class PieChartRenderer: DataRenderer
                         labelPoint = CGPoint(x: pt2.x + 5, y: pt2.y - lineHeight)
                     }
 
-                    if dataSet.valueLineColor != nil
-                    {
-                        if dataSet.useValueColorForLine
-                        {
+                    do {
+                        if dataSet.useValueColorForLine {
                             context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
-                        }
-                        else
-                        {
-                            context.setStrokeColor(dataSet.valueLineColor!.cgColor)
+                        } else if let valueLineColor = dataSet.valueLineColor {
+                            context.setStrokeColor(valueLineColor.cgColor)
+                        } else {
+                            return
                         }
                         context.setLineWidth(dataSet.valueLineWidth)
 
@@ -456,7 +454,7 @@ open class PieChartRenderer: DataRenderer
 
                         context.drawPath(using: CGPathDrawingMode.stroke)
                     }
-
+                    
                     if drawXOutside && drawYOutside
                     {
                         ChartUtils.drawText(

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -440,7 +440,11 @@ open class PieChartRenderer: DataRenderer
 
                     if dataSet.valueLineColor != nil
                     {
-                        context.setStrokeColor(dataSet.valueLineColor!.cgColor)
+                        if dataSet.matchValueLineColorToPieSlice {
+                            context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
+                        } else {
+                            context.setStrokeColor(dataSet.valueLineColor!.cgColor)
+                        }
                         context.setLineWidth(dataSet.valueLineWidth)
 
                         context.move(to: CGPoint(x: pt0.x, y: pt0.y))

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -440,9 +440,12 @@ open class PieChartRenderer: DataRenderer
 
                     if dataSet.valueLineColor != nil
                     {
-                        if dataSet.useValueColorForLine {
+                        if dataSet.useValueColorForLine
+                        {
                             context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
-                        } else {
+                        }
+                        else
+                        {
                             context.setStrokeColor(dataSet.valueLineColor!.cgColor)
                         }
                         context.setLineWidth(dataSet.valueLineWidth)

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -440,7 +440,7 @@ open class PieChartRenderer: DataRenderer
 
                     if dataSet.valueLineColor != nil
                     {
-                        if dataSet.valueLineAutoColor {
+                        if dataSet.useValueColorForLine {
                             context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
                         } else {
                             context.setStrokeColor(dataSet.valueLineColor!.cgColor)

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -438,7 +438,7 @@ open class PieChartRenderer: DataRenderer
                         labelPoint = CGPoint(x: pt2.x + 5, y: pt2.y - lineHeight)
                     }
 
-                    do
+                    DrawLine: do
                     {
                         if dataSet.useValueColorForLine
                         {

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -438,12 +438,18 @@ open class PieChartRenderer: DataRenderer
                         labelPoint = CGPoint(x: pt2.x + 5, y: pt2.y - lineHeight)
                     }
 
-                    do {
-                        if dataSet.useValueColorForLine {
+                    do
+                    {
+                        if dataSet.useValueColorForLine
+                        {
                             context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
-                        } else if let valueLineColor = dataSet.valueLineColor {
+                        }
+                        else if let valueLineColor = dataSet.valueLineColor
+                        {
                             context.setStrokeColor(valueLineColor.cgColor)
-                        } else {
+                        }
+                        else
+                        {
                             return
                         }
                         context.setLineWidth(dataSet.valueLineWidth)

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -440,7 +440,7 @@ open class PieChartRenderer: DataRenderer
 
                     if dataSet.valueLineColor != nil
                     {
-                        if dataSet.matchValueLineColorToPieSlice {
+                        if dataSet.valueLineAutoColor {
                             context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
                         } else {
                             context.setStrokeColor(dataSet.valueLineColor!.cgColor)


### PR DESCRIPTION
This change adds a flag matchValueLineColorToPieSlice to PieChartDataSet and IPieChartDataSet protocol.

When enabled, valuelines will have the same color as slices they attached to.
matchValueLineColorToPieSlice is set to false by default, so colors won't be changed in old projects that use Charts.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
https://github.com/danielgindi/Charts/issues/3480

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
To be able to draw valueLines with the same color as slices they come from. 
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
A bool flag gives an option to use the same color for all valueLines or different colors matching a corresponding pie slice color. 
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Tested using sample project. 

 ```
set.matchValueLineColorToPieSlice = true
```

![simulator screen shot - iphone x - 2018-10-23 at 18 39 10](https://user-images.githubusercontent.com/8983928/47405246-ae6a6880-d71e-11e8-8435-bcfb70d8c45d.png)
