### PR TITLE
Use a stock iterator instead of a custom one.

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -102,22 +102,18 @@ extension BarLineScatterCandleBubbleRenderer.XBounds: RangeExpression {
 
 extension BarLineScatterCandleBubbleRenderer.XBounds: Sequence {
     public struct Iterator: IteratorProtocol {
-        private let bounds: BarLineScatterCandleBubbleRenderer.XBounds
-        private var value: Int
-
-        fileprivate init(bounds: BarLineScatterCandleBubbleRenderer.XBounds) {
-            self.bounds = bounds
-            self.value = bounds.min
+        private var iterator: IndexingIterator<ClosedRange<Int>>
+        
+        fileprivate init(min: Int, max: Int) {
+            self.iterator = (min...max).makeIterator()
         }
-
+        
         public mutating func next() -> Int? {
-            guard value < bounds.max else { return  nil }
-            value += 1
-            return value
+            return self.iterator.next()
         }
     }
-
+    
     public func makeIterator() -> Iterator {
-        return Iterator(bounds: self)
+        return Iterator(min: self.min, max: self.max)
     }
 }


### PR DESCRIPTION
Use a stock iterator instead of a custom one.

### Issue Link :link:
A fix for https://github.com/danielgindi/Charts/issues/3848

### Goals :soccer:
The first circle was not being drawn by the BarLineScatterCandleBubbleRenderer.
Example:
![Screen Shot 2019-03-08 at 5 52 14 PM](https://user-images.githubusercontent.com/63393/54060735-d3daa900-41cb-11e9-812c-ef496a55b539.png)

### Implementation Details :construction:
The previous iterator was skipping the first version. There is another PR (
https://github.com/danielgindi/Charts/pull/3865) out that I felt didn't address the situation in the best way possible.
Fixed:
![Screen Shot 2019-03-08 at 5 52 42 PM](https://user-images.githubusercontent.com/63393/54060768-ef45b400-41cb-11e9-98ff-f060c220339a.png)
