### PR TITLE
Take into account the rendered size for the labels

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -126,17 +126,18 @@ open class AxisBase: ComponentBase
     /// if true, the set number of y-labels will be forced
     @objc open var forceLabelsEnabled = false
     
-    @objc open func getLongestLabel() -> String
+    @objc open func getLongestLabelSize() -> CGSize
     {
-        var longest = ""
-        
+        var longest = CGSize.zero
+
         for i in 0 ..< entries.count
         {
             let text = getFormattedLabel(i)
-            
-            if longest.count < text.count
-            {
-                longest = text
+            // Compare the size instead of the string count
+            // as there could be 
+            let size = text.size(withAttributes: [NSAttributedString.Key.font: labelFont])
+            if longest.width < size.width {
+                longest = size
             }
         }
         

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -112,8 +112,7 @@ open class YAxis: AxisBase
     
     @objc open func requiredSize() -> CGSize
     {
-        let label = getLongestLabel() as NSString
-        var size = label.size(withAttributes: [NSAttributedString.Key.font: labelFont])
+        var size = getLongestLabelSize()
         size.width += xOffset * 2.0
         size.height += yOffset * 2.0
         size.width = max(minWidth, min(size.width, maxWidth > 0.0 ? maxWidth : size.width))

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -62,10 +62,7 @@ open class XAxisRenderer: AxisRendererBase
             xAxis = self.axis as? XAxis
             else { return }
         
-        let longest = xAxis.getLongestLabel()
-        
-        let labelSize = longest.size(withAttributes: [NSAttributedString.Key.font: xAxis.labelFont])
-        
+        let labelSize = xAxis.getLongestLabelSize()
         let labelWidth = labelSize.width
         let labelHeight = labelSize.height
         

--- a/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
@@ -58,10 +58,7 @@ open class XAxisRendererHorizontalBarChart: XAxisRenderer
             xAxis = self.axis as? XAxis
             else { return }
        
-        let longest = xAxis.getLongestLabel() as NSString
-        
-        let labelSize = longest.size(withAttributes: [NSAttributedString.Key.font: xAxis.labelFont])
-        
+        let labelSize = xAxis.getLongestLabelSize()
         let labelWidth = floor(labelSize.width + xAxis.xOffset * 3.5)
         let labelHeight = labelSize.height
         let labelRotatedSize = CGSize(width: labelSize.width, height: labelHeight).rotatedBy(degrees: xAxis.labelRotationAngle)


### PR DESCRIPTION
Take into account the rendered size for the labels instead of the char count for size calculations.

### Goals :soccer:
When setting up the margin size for the axis labels, right now it uses the string characters count. In some cases it is not the right approach (example: strings with multilines, or "iiiiii" vs "kkkkkk".

### Implementation Details :construction:
I've replaced the string characters count by the calculated size given the attributes.
