### PR TITLE
Fix applying lineCap value for line chart data sets (Fixes #3739)

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -73,6 +73,8 @@ open class LineChartRenderer: LineRadarRenderer
             context.setLineDash(phase: 0.0, lengths: [])
         }
         
+        context.setLineCap(dataSet.lineCapType)
+        
         // if drawing cubic lines is enabled
         switch dataSet.mode
         {
@@ -313,8 +315,6 @@ open class LineChartRenderer: LineRadarRenderer
         }
         
         context.saveGState()
-        
-        context.setLineCap(dataSet.lineCapType)
 
         // more than 1 color
         if dataSet.colors.count > 1


### PR DESCRIPTION
DataSets for line chart have lineCap property which is supposed to be applied to the chart line. But it was applied only if dataSet is drawn in linear/stepped mode. This commit makes lineCap work for any existing mode.

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/3739

### Goals :soccer:
Make it possible to use lineCap property of DataSet for line chart in any mode

### Implementation Details :construction:
Moved setting lineCap to drawDataSet method

### Testing Details :mag:
tested on sample app (just changed line width in example app and tried different combinations of mode-lineCap)