### PR TITLE
Data as any

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -37,7 +37,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for normal bars (not stacked).
-    public convenience init(x: Double, y: Double, data: AnyObject?)
+    public convenience init(x: Double, y: Double, data: Any?)
     {
         self.init(x: x, y: y)
         self.data = data
@@ -51,7 +51,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// Constructor for normal bars (not stacked).
-    public convenience init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
+    public convenience init(x: Double, y: Double, icon: NSUIImage?, data: Any?)
     {
         self.init(x: x, y: y)
         self.icon = icon
@@ -75,14 +75,14 @@ open class BarChartDataEntry: ChartDataEntry
     }
 
     /// Constructor for stacked bar entries. One data object for whole stack
-    @objc public convenience init(x: Double, yValues: [Double], data: AnyObject?)
+    @objc public convenience init(x: Double, yValues: [Double], data: Any?)
     {
         self.init(x: x, yValues: yValues)
         self.data = data
     }
 
     /// Constructor for stacked bar entries. One data object for whole stack
-    @objc public convenience init(x: Double, yValues: [Double], icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, yValues: [Double], icon: NSUIImage?, data: Any?)
     {
         self.init(x: x, yValues: yValues)
         self.icon = icon

--- a/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BubbleChartDataEntry.swift
@@ -38,7 +38,7 @@ open class BubbleChartDataEntry: ChartDataEntry
     ///   - y: The value on the y-axis.
     ///   - size: The size of the bubble.
     ///   - data: Spot for additional data this Entry represents.
-    @objc public convenience init(x: Double, y: Double, size: CGFloat, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, size: CGFloat, data: Any?)
     {
         self.init(x: x, y: y, size: size)
         self.data = data
@@ -61,7 +61,7 @@ open class BubbleChartDataEntry: ChartDataEntry
     ///   - size: The size of the bubble.
     ///   - icon: icon image
     ///   - data: Spot for additional data this Entry represents.
-    @objc public convenience init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, size: CGFloat, icon: NSUIImage?, data: Any?)
     {
         self.init(x: x, y: y, size: size)
         self.icon = icon

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
@@ -46,13 +46,13 @@ open class CandleChartDataEntry: ChartDataEntry
         self.icon = icon
     }
 
-    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, data: AnyObject?)
+    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, data: Any?)
     {
         self.init(x: x, shadowH: shadowH, shadowL: shadowL, open: open, close: close)
         self.data = data
     }
 
-    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, shadowH: Double, shadowL: Double, open: Double, close: Double, icon: NSUIImage?, data: Any?)
     {
         self.init(x: x, shadowH: shadowH, shadowL: shadowL, open: open, close: close)
         self.icon = icon

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -104,8 +104,7 @@ extension ChartDataEntry/*: Equatable*/ {
             return true
         }
 
-        return ((data == nil && object.data == nil) || (data?.isEqual(object.data) ?? false))
-            && y == object.y
+        return y == object.y
             && x == object.x
     }
 }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntry.swift
@@ -39,7 +39,7 @@ open class ChartDataEntry: ChartDataEntryBase, NSCopying
     ///   - y: the y value (the actual value of the entry)
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public convenience init(x: Double, y: Double, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, data: Any?)
     {
         self.init(x: x, y: y)
         self.data = data
@@ -66,7 +66,7 @@ open class ChartDataEntry: ChartDataEntryBase, NSCopying
     ///   - icon: icon image
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public convenience init(x: Double, y: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(x: Double, y: Double, icon: NSUIImage?, data: Any?)
     {
         self.init(x: x, y: y)
         self.icon = icon

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -17,7 +17,7 @@ open class ChartDataEntryBase: NSObject
     @objc open var y = 0.0
     
     /// optional spot for additional data this Entry represents
-    @objc open var data: AnyObject?
+    @objc open var data: Any?
     
     /// optional icon image
     @objc open var icon: NSUIImage?
@@ -91,7 +91,6 @@ extension ChartDataEntryBase/*: Equatable*/ {
             return true
         }
 
-        return ((data == nil && object.data == nil) || (data?.isEqual(object.data) ?? false))
-            && y == object.y
+        return y == object.y
     }
 }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataEntryBase.swift
@@ -42,7 +42,7 @@ open class ChartDataEntryBase: NSObject
     ///   - y: the y value (the actual value of the entry)
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public convenience init(y: Double, data: AnyObject?)
+    @objc public convenience init(y: Double, data: Any?)
     {
         self.init(y: y)
         
@@ -65,7 +65,7 @@ open class ChartDataEntryBase: NSObject
     ///   - icon: icon image
     ///   - data: Space for additional data this Entry represents.
     
-    @objc public convenience init(y: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(y: Double, icon: NSUIImage?, data: Any?)
     {
         self.init(y: y)
 

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataEntry.swift
@@ -40,7 +40,7 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - value: The value on the y-axis
     ///   - label: The label for the x-axis
     ///   - data: Spot for additional data this Entry represents
-    @objc public convenience init(value: Double, label: String?, data: AnyObject?)
+    @objc public convenience init(value: Double, label: String?, data: Any?)
     {
         self.init(value: value, label: label, icon: nil, data: data)
     }
@@ -61,7 +61,7 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - label: The label for the x-axis
     ///   - icon: icon image
     ///   - data: Spot for additional data this Entry represents
-    @objc public convenience init(value: Double, label: String?, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(value: Double, label: String?, icon: NSUIImage?, data: Any?)
     {
         self.init(value: value)
         self.label = label
@@ -72,7 +72,7 @@ open class PieChartDataEntry: ChartDataEntry
     /// - Parameters:
     ///   - value: The value on the y-axis
     ///   - data: Spot for additional data this Entry represents
-    @objc public convenience init(value: Double, data: AnyObject?)
+    @objc public convenience init(value: Double, data: Any?)
     {
         self.init(value: value)
         self.data = data
@@ -91,7 +91,7 @@ open class PieChartDataEntry: ChartDataEntry
     ///   - value: The value on the y-axis
     ///   - icon: icon image
     ///   - data: Spot for additional data this Entry represents
-    @objc public convenience init(value: Double, icon: NSUIImage?, data: AnyObject?)
+    @objc public convenience init(value: Double, icon: NSUIImage?, data: Any?)
     {
         self.init(value: value)
         self.icon = icon

--- a/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
@@ -29,7 +29,7 @@ open class RadarChartDataEntry: ChartDataEntry
     /// - Parameters:
     ///   - value: The value on the y-axis.
     ///   - data: Spot for additional data this Entry represents.
-    @objc public convenience init(value: Double, data: AnyObject?)
+    @objc public convenience init(value: Double, data: Any?)
     {
         self.init(value: value)
         self.data = data

--- a/Tests/Charts/EquatableTests.swift
+++ b/Tests/Charts/EquatableTests.swift
@@ -23,7 +23,7 @@ class EquatableTests: XCTestCase {
         let data1 = NSObject()
         let data2 = NSObject()
         let entry1 = ChartDataEntry(x: 5, y: 3, icon: image, data: data1)
-        let entry2 = ChartDataEntry(x: 5, y: 3, icon: image, data: data2)
+        let entry2 = ChartDataEntry(x: 5, y: 9, icon: image, data: data2)
 
         XCTAssertFalse(entry1 == entry2)
     }


### PR DESCRIPTION
There is no need to restrict `ChartEntry.data` to `AnyObject`. This PR loosens that restriction. As a result we cannot compare `data`, though this should never have been the case in the first place.