### PR TITLE
Changes to fix Catalyst compatibility

### DIFF
--- a/Source/Charts/Utils/Platform+Color.swift
+++ b/Source/Charts/Utils/Platform+Color.swift
@@ -28,7 +28,7 @@ extension UIColor
 }
 #endif
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 

--- a/Source/Charts/Utils/Platform+Gestures.swift
+++ b/Source/Charts/Utils/Platform+Gestures.swift
@@ -84,7 +84,7 @@ extension NSUIPinchGestureRecognizer
 #endif
 
 // MARK: - AppKit
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 public typealias NSUIGestureRecognizer = NSGestureRecognizer

--- a/Source/Charts/Utils/Platform+Graphics.swift
+++ b/Source/Charts/Utils/Platform+Graphics.swift
@@ -51,7 +51,7 @@ func NSUIGraphicsBeginImageContextWithOptions(_ size: CGSize, _ opaque: Bool, _ 
 #endif
 
 // MARK: - AppKit
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 func NSUIGraphicsGetCurrentContext() -> CGContext?

--- a/Source/Charts/Utils/Platform+Touch Handling.swift
+++ b/Source/Charts/Utils/Platform+Touch Handling.swift
@@ -64,7 +64,7 @@ extension UIView
 #endif
 
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 public typealias NSUIEvent = NSEvent


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4233

### Goals :soccer:
Fixes compatibility with Catalyst

### Implementation Details :construction:
Essentially, in the "Platform+" files, attempts to alias types to their AppKit equivalents for regular macOS apps works file, but fails in Catalyst apps because while those are Mac apps, Catalyst needs UIKit for certain things. 

Basically I changed this line in four files

`#if canImport(AppKit)`

to 

`#if canImport(AppKit) && !targetEnvironment(macCatalyst)`

Which causes the macro to skip over this on Catalyst apps. 

### Testing Details :mag:
No changes to unit testing performed, though I have successfully tried my fork in a Catalyst app, and the changes above have no effect on the macOS demo app in the project. 