### PR TITLE
Fixes sharp edges on the line chart

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -316,123 +316,63 @@ open class LineChartRenderer: LineRadarRenderer
         
         context.saveGState()
 
-        // more than 1 color
-        if dataSet.colors.count > 1
-        {
             if _lineSegments.count != pointsPerEntryPair
             {
                 // Allocate once in correct size
                 _lineSegments = [CGPoint](repeating: CGPoint(), count: pointsPerEntryPair)
             }
             
-            for j in stride(from: _xBounds.min, through: _xBounds.range + _xBounds.min, by: 1)
+        for j in stride(from: _xBounds.min, through: _xBounds.range + _xBounds.min, by: 1)
+        {
+            var e: ChartDataEntry! = dataSet.entryForIndex(j)
+            
+            if e == nil { continue }
+            
+            _lineSegments[0].x = CGFloat(e.x)
+            _lineSegments[0].y = CGFloat(e.y * phaseY)
+            
+            if j < _xBounds.max
             {
-                var e: ChartDataEntry! = dataSet.entryForIndex(j)
+                e = dataSet.entryForIndex(j + 1)
                 
-                if e == nil { continue }
+                if e == nil { break }
                 
-                _lineSegments[0].x = CGFloat(e.x)
-                _lineSegments[0].y = CGFloat(e.y * phaseY)
-                
-                if j < _xBounds.max
+                if isDrawSteppedEnabled
                 {
-                    e = dataSet.entryForIndex(j + 1)
-                    
-                    if e == nil { break }
-                    
-                    if isDrawSteppedEnabled
-                    {
-                        _lineSegments[1] = CGPoint(x: CGFloat(e.x), y: _lineSegments[0].y)
-                        _lineSegments[2] = _lineSegments[1]
-                        _lineSegments[3] = CGPoint(x: CGFloat(e.x), y: CGFloat(e.y * phaseY))
-                    }
-                    else
-                    {
-                        _lineSegments[1] = CGPoint(x: CGFloat(e.x), y: CGFloat(e.y * phaseY))
-                    }
+                    _lineSegments[1] = CGPoint(x: CGFloat(e.x), y: _lineSegments[0].y)
+                    _lineSegments[2] = _lineSegments[1]
+                    _lineSegments[3] = CGPoint(x: CGFloat(e.x), y: CGFloat(e.y * phaseY))
                 }
                 else
                 {
-                    _lineSegments[1] = _lineSegments[0]
+                    _lineSegments[1] = CGPoint(x: CGFloat(e.x), y: CGFloat(e.y * phaseY))
                 }
-
-                for i in 0..<_lineSegments.count
-                {
-                    _lineSegments[i] = _lineSegments[i].applying(valueToPixelMatrix)
-                }
-                
-                if (!viewPortHandler.isInBoundsRight(_lineSegments[0].x))
-                {
-                    break
-                }
-                
-                // make sure the lines don't do shitty things outside bounds
-                if !viewPortHandler.isInBoundsLeft(_lineSegments[1].x)
-                    || (!viewPortHandler.isInBoundsTop(_lineSegments[0].y) && !viewPortHandler.isInBoundsBottom(_lineSegments[1].y))
-                {
-                    continue
-                }
-                
-                // get the color that is set for this line-segment
-                context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
-                context.strokeLineSegments(between: _lineSegments)
             }
-        }
-        else
-        { // only one color per dataset
-            
-            var e1: ChartDataEntry!
-            var e2: ChartDataEntry!
-            
-            e1 = dataSet.entryForIndex(_xBounds.min)
-            
-            if e1 != nil
+            else
             {
-                context.beginPath()
-                var firstPoint = true
-                
-                for x in stride(from: _xBounds.min, through: _xBounds.range + _xBounds.min, by: 1)
-                {
-                    e1 = dataSet.entryForIndex(x == 0 ? 0 : (x - 1))
-                    e2 = dataSet.entryForIndex(x)
-                    
-                    if e1 == nil || e2 == nil { continue }
-                    
-                    let pt = CGPoint(
-                        x: CGFloat(e1.x),
-                        y: CGFloat(e1.y * phaseY)
-                        ).applying(valueToPixelMatrix)
-                    
-                    if firstPoint
-                    {
-                        context.move(to: pt)
-                        firstPoint = false
-                    }
-                    else
-                    {
-                        context.addLine(to: pt)
-                    }
-                    
-                    if isDrawSteppedEnabled
-                    {
-                        context.addLine(to: CGPoint(
-                            x: CGFloat(e2.x),
-                            y: CGFloat(e1.y * phaseY)
-                            ).applying(valueToPixelMatrix))
-                    }
-                    
-                    context.addLine(to: CGPoint(
-                            x: CGFloat(e2.x),
-                            y: CGFloat(e2.y * phaseY)
-                        ).applying(valueToPixelMatrix))
-                }
-                
-                if !firstPoint
-                {
-                    context.setStrokeColor(dataSet.color(atIndex: 0).cgColor)
-                    context.strokePath()
-                }
+                _lineSegments[1] = _lineSegments[0]
             }
+
+            for i in 0..<_lineSegments.count
+            {
+                _lineSegments[i] = _lineSegments[i].applying(valueToPixelMatrix)
+            }
+            
+            if (!viewPortHandler.isInBoundsRight(_lineSegments[0].x))
+            {
+                break
+            }
+            
+            // make sure the lines don't do shitty things outside bounds
+            if !viewPortHandler.isInBoundsLeft(_lineSegments[1].x)
+                || (!viewPortHandler.isInBoundsTop(_lineSegments[0].y) && !viewPortHandler.isInBoundsBottom(_lineSegments[1].y))
+            {
+                continue
+            }
+            
+            // get the color that is set for this line-segment
+            context.setStrokeColor(dataSet.color(atIndex: j).cgColor)
+            context.strokeLineSegments(between: _lineSegments)
         }
         
         context.restoreGState()


### PR DESCRIPTION

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/2180

### Goals :soccer:
This fixes the sharpness to some of the connected data points for the line charts.

### Implementation Details :construction:
When a line is drawn, vertices need to be extended to account for sharp angles, to avoid the long vertices the app needs to draw each line 1 at a time (the way it already does for line charts with more than 1 color for their lines).

**Note that existing users may have to update their line cap type to rounded** because when each line is drawn 1 at a time there can be very small open space between connected lines (this already exists for line charts with more than 1 color)

### Testing Details :mag:
**-----Before-----**
![before fix](https://user-images.githubusercontent.com/8028662/49322774-641b9a80-f4c7-11e8-9483-ce38dae40efb.png)

**-----After-----**
![after fix](https://user-images.githubusercontent.com/8028662/49322777-6a117b80-f4c7-11e8-9c3e-4fb3847bf0eb.png)
