### PR TITLE
Use public property of legend renderer instead of internal variable i…

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -269,7 +269,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
             renderer.drawValues(context: context)
         }
 
-        _legendRenderer.renderLegend(context: context)
+        legendRenderer.renderLegend(context: context)
 
         drawDescription(context: context)
         


### PR DESCRIPTION
…n order to be able to customize the legend

### Goals :soccer:
The goal is to be able to to customize the legend.

### Implementation Details :construction:
renderLegend method was not called on the custom legend renderer.