### PR TITLE
Add lineJoinType and miterLimit parameters to LineChartDataSet (fixes #2180 )

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
@@ -135,6 +135,12 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
     /// Line cap type, default is CGLineCap.Butt
     open var lineCapType = CGLineCap.butt
     
+    /// Line cap type, default is CGLineJoin.miter
+    open var lineJoinType: CGLineJoin = .miter
+    
+    /// Miter limit value used when `lineJoinType` is set to `CGLineJoin.miter`, default is `CGFloat = .greatestFiniteMagnitude`
+    open var lineMiterLimit: CGFloat = .greatestFiniteMagnitude
+    
     /// formatter for customizing the position of the fill-line
     private var _fillFormatter: IFillFormatter = DefaultFillFormatter()
     

--- a/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
@@ -75,6 +75,12 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     /// Line cap type, default is CGLineCap.Butt
     var lineCapType: CGLineCap { get set }
     
+    /// Line cap type, default is CGLineJoin.miter
+    var lineJoinType: CGLineJoin { get set }
+    
+    /// Miter limit value used when `lineJoinType` is set to `CGLineJoin.miter`, default is `CGFloat = .greatestFiniteMagnitude`
+    var lineMiterLimit: CGFloat { get set }
+    
     /// Sets a custom IFillFormatter to the chart that handles the position of the filled-line for each DataSet. Set this to null to use the default logic.
     var fillFormatter: IFillFormatter? { get set }
 }

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -74,6 +74,10 @@ open class LineChartRenderer: LineRadarRenderer
         }
         
         context.setLineCap(dataSet.lineCapType)
+        context.setLineJoin(dataSet.lineJoinType)
+        if dataSet.lineJoinType == .miter {
+            context.setMiterLimit(dataSet.lineMiterLimit)
+        }
         
         // if drawing cubic lines is enabled
         switch dataSet.mode


### PR DESCRIPTION
let users fix sharp edges the way they want, keeping default behaviour same as current.

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/2180

### Implementation Details :construction:
There is another PR that is made to solve same issue but it changes the default behaviour and actually also breaks line joins when `lineCapType` is not `.round`. This PR is another way to solve that problem, but it also not ideal - multicolored line will not use introduced `lineJoinType` property because of tricky way to draw that line (actually that tricky way leads to bad line when `lineCapType` is not `.round`) 