### PR TITLE
Call chartViewDidEndPanning on when *panning* is ended

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -787,6 +787,8 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 }
                 
                 _isDragging = false
+                
+                delegate?.chartViewDidEndPanning?(self)
             }
             
             if _outerScrollView !== nil
@@ -794,8 +796,6 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                 _outerScrollView?.nsuiIsScrollEnabled = true
                 _outerScrollView = nil
             }
-            
-            delegate?.chartViewDidEndPanning?(self)
         }
     }
     


### PR DESCRIPTION
### Goals :soccer:
Straighten the semantics of the event.

### Implementation Details :construction:
Currently the relatively new protocol method is called in the end of the gesture, even if the gesture does not mean "pan". This could cause unexpected bugs.
