### PR TITLE
Fixed calcMinMaxY logic for datasets that fall outside fromX...toX range

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -107,7 +107,7 @@ open class ChartDataSet: ChartBaseDataSet
         let indexFrom = entryIndex(x: fromX, closestToY: Double.nan, rounding: .down)
         let indexTo = entryIndex(x: toX, closestToY: Double.nan, rounding: .up)
         
-        guard !(indexTo < indexFrom) else { return }
+        guard !(indexTo <= indexFrom) else { return }
         // only recalculate y
         self[indexFrom...indexTo].forEach(calcMinMaxY)
     }


### PR DESCRIPTION
### Goals :soccer:
Fixes bug in calcMinMaxY logic: when a dataset has X values exclusively outside of the fromX...toX range, the first datapoint will be used to calculate the Y range.

### Implementation Details :construction:
Fixed the guard to include the case when "indexFrom" is equal to "indexTo"

### Testing Details :mag:
Did not add tests.