### PR TITLE
Fix line chart x axis animation #4093, also close #3960

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -114,6 +114,14 @@ extension BarLineScatterCandleBubbleRenderer.XBounds: Sequence {
     }
     
     public func makeIterator() -> Iterator {
-        return Iterator(min: self.min, max: self.max)
+        return Iterator(min: self.min, max: self.min + self.range)
+    }
+}
+
+extension BarLineScatterCandleBubbleRenderer.XBounds: CustomDebugStringConvertible
+{
+    public var debugDescription: String
+    {
+        return "min:\(self.min), max:\(self.max), range:\(self.range)"
     }
 }

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -117,10 +117,8 @@ open class LineChartRenderer: LineRadarRenderer
             // Take an extra point from the left, and an extra from the right.
             // That's because we need 4 points for a cubic bezier (cubic=4), otherwise we get lines moving and doing weird stuff on the edges of the chart.
             // So in the starting `prev` and `cur`, go -2, -1
-            // And in the `lastIndex`, add +1
             
             let firstIndex = _xBounds.min + 1
-            let lastIndex = _xBounds.min + _xBounds.range
             
             var prevPrev: ChartDataEntry! = nil
             var prev: ChartDataEntry! = dataSet.entryForIndex(max(firstIndex - 2, 0))
@@ -133,7 +131,7 @@ open class LineChartRenderer: LineRadarRenderer
             // let the spline start
             cubicPath.move(to: CGPoint(x: CGFloat(cur.x), y: CGFloat(cur.y * phaseY)), transform: valueToPixelMatrix)
             
-            for j in stride(from: firstIndex, through: lastIndex, by: 1)
+            for j in _xBounds.dropFirst()  // same as firstIndex
             {
                 prevPrev = prev
                 prev = cur
@@ -316,8 +314,8 @@ open class LineChartRenderer: LineRadarRenderer
                 // Allocate once in correct size
                 _lineSegments = [CGPoint](repeating: CGPoint(), count: pointsPerEntryPair)
             }
-            
-        for j in stride(from: _xBounds.min, through: _xBounds.range + _xBounds.min, by: 1)
+
+        for j in _xBounds.dropLast()
         {
             var e: ChartDataEntry! = dataSet.entryForIndex(j)
             
@@ -328,6 +326,9 @@ open class LineChartRenderer: LineRadarRenderer
             
             if j < _xBounds.max
             {
+                // TODO: remove the check.
+                // With the new XBounds iterator, j is always smaller than _xBounds.max
+                // Keeping this check for a while, if xBounds have no further breaking changes, it should be safe to remove the check
                 e = dataSet.entryForIndex(j + 1)
                 
                 if e == nil { break }


### PR DESCRIPTION
1. change XBounds iterator to use self.min + self.range rather than self.x
2. align drawLinear,  drawCubicBezier to new XBounds iterator.
3. fix unexpected dash line during linear animation due to reading the next entry point

### Issue Link :link:
#4093, #3960

It seems to fix issue 3, the simple way is to call `for j in _xBounds.dropLast()` instead of `for j in _xBounds` so it ignores the last point, then j+1 will always be the last point to avoid additional dash line 