### PR TITLE
Fix fatal error with x values in reverse order

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -38,7 +38,7 @@ open class ChartDataSet: ChartBaseDataSet
     
     @objc public init(entries: [ChartDataEntry]?, label: String?)
     {
-        self.entries = entries ?? []
+        self.entries = entries?.sorted { $0.x < $1.x } ?? []
 
         super.init(label: label)
 
@@ -60,7 +60,11 @@ open class ChartDataSet: ChartBaseDataSet
     open var values: [ChartDataEntry] { return entries }
 
     @objc
-    open private(set) var entries: [ChartDataEntry]
+    open private(set) var entries: [ChartDataEntry] {
+        didSet {
+            entries.sort { $0.x < $1.x }
+        }
+    }
 
     /// Used to replace all entries of a data set while retaining styling properties.
     /// This is a separate method from a setter on `entries` to encourage usage


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

* https://github.com/danielgindi/Charts/issues/2884
* https://github.com/danielgindi/Charts/issues/3185

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Fixing bugs of the issues above and bugs as follows. Those bugs happen on `BarChartViewController` when you set entries which have x values in reverse order. A fatal error occurs on `BubbleChartViewController`, `CandleStickChartViewController`, `LineChart1ViewController` and `ScatterChartViewController` when you do the same things.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Arrays of `ChartDataEntry` should be sorted in an ascending order when you initialize `ChartDataSet` and whenever you set them again, for instance, using `replaceEntries(_:)`.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->