### PR TITLE
Fixbug

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -663,7 +663,19 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                     matrix = matrix.translatedBy(x: -location.x, y: -location.y)
                     
                     matrix = _viewPortHandler.touchMatrix.concatenating(matrix)
-                    
+                    // Fix bug https://github.com/danielgindi/Charts/issues/3939#issuecomment-549259844
+                    if matrix.a > _viewPortHandler.maxScaleX {
+                        matrix.a = _viewPortHandler.maxScaleX
+                    }
+                    if matrix.a < _viewPortHandler.minScaleX {
+                        matrix.a = _viewPortHandler.minScaleX
+                    }
+                    if matrix.d > _viewPortHandler.maxScaleY {
+                        matrix.d = _viewPortHandler.maxScaleY
+                    }
+                    if matrix.d < _viewPortHandler.minScaleY {
+                        matrix.d = _viewPortHandler.minScaleY
+                    }
                     _viewPortHandler.refresh(newMatrix: matrix, chart: self, invalidate: true)
                     
                     if delegate !== nil

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -167,7 +167,19 @@ open class YAxis: AxisBase
             case(false, true):
                 max = min < 0 ? min * 0.5 : min * 1.5
             case(false, false):
-                break
+                /*
+                 Is this case possible when everything is correct?
+                 If it is possible, here should not return
+                 getYMin and getYMax of ChartData will pass value to dataMin and dataMax
+                 when there is no data
+                 getYMin will return +Double.greatestFiniteMagnitude and min is +Inf
+                 getYMax will reutrn -Double.greatestFiniteMagnitude nad max is -Inf
+                 and this method comes to this case
+                 max - min becomes meaningless here
+                 +Inf and -Inf should not be involved in calculation
+                 https://github.com/danielgindi/Charts/issues/3352 looks the same problem
+                 */
+                return
             }
         }
         

--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -115,6 +115,13 @@ open class AxisRendererBase: Renderer
             interval = interval < axis.granularity ? axis.granularity : interval
         }
         
+        // As discussed in https://github.com/danielgindi/Charts/pull/1558
+        // It is still necesssary to add a safety check, but it is likely to hide the real problem
+        if (interval.isNaN || interval.isInfinite) {
+            print("Charts: Interval should be a valid number")
+            return
+        }
+        
         // Normalize interval
         let intervalMagnitude = pow(10.0, Double(Int(log10(interval)))).roundedToNextSignficant()
         let intervalSigDigit = Int(interval / intervalMagnitude)


### PR DESCRIPTION
### Issue Link :link:
https://github.com/Andy1984/Charts
On the Swift Demo of master branch, I wrote a demo to demonstrate the crash.
Steps:
1. Run the Swift Demo
2. Select the first row of tableView, that is CrashWhenNaN
3. Click No Data and zoom of the segementedControl
4. Zoom in
5. Click Show Data of the segementedControl
6. It crashes

### Goals :soccer:
1. Fix the crash issue
2. Fix the bug https://github.com/danielgindi/Charts/issues/3939#issuecomment-549259844

### Implementation Details :construction:
1. Avoid the calculation of +Inf, -Inf and NaN
2. Add a safety check of NaN
3. Inhabit zoom in is over MaxScale

### Testing Details :mag:
Sorry, I am not familiar with XCTest or anything similar. I changed the source code in my company's project. Everything works fine.