### PR TITLE
HorizontalBarChar value label offset calculation 

### DIFF
--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -393,7 +393,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                         // calculate the correct offset depending on the draw position of the value
                         let valueTextWidth = valueText.size(withAttributes: [NSAttributedString.Key.font: valueFont]).width
                         posOffset = (drawValueAboveBar ? valueOffsetPlus : -(valueTextWidth + valueOffsetPlus))
-                        negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus)
+                        negOffset = (drawValueAboveBar ? -(valueTextWidth + valueOffsetPlus) : valueOffsetPlus) - rect.size.width
                         
                         if isInverted
                         {


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/3850

### Goals :soccer:
Improve HorizontalBarChart offset calculation for negative value labels.

### Implementation Details :construction:
Just subtract the bar width from negative offset calculation. 

### Testing Details :mag:
Tested with positive and negative value set, value icons, drawValueAboveBarEnabled (true/false)