### PR TITLE
fixed stacked chart bug when there are different stacks on columns.

### DIFF
--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -867,9 +867,12 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             } else {
                 stackLabel = nil
             }
-
+            
+            //Handles empty array of yValues
+            let yValue = vals.isEmpty ? 0.0 : vals[idx % vals.count]
+            
             elementValueText = dataSet.valueFormatter?.stringForValue(
-                vals[idx % vals.count],
+                yValue,
                 entry: e,
                 dataSetIndex: dataSetIndex,
                 viewPortHandler: viewPortHandler) ?? "\(e.y)"

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -869,7 +869,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             }
 
             elementValueText = dataSet.valueFormatter?.stringForValue(
-                vals[idx % stackSize],
+                vals[idx % vals.count],
                 entry: e,
                 dataSetIndex: dataSetIndex,
                 viewPortHandler: viewPortHandler) ?? "\(e.y)"


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/3659

### Goals :soccer:
Fixing the issue, see link above.

### Implementation Details :construction:
Preventing the stacked bar chart from crashing when there was different number of stacks in columns.

### Testing Details :mag:
No test added, but i did test this against other chart views and confirmed that this fix did not make an affect on them.