### PR TITLE
Handles NaN values (Fixes #3989)

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -278,6 +278,7 @@ open class ChartDataSet: ChartBaseDataSet
         closestToY yValue: Double,
         rounding: ChartDataSetRounding) -> Int
     {
+        guard xValue.isFinite else { return -1 }
         var low = startIndex
         var high = endIndex - 1
         var closest = high


### PR DESCRIPTION
Adds nan handling for the xValue of entryIndex(xValue:yValue:rounding)

### Issue Link :link:
#3989

### Goals :soccer:
This would be best described as not supporting default PieChartDataEntries that have their x values set to Nan. I'm don't think that is an issue, but passing a nan as the xValue should not cause an infinite loop.

### Implementation Details :construction:
Adds a guard statement to ensure `func entryIndex` does not enter a infinite loop

### Testing Details :mag:
`func entryIndex` should now support PieChartDataEntries with Nan xValues