### PR TITLE
introduce gracefully degrading abstractions for dark mode for ios and…

### DIFF
--- a/ChartsDemo-macOS/PlaygroundChart.playground/Pages/BubbleChart.xcplaygroundpage/Contents.swift
+++ b/ChartsDemo-macOS/PlaygroundChart.playground/Pages/BubbleChart.xcplaygroundpage/Contents.swift
@@ -59,7 +59,7 @@ for index in 0..<ITEM_COUNT
 //: ### BubbleChartDataSet
 let set = BubbleChartDataSet(values: entries, label: "Bubble DataSet")
 set.colors = ChartColorTemplates.vordiplom()
-set.valueTextColor = NSUIColor.black
+set.valueTextColor = NSUIColor.labelOrBlack
 set.valueFont = NSUIFont.systemFont(ofSize: CGFloat(10.0))
 set.drawValuesEnabled = true
 set.normalizeSizeEnabled = false

--- a/ChartsDemo-macOS/PlaygroundChart.playground/Pages/LineChart.xcplaygroundpage/Contents.swift
+++ b/ChartsDemo-macOS/PlaygroundChart.playground/Pages/LineChart.xcplaygroundpage/Contents.swift
@@ -60,7 +60,7 @@ rightAxis.granularityEnabled = false
 //: ### Legend
 let legend = chartView.legend
 legend.font = NSUIFont(name: "HelveticaNeue-Light", size: CGFloat(12.0))!
-legend.textColor = NSUIColor.black
+legend.textColor = NSUIColor.labelOrBlack
 legend.form = .square
 legend.drawInside = false
 legend.orientation = .horizontal

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -98,7 +98,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     @objc open var noDataFont = NSUIFont.systemFont(ofSize: 12)
     
     /// color of the no data text
-    @objc open var noDataTextColor: NSUIColor = NSUIColor.black
+    @objc open var noDataTextColor: NSUIColor = NSUIColor.labelOrBlack
 
     /// alignment of the no data text
     @objc open var noDataTextAlignment: NSTextAlignment = .left

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -363,7 +363,7 @@ open class PieChartView: PieRadarChartViewBase
                 
                 attrString = NSMutableAttributedString(string: newValue!)
                 attrString?.setAttributes([
-                    .foregroundColor: NSUIColor.black,
+                    .foregroundColor: NSUIColor.labelOrBlack,
                     .font: NSUIFont.systemFont(ofSize: 12.0),
                     .paragraphStyle: paragraphStyle
                     ], range: NSMakeRange(0, attrString!.length))

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -25,7 +25,7 @@ open class AxisBase: ComponentBase
     private var _axisValueFormatter: IAxisValueFormatter?
     
     @objc open var labelFont = NSUIFont.systemFont(ofSize: 10.0)
-    @objc open var labelTextColor = NSUIColor.black
+    @objc open var labelTextColor = NSUIColor.labelOrBlack
     
     @objc open var axisLineColor = NSUIColor.gray
     @objc open var axisLineWidth = CGFloat(0.5)

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -34,7 +34,7 @@ open class ChartLimitLine: ComponentBase
     @objc open var lineDashPhase = CGFloat(0.0)
     @objc open var lineDashLengths: [CGFloat]?
     
-    @objc open var valueTextColor = NSUIColor.black
+    @objc open var valueTextColor = NSUIColor.labelOrBlack
     @objc open var valueFont = NSUIFont.systemFont(ofSize: 13.0)
     
     @objc open var drawLabelEnabled = true

--- a/Source/Charts/Components/Description.swift
+++ b/Source/Charts/Components/Description.swift
@@ -50,5 +50,5 @@ open class Description: ComponentBase
     @objc open var font: NSUIFont
     
     /// Text color used for drawing the description text
-    @objc open var textColor = NSUIColor.black
+    @objc open var textColor = NSUIColor.labelOrBlack
 }

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -98,7 +98,7 @@ open class Legend: ComponentBase
     @objc open var direction: Direction = Direction.leftToRight
 
     @objc open var font: NSUIFont = NSUIFont.systemFont(ofSize: 10.0)
-    @objc open var textColor = NSUIColor.black
+    @objc open var textColor = NSUIColor.labelOrBlack
 
     /// The form/shape of the legend forms
     @objc open var form = Form.square

--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -21,7 +21,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet, NSCopying
         
         // default color
         colors.append(NSUIColor(red: 140.0/255.0, green: 234.0/255.0, blue: 255.0/255.0, alpha: 1.0))
-        valueColors.append(NSUIColor.black)
+        valueColors.append(NSUIColor.labelOrBlack)
     }
     
     @objc public init(label: String?)
@@ -30,7 +30,7 @@ open class ChartBaseDataSet: NSObject, IChartDataSet, NSCopying
         
         // default color
         colors.append(NSUIColor(red: 140.0/255.0, green: 234.0/255.0, blue: 255.0/255.0, alpha: 1.0))
-        valueColors.append(NSUIColor.black)
+        valueColors.append(NSUIColor.labelOrBlack)
         
         self.label = label
     }

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -542,7 +542,7 @@ private func fetchLabelColor() -> NSColor
 {
     if #available(macOS 10.14, *)
     {
-        return .label
+        return .labelColor
     }
     else
     {

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -27,6 +27,24 @@ public typealias NSUIScreen = UIScreen
 
 public typealias NSUIDisplayLink = CADisplayLink
 
+private func fetchLabelColor() -> UIColor
+{
+    if #available(iOS 13, tvOS 13, *)
+    {
+        return .label
+    }
+    else
+    {
+        return .black
+    }
+}
+private let labelColor: UIColor = fetchLabelColor()
+
+extension UIColor
+{
+    static var labelOrBlack: UIColor { labelColor }
+}
+
 extension NSUITapGestureRecognizer
 {
     @objc final func nsuiNumberOfTouches() -> Int
@@ -518,6 +536,24 @@ extension NSTouch
         let b = view.bounds
         return NSPoint(x: b.origin.x + b.size.width * n.x, y: b.origin.y + b.size.height * n.y)
     }
+}
+
+private func fetchLabelColor() -> NSColor
+{
+    if #available(macOS 10.14, *)
+    {
+        return .label
+    }
+    else
+    {
+        return .black
+    }
+}
+private let labelColor: NSColor = fetchLabelColor()
+
+extension NSColor
+{
+    static var labelOrBlack: NSColor { labelColor }
 }
 
 extension NSScrollView


### PR DESCRIPTION
… macos and use them to draw text

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4133
https://github.com/danielgindi/Charts/issues/3742

### Goals :soccer:
Introduce dark mode for label and gracefully degrade to black for the older operating systems

### Implementation Details :construction:
Introduce labelOrBlack in NSUIColor. Set it to either NSUIColor.label or black depending on os versions. use it in charts

### Testing Details :mag:
decided against it as it's colours that in some cases are not configurable and hence easily testable