### PR TITLE
Use interpolation instead of '+' concatenation for problematic expression

### DIFF
--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -403,7 +403,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet, NSCopying
     open override var debugDescription: String
     {
         return (0..<entryCount).reduce(description + ":") {
-            $0 + "\n" + (self.entryForIndex($1)?.description ?? "")
+            "\($0)\n\(self.entryForIndex($1)?.description ?? "")"
         }
     }
     


### PR DESCRIPTION
### Goals :soccer:
Reduces the type-checking time of a `debugDescription` variable by at least an order of magnitude.

### Implementation Details :construction:
Because type inference with `+` and literals has to do a lot of overload checking (for every `ExpressibleBy____Literal`), many expressions which use `+` for string concatenation with literals in contexts where type information is sparse may inadvertently cause a type checker performance explosion. In this case, we are concatenating an anonymous closure argument with a string literal, which caused a compilation time on the order of multiple seconds (on my MBP, YMMV). With this change, the type checking of this expression completes in under 100ms.

### Testing Details :mag:
There's no behavior change here. We could consider adding `-Xfrontend -warn-long-expression-type-checking=<limit>` to the Xcode project to catch warnings about type checker performance bottlenecks.