### PR TITLE
SPM support for iOS, macOS, tvOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ fastlane/test_output
 Carthage
 Charts.framework.zip
 ChartsRealm.framework.zip
+.swiftpm/

--- a/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
+++ b/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2017 jc. All rights reserved.
 //
 
-import UIKit
+
 import Charts
+import UIKit
 
 enum Option {
     case toggleValues

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,18 @@
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
     name: "Charts",
+    platforms: [
+       .iOS(.v8),
+       .tvOS(.v9),
+       .macOS(.v10_11),
+    ],
     products: [
         .library(name: "Charts", type: .dynamic, targets: ["Charts"])
     ],
     dependencies: [],
     targets: [
-        .target(name: "Charts", dependencies: [])
-    ],
-    swiftLanguageVersions: [5]
+        .target(name: "Charts", dependencies: [], path: "./Source", publicHeadersPath: "./Source/Supporting Files")
+    ]
 )

--- a/Source/Charts/Animation/Animator.swift
+++ b/Source/Charts/Animation/Animator.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 @objc(ChartAnimatorDelegate)
 public protocol AnimatorDelegate

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 /// Base-class of LineChart, BarChart, ScatterChart and CandleStickChart.
 open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartDataProvider, NSUIGestureRecognizerDelegate

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -12,6 +12,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 @objc
 public protocol ChartViewDelegate

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 /// View that represents a pie chart. Draws cake like slices.
 open class PieChartView: PieRadarChartViewBase

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 /// Base class of PieChartView and RadarChartView.
 open class PieRadarChartViewBase: ChartViewBase

--- a/Source/Charts/Components/Description.swift
+++ b/Source/Charts/Components/Description.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 @objc(ChartDescription)
 open class Description: ComponentBase

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -11,7 +11,9 @@
 
 import Foundation
 import CoreGraphics
-
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 /// Class representing the y-axis labels settings and its entries.
 /// Be aware that not all features the YLabels class provides are suitable for the RadarChart.

--- a/Source/Charts/Filters/DataApproximator+N.swift
+++ b/Source/Charts/Filters/DataApproximator+N.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import CoreGraphics
 
 extension CGPoint {
     fileprivate func distanceToLine(from linePoint1: CGPoint, to linePoint2: CGPoint) -> CGFloat {

--- a/Source/Charts/Filters/DataApproximator.swift
+++ b/Source/Charts/Filters/DataApproximator.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 @objc(ChartDataApproximator)
 open class DataApproximator: NSObject

--- a/Source/Charts/Jobs/AnimatedViewPortJob.swift
+++ b/Source/Charts/Jobs/AnimatedViewPortJob.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 open class AnimatedViewPortJob: ViewPortJob
 {

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
 {

--- a/Source/Charts/Renderers/ChartDataRendererBase.swift
+++ b/Source/Charts/Renderers/ChartDataRendererBase.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 @objc(ChartDataRendererBase)
 open class DataRenderer: Renderer

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 open class HorizontalBarChartRenderer: BarChartRenderer
 {

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 open class LineChartRenderer: LineRadarRenderer
 {

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 open class PieChartRenderer: DataRenderer
 {

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 @objc(ChartXAxisRenderer)
 open class XAxisRenderer: AxisRendererBase

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 @objc(ChartYAxisRenderer)
 open class YAxisRenderer: AxisRendererBase

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -11,6 +11,10 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 open class YAxisRendererRadarChart: YAxisRenderer
 {

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -11,6 +11,9 @@
 
 import Foundation
 import CoreGraphics
+#if canImport(UIKit)
+    import UIKit
+#endif
 
 extension Comparable {
     func clamped(to range: ClosedRange<Self>) -> Self {

--- a/Source/Charts/Utils/Platform+Accessibility.swift
+++ b/Source/Charts/Utils/Platform+Accessibility.swift
@@ -1,4 +1,8 @@
 import Foundation
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 
 #if os(iOS) || os(tvOS)
 


### PR DESCRIPTION
Currently Swift Package Manager for Xcode11 can only build static libraries. This means that UIKit can't be linked dynamically, so we need to check if UIKit is available and import it if possible. “canImport” is available from Swift 4.1, so these changes won’t cause any compiling issues and everything will work correctly (Carthage, Pods, etc). Since it's CRITICAL to make this lib Swift Package Manager compatible for appleOS platforms, could you please merge this pull request as soon as possible?