### PR TITLE
Use faster check for line whether it's inside drawing rect

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -354,20 +354,24 @@ open class LineChartRenderer: LineRadarRenderer
                 _lineSegments[i] = _lineSegments[i].applying(valueToPixelMatrix)
             }
             
+            if !viewPortHandler.isInBoundsRight(_lineSegments[0].x)
+            {
+                break
+            }
+            
             // Determine the start and end coordinates of the line, and make sure they differ.
             guard
                 let firstCoordinate = _lineSegments.first,
                 let lastCoordinate = _lineSegments.last,
                 firstCoordinate != lastCoordinate else { continue }
             
-            // If both points lie left of viewport, skip stroking.
-            if !viewPortHandler.isInBoundsLeft(lastCoordinate.x) { continue }
-            
-            // If both points lie right of the viewport, break out early.
-            if !viewPortHandler.isInBoundsRight(firstCoordinate.x) { break }
-            
-            // Only stroke the line if it intersects with the viewport.
-            guard viewPortHandler.isIntersectingLine(from: firstCoordinate, to: lastCoordinate) else { continue }
+            // make sure the lines don't do shitty things outside bounds
+            if !viewPortHandler.isInBoundsLeft(lastCoordinate.x) ||
+                !viewPortHandler.isInBoundsTop(max(firstCoordinate.y, lastCoordinate.y)) ||
+                !viewPortHandler.isInBoundsBottom(min(firstCoordinate.y, lastCoordinate.y))
+            {
+                continue
+            }
             
             // get the color that is set for this line-segment
             context.setStrokeColor(dataSet.color(atIndex: j).cgColor)


### PR DESCRIPTION
This obviously does not consider slope that's outside,
But these cases will be clipping by CoreGraphics anyway.
Doing a full line collision test here is an overkill.

### Issue Link :link:
Fixes a performance degradation introduced here: https://github.com/danielgindi/Charts/pull/4100
It was a big chunk of code that was introduced to fix a subtle bug, but most of the fix was actually the code calling it - figuring out the first/last line coordinate for stepped lined.

### Goals :soccer:
Revert to almost-the-previous-implementation, keeping the actual fix in place.

### Implementation Details :construction:
When testing simply that `lastCoordinate.x > left && firstCoordinate.x < right`, it's enough to ensure the line is horizontally somewhere in the content rect.
The equivalent vertical check was inverted, causing rare issues.
But the main issue was actually with stepped lines, where a line was more than 2 coordinates, and only the first 2 were validated.


### Testing Details :mag:
Zooming in manually in all scenarios until all coordinates are off screen - horizontally and vertically.