### PR TITLE
Deselect chart value upon highlighting already selected value

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -529,7 +529,15 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             }
             else
             {
-                _indicesToHighlight = [h!]
+                if (_indicesToHighlight == [h!])
+                {
+                    h = nil
+                    _indicesToHighlight.removeAll(keepingCapacity: false)
+                }
+                else
+                {
+                    _indicesToHighlight = [h!]
+                }
             }
         }
         


### PR DESCRIPTION
### Issue Link :link:
#3861 

### Goals :soccer:
When you select an already selected value, it will deselect the selected value rather than select it again. This is how MPAndroidChart behaves as well.

### Implementation Details :construction:
It checks if it will be the same and if so deselects instead

### Testing Details :mag:
No changes made to tests