### PR TITLE
add chartScaled() call after double tap in BarLineChartViewBase

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -573,8 +573,12 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 {
                     location.y = -(self.bounds.size.height - location.y - _viewPortHandler.offsetBottom)
                 }
-                
-                self.zoom(scaleX: isScaleXEnabled ? 1.4 : 1.0, scaleY: isScaleYEnabled ? 1.4 : 1.0, x: location.x, y: location.y)
+
+                let scaleX: CGFloat = isScaleXEnabled ? 1.4 : 1.0
+                let scaleY: CGFloat = isScaleYEnabled ? 1.4 : 1.0
+
+                self.zoom(scaleX: scaleX, scaleY: scaleY, x: location.x, y: location.y)
+                delegate?.chartScaled?(self, scaleX: scaleX, scaleY: scaleY)
             }
         }
     }


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
chartScaled() func from ChartViewDelegate should be called after performing double tap

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
I use chartScaled() func from ChartViewDelegate and found that it doesn't called after performing double tap. I see explanation before chartScaled() which says that it callbacks when the chart is scaled / zoomed via pinch zoom gesture, but zoom() func is called after double tap in BarLineChartViewBase, so I think it's logical to add this functionality. If you don't like this solution then maybe other possible way is to add chartZoomed() or chartDoubleTapped() to ChartViewDelegate

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->