### PR TITLE
changed to display leftAxis line even if it fills between two line gr…

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -181,7 +181,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 
         // execute all drawing commands
         drawGridBackground(context: context)
-        
+        renderer.drawData(context: context)
 
         if _autoScaleMinMaxEnabled
         {
@@ -232,7 +232,6 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         if clipDataToContentEnabled {
             context.clip(to: _viewPortHandler.contentRect)
         }
-        renderer.drawData(context: context)
         
         // if highlighting is enabled
         if (valuesToHighlight())


### PR DESCRIPTION
…aphs.

### Issue Link :link:
#4037 

### Goals :soccer:
The leftAxis line is displayed even if you fill between two line graphs.

|Before|After|
|:--:|:--:|
|![Simulator_Screen_Shot_-_iPhone_11_Pro_Max_-_2019-10-29_at_13_49_23](https://user-images.githubusercontent.com/1317847/67739179-f2402e00-fa54-11e9-976f-c32dcb50bef9.png)|![Simulator_Screen_Shot_-_iPhone_11_Pro_Max_-_2019-10-29_at_13_51_44](https://user-images.githubusercontent.com/1317847/67739205-0b48df00-fa55-11e9-80f5-d96cfd10cdd6.png)|

### Implementation Details :construction:
Changed timing to call `renderer.drawData (context: context)`
