### PR TITLE
Reassess convenience initializers

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -37,21 +37,25 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for normal bars (not stacked).
-    public override init(x: Double, y: Double, data: AnyObject?)
+    public convenience init(x: Double, y: Double, data: AnyObject?)
     {
-        super.init(x: x, y: y, data: data)
+        self.init(x: x, y: y)
+        self.data = data
     }
     
     /// Constructor for normal bars (not stacked).
-    public override init(x: Double, y: Double, icon: NSUIImage?)
+    public convenience init(x: Double, y: Double, icon: NSUIImage?)
     {
-        super.init(x: x, y: y, icon: icon)
+        self.init(x: x, y: y)
+        self.icon = icon
     }
     
     /// Constructor for normal bars (not stacked).
-    public override init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
+    public convenience init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
     {
-        super.init(x: x, y: y, icon: icon, data: data)
+        self.init(x: x, y: y)
+        self.icon = icon
+        self.data = data
     }
     
     /// Constructor for stacked bar entries.
@@ -62,32 +66,27 @@ open class BarChartDataEntry: ChartDataEntry
         calcPosNegSum()
         calcRanges()
     }
-        
+
     /// Constructor for stacked bar entries. One data object for whole stack
-    @objc public init(x: Double, yValues: [Double], data: AnyObject?)
+    @objc public convenience init(x: Double, yValues: [Double], icon: NSUIImage?)
     {
-        super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), data: data)
-        self._yVals = yValues
-        calcPosNegSum()
-        calcRanges()
+        self.init(x: x, yValues: yValues)
+        self.icon = icon
     }
-    
+
     /// Constructor for stacked bar entries. One data object for whole stack
-    @objc public init(x: Double, yValues: [Double], icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, yValues: [Double], data: AnyObject?)
     {
-        super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), icon: icon, data: data)
-        self._yVals = yValues
-        calcPosNegSum()
-        calcRanges()
+        self.init(x: x, yValues: yValues)
+        self.data = data
     }
-    
+
     /// Constructor for stacked bar entries. One data object for whole stack
-    @objc public init(x: Double, yValues: [Double], icon: NSUIImage?)
+    @objc public convenience init(x: Double, yValues: [Double], icon: NSUIImage?, data: AnyObject?)
     {
-        super.init(x: x, y: BarChartDataEntry.calcSum(values: yValues), icon: icon)
-        self._yVals = yValues
-        calcPosNegSum()
-        calcRanges()
+        self.init(x: x, yValues: yValues)
+        self.icon = icon
+        self.data = data
     }
     
     @objc open func sumBelow(stackIndex :Int) -> Double

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -122,30 +122,13 @@ open class BarChartDataEntry: ChartDataEntry
 
     @objc open func calcPosNegSum()
     {
-        guard let _yVals = _yVals else
-        {
-            _positiveSum = 0.0
-            _negativeSum = 0.0
-            return
-        }
-        
-        var sumNeg: Double = 0.0
-        var sumPos: Double = 0.0
-        
-        for f in _yVals
-        {
-            if f < 0.0
-            {
-                sumNeg += -f
+        (_negativeSum, _positiveSum) = _yVals?.reduce(into: (0,0)) { (result, y) in
+            if y < 0 {
+                result.0 += -y
+            } else {
+                result.1 += y
             }
-            else
-            {
-                sumPos += f
-            }
-        }
-        
-        _negativeSum = sumNeg
-        _positiveSum = sumPos
+        } ?? (0,0)
     }
     
     /// Splits up the stack-values of the given bar-entry into Range objects.
@@ -155,38 +138,34 @@ open class BarChartDataEntry: ChartDataEntry
     /// - Returns:
     @objc open func calcRanges()
     {
-        let values = yValues
-        if values?.isEmpty != false
-        {
+        guard let values = yValues, !values.isEmpty else {
             return
         }
-        
+
         if _ranges == nil
         {
             _ranges = [Range]()
         }
         else
         {
-            _ranges?.removeAll()
+            _ranges!.removeAll()
         }
         
-        _ranges?.reserveCapacity(values!.count)
+        _ranges!.reserveCapacity(values.count)
         
         var negRemain = -negativeSum
         var posRemain: Double = 0.0
         
-        for i in 0 ..< values!.count
+        for value in values
         {
-            let value = values![i]
-            
             if value < 0
             {
-                _ranges?.append(Range(from: negRemain, to: negRemain - value))
+                _ranges!.append(Range(from: negRemain, to: negRemain - value))
                 negRemain -= value
             }
             else
             {
-                _ranges?.append(Range(from: posRemain, to: posRemain + value))
+                _ranges!.append(Range(from: posRemain, to: posRemain + value))
                 posRemain += value
             }
         }

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -123,9 +123,12 @@ open class BarChartDataEntry: ChartDataEntry
     @objc open func calcPosNegSum()
     {
         (_negativeSum, _positiveSum) = _yVals?.reduce(into: (0,0)) { (result, y) in
-            if y < 0 {
+            if y < 0
+            {
                 result.0 += -y
-            } else {
+            }
+            else
+            {
                 result.1 += y
             }
         } ?? (0,0)
@@ -138,9 +141,7 @@ open class BarChartDataEntry: ChartDataEntry
     /// - Returns:
     @objc open func calcRanges()
     {
-        guard let values = yValues, !values.isEmpty else {
-            return
-        }
+        guard let values = yValues, !values.isEmpty else { return }
 
         if _ranges == nil
         {

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
@@ -38,11 +38,10 @@ open class BubbleChartDataEntry: ChartDataEntry
     ///   - y: The value on the y-axis.
     ///   - size: The size of the bubble.
     ///   - data: Spot for additional data this Entry represents.
-    @objc public init(x: Double, y: Double, size: CGFloat, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, size: CGFloat, data: AnyObject?)
     {
-        super.init(x: x, y: y, data: data)
-        
-        self.size = size
+        self.init(x: x, y: y, size: size)
+        self.data = data
     }
     
     /// - Parameters:
@@ -50,11 +49,10 @@ open class BubbleChartDataEntry: ChartDataEntry
     ///   - y: The value on the y-axis.
     ///   - size: The size of the bubble.
     ///   - icon: icon image
-    @objc public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?)
+    @objc public convenience init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?)
     {
-        super.init(x: x, y: y, icon: icon)
-        
-        self.size = size
+        self.init(x: x, y: y, size: size)
+        self.icon = icon
     }
     
     /// - Parameters:
@@ -63,11 +61,11 @@ open class BubbleChartDataEntry: ChartDataEntry
     ///   - size: The size of the bubble.
     ///   - icon: icon image
     ///   - data: Spot for additional data this Entry represents.
-    @objc public init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: AnyObject?)
     {
-        super.init(x: x, y: y, icon: icon, data: data)
-        
-        self.size = size
+        self.init(x: x, y: y, size: size)
+        self.icon = icon
+        self.data = data
     }
     
     // MARK: NSCopying

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
@@ -39,35 +39,24 @@ open class CandleChartDataEntry: ChartDataEntry
         self.open = open
         self.close = close
     }
-    
-    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, data: AnyObject?)
+
+    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?)
     {
-        super.init(x: x, y: (shadowH + shadowL) / 2.0, data: data)
-        
-        self.high = shadowH
-        self.low = shadowL
-        self.open = open
-        self.close = close
+        self.init(x: x, shadowH: shadowH, shadowL: shadowL, open: open, close: close)
+        self.icon = icon
     }
-    
-    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?)
+
+    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, data: AnyObject?)
     {
-        super.init(x: x, y: (shadowH + shadowL) / 2.0, icon: icon)
-        
-        self.high = shadowH
-        self.low = shadowL
-        self.open = open
-        self.close = close
+        self.init(x: x, shadowH: shadowH, shadowL: shadowL, open: open, close: close)
+        self.data = data
     }
-    
-    @objc public init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?, data: AnyObject?)
+
+    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?, data: AnyObject?)
     {
-        super.init(x: x, y: (shadowH + shadowL) / 2.0, icon: icon, data: data)
-        
-        self.high = shadowH
-        self.low = shadowL
-        self.open = open
-        self.close = close
+        self.init(x: x, shadowH: shadowH, shadowL: shadowL, open: open, close: close)
+        self.icon = icon
+        self.data = data
     }
     
     /// The overall range (difference) between shadow-high and shadow-low.

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -14,7 +14,7 @@ import Foundation
 open class ChartDataEntry: ChartDataEntryBase, NSCopying
 {
     /// the x value
-    @objc open var x = Double(0.0)
+    @objc open var x = 0.0
     
     public required init()
     {
@@ -29,7 +29,6 @@ open class ChartDataEntry: ChartDataEntryBase, NSCopying
     @objc public init(x: Double, y: Double)
     {
         super.init(y: y)
-        
         self.x = x
     }
     
@@ -40,12 +39,9 @@ open class ChartDataEntry: ChartDataEntryBase, NSCopying
     ///   - y: the y value (the actual value of the entry)
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public init(x: Double, y: Double, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, data: AnyObject?)
     {
-        super.init(y: y)
-        
-        self.x = x
-        
+        self.init(x: x, y: y)
         self.data = data
     }
     
@@ -56,11 +52,10 @@ open class ChartDataEntry: ChartDataEntryBase, NSCopying
     ///   - y: the y value (the actual value of the entry)
     ///   - icon: icon image
     
-    @objc public init(x: Double, y: Double, icon: NSUIImage?)
+    @objc public convenience init(x: Double, y: Double, icon: NSUIImage?)
     {
-        super.init(y: y, icon: icon)
-        
-        self.x = x
+        self.init(x: x, y: y)
+        self.icon = icon
     }
     
     /// An Entry represents one single entry in the chart.
@@ -71,11 +66,11 @@ open class ChartDataEntry: ChartDataEntryBase, NSCopying
     ///   - icon: icon image
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
     {
-        super.init(y: y, icon: icon, data: data)
-        
-        self.x = x
+        self.init(x: x, y: y)
+        self.icon = icon
+        self.data = data
     }
         
     // MARK: NSObject

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -14,7 +14,7 @@ import Foundation
 open class ChartDataEntryBase: NSObject
 {
     /// the y value
-    @objc open var y = Double(0.0)
+    @objc open var y = 0.0
     
     /// optional spot for additional data this Entry represents
     @objc open var data: AnyObject?
@@ -42,11 +42,10 @@ open class ChartDataEntryBase: NSObject
     ///   - y: the y value (the actual value of the entry)
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public init(y: Double, data: AnyObject?)
+    @objc public convenience init(y: Double, data: AnyObject?)
     {
-        super.init()
+        self.init(y: y)
         
-        self.y = y
         self.data = data
     }
     
@@ -54,11 +53,10 @@ open class ChartDataEntryBase: NSObject
     ///   - y: the y value (the actual value of the entry)
     ///   - icon: icon image
     
-    @objc public init(y: Double, icon: NSUIImage?)
+    @objc public convenience init(y: Double, icon: NSUIImage?)
     {
-        super.init()
-        
-        self.y = y
+        self.init(y: y)
+
         self.icon = icon
     }
     
@@ -67,11 +65,10 @@ open class ChartDataEntryBase: NSObject
     ///   - icon: icon image
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public init(y: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(y: Double, icon: NSUIImage?, data: AnyObject?)
     {
-        super.init()
-        
-        self.y = y
+        self.init(y: y)
+
         self.icon = icon
         self.data = data
     }

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
@@ -19,12 +19,21 @@ open class PieChartDataEntry: ChartDataEntry
         super.init()
     }
     
+
+    /// - Parameters:
+    ///   - value: The value on the y-axis
+    @objc public init(value: Double)
+    {
+        super.init(x: .nan, y: value)
+    }
+
     /// - Parameters:
     ///   - value: The value on the y-axis
     ///   - label: The label for the x-axis
     @objc public convenience init(value: Double, label: String?)
     {
-        self.init(value: value, label: label, icon: nil, data: nil)
+        self.init(value: value)
+        self.label = label
     }
     
     /// - Parameters:
@@ -42,7 +51,9 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - icon: icon image
     @objc public convenience init(value: Double, label: String?, icon: NSUIImage?)
     {
-        self.init(value: value, label: label, icon: icon, data: nil)
+        self.init(value: value)
+        self.label = label
+        self.icon = icon
     }
     
     /// - Parameters:
@@ -50,26 +61,21 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - label: The label for the x-axis
     ///   - icon: icon image
     ///   - data: Spot for additional data this Entry represents
-    @objc public init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
     {
-        super.init(x: 0.0, y: value, icon: icon, data: data)
-        
+        self.init(value: value)
         self.label = label
+        self.icon = icon
+        self.data = data
     }
-    
-    /// - Parameters:
-    ///   - value: The value on the y-axis
-    @objc public convenience init(value: Double)
-    {
-        self.init(value: value, label: nil, icon: nil, data: nil)
-    }
-    
+
     /// - Parameters:
     ///   - value: The value on the y-axis
     ///   - data: Spot for additional data this Entry represents
     @objc public convenience init(value: Double, data: AnyObject?)
     {
-        self.init(value: value, label: nil, icon: nil, data: data)
+        self.init(value: value)
+        self.data = data
     }
     
     /// - Parameters:
@@ -77,7 +83,8 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - icon: icon image
     @objc public convenience init(value: Double, icon: NSUIImage?)
     {
-        self.init(value: value, label: nil, icon: icon, data: nil)
+        self.init(value: value)
+        self.icon = icon
     }
     
     /// - Parameters:
@@ -86,7 +93,9 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - data: Spot for additional data this Entry represents
     @objc public convenience init(value: Double, icon: NSUIImage?, data: AnyObject?)
     {
-        self.init(value: value, label: nil, icon: icon, data: data)
+        self.init(value: value)
+        self.icon = icon
+        self.data = data
     }
     
     // MARK: Data property accessors

--- a/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
@@ -18,20 +18,21 @@ open class RadarChartDataEntry: ChartDataEntry
     {
         super.init()
     }
-    
+
+    /// - Parameters:
+    ///   - value: The value on the y-axis.
+    @objc public init(value: Double)
+    {
+        super.init(x: .nan, y: value)
+    }
+
     /// - Parameters:
     ///   - value: The value on the y-axis.
     ///   - data: Spot for additional data this Entry represents.
-    @objc public init(value: Double, data: AnyObject?)
+    @objc public convenience init(value: Double, data: AnyObject?)
     {
-        super.init(x: 0.0, y: value, data: data)
-    }
-    
-    /// - Parameters:
-    ///   - value: The value on the y-axis.
-    @objc public convenience init(value: Double)
-    {
-        self.init(value: value, data: nil)
+        self.init(value: value)
+        self.data = data
     }
     
     // MARK: Data property accessors


### PR DESCRIPTION
The only data required to initialize an entry is an x and y value (or y in the case of Pie and Radar). All other data can easily be updated by initializing and assigning properties on the entry. Therefor, those initializers should be the ones marked as convenience. This also has the side effect of faster data set creation when only providing required data as those initializers no longer chain through to designated initializers.

Made initializer declarations consistent.