### PR TITLE
Silence a bunch of warnings from Xcode

### DIFF
--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -749,11 +749,11 @@
 			};
 			buildConfigurationList = 493FF4FB1D40FC7C51DDDA6B /* Build configuration list for PBXProject "Charts" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 865A1CF149F52850CAB7F177;
 			productRefGroup = AB2D554102718F209377399E /* Products */;

--- a/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/RadarChartDataEntry.swift
@@ -40,7 +40,7 @@ open class RadarChartDataEntry: ChartDataEntry
     @objc open var value: Double
     {
         get { return y }
-        set { y = value }
+        set { y = newValue }
     }
     
     // MARK: NSCopying

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -482,7 +482,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 let barData = dataProvider.barData
                 else { return }
 
-            var dataSets = barData.dataSets
+            let dataSets = barData.dataSets
 
             let valueOffsetPlus: CGFloat = 4.5
             var posOffset: CGFloat

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -275,7 +275,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
         // if values are drawn
         if isDrawingValuesAllowed(dataProvider: dataProvider)
         {
-            var dataSets = candleData.dataSets
+            let dataSets = candleData.dataSets
             
             let phaseY = animator.phaseY
             

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -319,7 +319,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 let barData = dataProvider.barData
                 else { return }
             
-            var dataSets = barData.dataSets
+            let dataSets = barData.dataSets
             
             let textAlign = NSTextAlignment.left
             

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -39,7 +39,7 @@ open class LegendRenderer: Renderer
             {
                 guard let dataSet = data.getDataSetByIndex(i) else { continue }
                 
-                var clrs: [NSUIColor] = dataSet.colors
+                let clrs: [NSUIColor] = dataSet.colors
                 let entryCount = dataSet.entryCount
                 
                 // if we have a barchart with stacked bars
@@ -47,7 +47,7 @@ open class LegendRenderer: Renderer
                     (dataSet as! IBarChartDataSet).isStacked
                 {
                     let bds = dataSet as! IBarChartDataSet
-                    var sLabels = bds.stackLabels
+                    let sLabels = bds.stackLabels
                     let minEntries = min(clrs.count, bds.stackSize)
 
                     for j in 0..<minEntries
@@ -208,7 +208,7 @@ open class LegendRenderer: Renderer
         let labelLineHeight = labelFont.lineHeight
         let formYOffset = labelLineHeight / 2.0
 
-        var entries = legend.entries
+        let entries = legend.entries
         
         let defaultFormSize = legend.formSize
         let formToTextSpace = legend.formToTextSpace
@@ -296,9 +296,9 @@ open class LegendRenderer: Renderer
         {
         case .horizontal:
             
-            var calculatedLineSizes = legend.calculatedLineSizes
-            var calculatedLabelSizes = legend.calculatedLabelSizes
-            var calculatedLabelBreakPoints = legend.calculatedLabelBreakPoints
+            let calculatedLineSizes = legend.calculatedLineSizes
+            let calculatedLabelSizes = legend.calculatedLabelSizes
+            let calculatedLabelBreakPoints = legend.calculatedLabelBreakPoints
             
             var posX: CGFloat = originPosX
             var posY: CGFloat

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -445,7 +445,7 @@ open class LineChartRenderer: LineRadarRenderer
 
         if isDrawingValuesAllowed(dataProvider: dataProvider)
         {
-            var dataSets = lineData.dataSets
+            let dataSets = lineData.dataSets
             
             let phaseY = animator.phaseY
             

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -112,7 +112,7 @@ open class PieChartRenderer: DataRenderer
         let phaseY = animator.phaseY
 
         let entryCount = dataSet.entryCount
-        var drawAngles = chart.drawAngles
+        let drawAngles = chart.drawAngles
         let center = chart.centerCircleBox
         let radius = chart.radius
         let drawInnerArc = chart.drawHoleEnabled && !chart.drawSlicesUnderHoleEnabled
@@ -707,8 +707,8 @@ open class PieChartRenderer: DataRenderer
         var angle: CGFloat = 0.0
         let rotationAngle = chart.rotationAngle
 
-        var drawAngles = chart.drawAngles
-        var absoluteAngles = chart.absoluteAngles
+        let drawAngles = chart.drawAngles
+        let absoluteAngles = chart.absoluteAngles
         let center = chart.centerCircleBox
         let radius = chart.radius
         let drawInnerArc = chart.drawHoleEnabled && !chart.drawSlicesUnderHoleEnabled

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -209,7 +209,7 @@ open class YAxisRendererRadarChart: YAxisRenderer
             let data = chart.data
             else { return }
         
-        var limitLines = yAxis.limitLines
+        let limitLines = yAxis.limitLines
         
         if limitLines.count == 0
         {


### PR DESCRIPTION
### Goals :soccer:
Make Xcode not have a bunch of warnings in the sidebar.

### Implementation Details :construction:
Mostly just let xcode take the wheel. The one exception is that setter, which I think was actually incorrect before.

### Testing Details :mag:
Unfortunately Carthage isn't working correctly, so I wasn't able to run the tests. I was able to confirm that it still builds and works though.