### PR TITLE
Fix wrong assignment to axisMaxLabels property

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -220,7 +220,7 @@ open class AxisBase: ComponentBase
     
     /// The maximum number of labels on the axis
     @objc open var axisMaxLabels = Int(25) {
-        didSet { axisMinLabels = axisMaxLabels > 0 ? axisMaxLabels : oldValue }
+        didSet { axisMaxLabels = axisMaxLabels > 0 ? axisMaxLabels : oldValue }
     }
     
     /// the number of label entries the axis should have


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/3656

### Goals :soccer:
Ensure that the max number of labels in the Y Axis is correct.

### Implementation Details :construction:
I'm just changing the wrong assignment.

### Testing Details :mag:
I didn't added any tests, but if necessary please let me know