### PR TITLE
Fix legend offset bug for horizontal bar chart (Fixes #3301)

### DIFF
--- a/Source/Charts/Charts/HorizontalBarChartView.swift
+++ b/Source/Charts/Charts/HorizontalBarChartView.swift
@@ -39,7 +39,7 @@ open class HorizontalBarChartView: BarChartView
         guard
             let legend = _legend,
             legend.isEnabled,
-            legend.drawInside
+            !legend.drawInside
         else { return }
         
         // setup offsets for legend


### PR DESCRIPTION
### Issue Link :link:
Horizontal Bar Chart legend issue #3301

### Goals :soccer:
This PR fixes the legend offset issue in case of horizontal bar charts.

### Implementation Details :construction:
The guard conditions in the method `calculateLegendOffsets` in the file `HorizontalBarChartView.swift` were wrong.

### Testing Details :mag:
Tested in own app.