### PR TITLE
Fix condition that is checked before `chartTranslated` delegate method call

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -816,7 +816,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         
         matrix = _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
         
-        if delegate !== nil
+        if matrix != originalMatrix
         {
             delegate?.chartTranslated?(self, dX: translation.x, dY: translation.y)
         }


### PR DESCRIPTION
### Issue Link :link:
#3803 

### Goals :soccer:
eliminate not needed `chartTranslated` delegate method calls

### Implementation Details :construction:
Removed check if delegate is not nil because it's already done in next line by `?` operator
Added check that transformation matrix has really been changed before `chartTranslated` call