### PR TITLE
Added a safety check before an unsafe array operation

### DIFF
--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -880,7 +880,9 @@ open class PieChartRenderer: DataRenderer
 
         // Prepend selected slices before the already rendered unselected ones.
         // NOTE: - This relies on drawDataSet() being called before drawHighlighted in PieChartView.
-        accessibleChartElements.insert(contentsOf: highlightedAccessibleElements, at: 1)
+        if !accessibleChartElements.isEmpty {
+            accessibleChartElements.insert(contentsOf: highlightedAccessibleElements, at: 1)
+        }
 
         context.restoreGState()
     }

--- a/Source/Supporting Files/Info.plist
+++ b/Source/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>3.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Supporting Files/Info.plist
+++ b/Source/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.1</string>
+	<string>3.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### Issue Link :link:

https://github.com/danielgindi/Charts/issues/4001

### Goals :soccer:

This code change helps safeguard against hard crashes caused by an array operation.  It doesn't fix potential issues that could cause such a condition in the first place.

### Testing Details :mag:

I manually stepped through the attached demo project and verified the PieChart views looked and behaved as expected.