### PR TITLE
labelXOffset = 10 is default for radar chart only

### DIFF
--- a/Source/Charts/Charts/RadarChartView.swift
+++ b/Source/Charts/Charts/RadarChartView.swift
@@ -59,6 +59,7 @@ open class RadarChartView: PieRadarChartViewBase
         super.initialize()
         
         _yAxis = YAxis(position: .left)
+        _yAxis.labelXOffset = 10.0
         
         renderer = RadarChartRenderer(chart: self, animator: _animator, viewPortHandler: _viewPortHandler)
         

--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -81,7 +81,7 @@ open class YAxis: AxisBase
     @objc open var labelAlignment: NSTextAlignment = .left
 
     /// the horizontal offset of the y-label
-    @objc open var labelXOffset: CGFloat = 10.0
+    @objc open var labelXOffset: CGFloat = 0.0
     
     /// the side this axis object represents
     private var _axisDependency = AxisDependency.left

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -142,6 +142,8 @@ open class YAxisRenderer: AxisRendererBase
         let from = yAxis.isDrawBottomYLabelEntryEnabled ? 0 : 1
         let to = yAxis.isDrawTopYLabelEntryEnabled ? yAxis.entryCount : (yAxis.entryCount - 1)
         
+        let xOffset = yAxis.labelXOffset
+        
         for i in stride(from: from, to: to, by: 1)
         {
             let text = yAxis.getFormattedLabel(i)
@@ -149,7 +151,7 @@ open class YAxisRenderer: AxisRendererBase
             ChartUtils.drawText(
                 context: context,
                 text: text,
-                point: CGPoint(x: fixedPosition, y: positions[i].y + offset),
+                point: CGPoint(x: fixedPosition + xOffset, y: positions[i].y + offset),
                 align: textAlign,
                 attributes: [.font: labelFont, .foregroundColor: labelTextColor]
             )

--- a/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
@@ -155,6 +155,8 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
         let from = yAxis.isDrawBottomYLabelEntryEnabled ? 0 : 1
         let to = yAxis.isDrawTopYLabelEntryEnabled ? yAxis.entryCount : (yAxis.entryCount - 1)
         
+        let xOffset = yAxis.labelXOffset
+        
         for i in stride(from: from, to: to, by: 1)
         {
             let text = yAxis.getFormattedLabel(i)
@@ -162,7 +164,10 @@ open class YAxisRendererHorizontalBarChart: YAxisRenderer
             ChartUtils.drawText(
                 context: context,
                 text: text,
-                point: CGPoint(x: positions[i].x, y: fixedPosition - offset),
+                point: CGPoint(
+                    x: positions[i].x, y:
+                    fixedPosition - offset + xOffset
+                ),
                 align: .center,
                 attributes: [NSAttributedString.Key.font: labelFont, NSAttributedString.Key.foregroundColor: labelTextColor])
         }

--- a/Source/Charts/Renderers/YAxisRendererRadarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererRadarChart.swift
@@ -187,7 +187,7 @@ open class YAxisRendererRadarChart: YAxisRenderer
         let to = yAxis.isDrawTopYLabelEntryEnabled ? yAxis.entryCount : (yAxis.entryCount - 1)
 
         let alignment: NSTextAlignment = yAxis.labelAlignment
-        let xOffset: CGFloat = yAxis.labelXOffset
+        let xOffset = yAxis.labelXOffset
         
         for j in stride(from: from, to: to, by: 1)
         {


### PR DESCRIPTION
+ also consider other renderers

Fixes https://github.com/danielgindi/Charts/pull/3406

### Issue Link :link:
https://github.com/danielgindi/Charts/pull/3406

### Goals :soccer:
Extend the solution to not be a piece of dead code.

### Implementation Details :construction:
Considering the new property in all `YAxisRenderer`s, while correctly setting the default of `10` only to Radar charts.

### Testing Details :mag:
Visually, + CI.