### PR TITLE
Bugfix/pie highlight

### DIFF
--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -167,7 +167,7 @@ open class PieChartRenderer: DataRenderer
             // draw only if the value is greater than zero
             if (abs(e.y) > Double.ulpOfOne)
             {
-                if !chart.needsHighlight(index: j)
+                if !dataSet.isHighlightEnabled || !chart.needsHighlight(index: j)
                 {
                     let accountForSliceSpacing = sliceSpace > 0.0 && sliceAngle <= 180.0
 
@@ -735,6 +735,8 @@ open class PieChartRenderer: DataRenderer
             }
 
             guard let set = data.getDataSetByIndex(indices[i].dataSetIndex) as? IPieChartDataSet else { continue }
+            
+            if !set.isHighlightEnabled { continue }
 
             let entryCount = set.entryCount
             var visibleAngleCount = 0
@@ -761,7 +763,7 @@ open class PieChartRenderer: DataRenderer
             let sliceAngle = drawAngles[index]
             var innerRadius = userInnerRadius
 
-            let shift = set.isHighlightEnabled ? set.selectionShift : 0.0
+            let shift = set.selectionShift
             let highlightedRadius = radius + shift
 
             let accountForSliceSpacing = sliceSpace > 0.0 && sliceAngle <= 180.0


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/pull/3996

### Goals :soccer:
The original PR made normal slices render through the highlight code, while disabling slice-shift. 
So special highlight colors or other styling - would still affect the normal rendering.

### Implementation Details :construction:
Avoid rendering highlights when rendering dataset, avoid rendering non-highlighted slices when rendering highlights.

### Testing Details :mag:
Manually.