### PR TITLE
Improve render performance if draw circles is disabled

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -562,12 +562,12 @@ open class LineChartRenderer: LineRadarRenderer
 
         for i in 0 ..< dataSets.count
         {
-            guard let dataSet = lineData.getDataSetByIndex(i) as? ILineChartDataSet else { continue }
-            
-            if !dataSet.isVisible || dataSet.entryCount == 0
-            {
-                continue
-            }
+            guard
+                let dataSet = lineData.getDataSetByIndex(i) as? ILineChartDataSet,
+                dataSet.drawCirclesEnabled,
+                dataSet.isVisible,
+                dataSet.entryCount > 0
+            else { continue }
             
             let trans = dataProvider.getTransformer(forAxis: dataSet.axisDependency)
             let valueToPixelMatrix = trans.valueToPixelMatrix


### PR DESCRIPTION
### Goals :soccer:
Improve line graph drawing performance for data sets with multiple thousands of points.

### Implementation Details :construction:
Draw circles is an expensive function. By not running it if `drawCirclesEnabled` returns false, we're able to easily draw a line graph >7000 data points on an iPhone X with 60fps.

### Testing Details :mag:
None