### PR TITLE
Backported @larryonoff’s gradient line drawing implementation from 4.0 to 3.4

### DIFF
--- a/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
+++ b/ChartsDemo-iOS/Swift/DemoBaseViewController.swift
@@ -23,6 +23,8 @@ enum Option {
     case toggleAutoScaleMinMax
     case toggleData
     case toggleBarBorders
+    // LineChart
+    case toggleGradientLine
     // CandleChart
     case toggleShadowColorSameAsCandle
     case toggleShowCandleBar
@@ -61,6 +63,8 @@ enum Option {
         case .toggleAutoScaleMinMax: return "Toggle auto scale min/max"
         case .toggleData: return "Toggle Data"
         case .toggleBarBorders: return "Toggle Bar Borders"
+        // LineChart
+        case .toggleGradientLine: return "Toggle Gradient Line"
         // CandleChart
         case .toggleShadowColorSameAsCandle: return "Toggle shadow same color"
         case .toggleShowCandleBar: return "Toggle show candle bar"

--- a/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/LineChart1ViewController.swift
@@ -32,6 +32,7 @@ class LineChart1ViewController: DemoBaseViewController {
                         .toggleIcons,
                         .toggleStepped,
                         .toggleHighlight,
+                        .toggleGradientLine,
                         .animateX,
                         .animateY,
                         .animateXY,
@@ -118,17 +119,7 @@ class LineChart1ViewController: DemoBaseViewController {
         let set1 = LineChartDataSet(entries: values, label: "DataSet 1")
         set1.drawIconsEnabled = false
         
-        set1.lineDashLengths = [5, 2.5]
-        set1.highlightLineDashLengths = [5, 2.5]
-        set1.setColor(.black)
-        set1.setCircleColor(.black)
-        set1.lineWidth = 1
-        set1.circleRadius = 3
-        set1.drawCircleHoleEnabled = false
-        set1.valueFont = .systemFont(ofSize: 9)
-        set1.formLineDashLengths = [5, 2.5]
-        set1.formLineWidth = 1
-        set1.formSize = 15
+        setup(set1)
         
         let gradientColors = [ChartColorTemplates.colorFromString("#00ff0000").cgColor,
                               ChartColorTemplates.colorFromString("#ffff0000").cgColor]
@@ -142,6 +133,36 @@ class LineChart1ViewController: DemoBaseViewController {
         
         chartView.data = data
     }
+    
+    private func setup(_ dataSet: LineChartDataSet) {
+         if dataSet.isDrawLineWithGradientEnabled {
+             dataSet.lineDashLengths = nil
+             dataSet.highlightLineDashLengths = nil
+             dataSet.setColors(.black, .red, .white)
+             dataSet.setCircleColor(.black)
+             dataSet.gradientPositions = [0, 40, 100]
+             dataSet.lineWidth = 1
+             dataSet.circleRadius = 3
+             dataSet.drawCircleHoleEnabled = false
+             dataSet.valueFont = .systemFont(ofSize: 9)
+             dataSet.formLineDashLengths = nil
+             dataSet.formLineWidth = 1
+             dataSet.formSize = 15
+         } else {
+             dataSet.lineDashLengths = [5, 2.5]
+             dataSet.highlightLineDashLengths = [5, 2.5]
+             dataSet.setColor(.black)
+             dataSet.setCircleColor(.black)
+             dataSet.gradientPositions = nil
+             dataSet.lineWidth = 1
+             dataSet.circleRadius = 3
+             dataSet.drawCircleHoleEnabled = false
+             dataSet.valueFont = .systemFont(ofSize: 9)
+             dataSet.formLineDashLengths = [5, 2.5]
+             dataSet.formLineWidth = 1
+             dataSet.formSize = 15
+         }
+     }
     
     override func optionTapped(_ option: Option) {
         switch option {
@@ -174,6 +195,13 @@ class LineChart1ViewController: DemoBaseViewController {
                 set.mode = (set.mode == .cubicBezier) ? .horizontalBezier : .cubicBezier
             }
             chartView.setNeedsDisplay()
+            
+        case .toggleGradientLine:
+             for set in chartView.data!.dataSets as! [LineChartDataSet] {
+                 set.isDrawLineWithGradientEnabled = !set.isDrawLineWithGradientEnabled
+                 setup(set)
+             }
+             chartView.setNeedsDisplay()
             
         default:
             super.handleOption(option, forChartView: chartView)

--- a/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineChartDataSet.swift
@@ -67,6 +67,10 @@ open class LineChartDataSet: LineRadarChartDataSet, ILineChartDataSet
             _cubicIntensity = newValue.clamped(to: 0.05...1)
         }
     }
+    
+    open var isDrawLineWithGradientEnabled = false
+
+    open var gradientPositions: [CGFloat]?
         
     /// The radius of the drawn circles.
     open var circleRadius = CGFloat(8.0)

--- a/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/ILineChartDataSet.swift
@@ -30,6 +30,10 @@ public protocol ILineChartDataSet: ILineRadarChartDataSet
     /// **default**: 0.2
     var cubicIntensity: CGFloat { get set }
     
+    var isDrawLineWithGradientEnabled: Bool { get set }
+
+    var gradientPositions: [CGFloat]? { get set }
+    
     /// The radius of the drawn circles.
     var circleRadius: CGFloat { get set }
     

--- a/Source/Charts/Utils/Platform.swift
+++ b/Source/Charts/Utils/Platform.swift
@@ -14,6 +14,22 @@ public typealias NSUIScrollView = UIScrollView
 public typealias NSUIScreen = UIScreen
 public typealias NSUIDisplayLink = CADisplayLink
 
+extension NSUIColor
+ {
+     var nsuirgba: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
+         var red: CGFloat = 0
+         var green: CGFloat = 0
+         var blue: CGFloat = 0
+         var alpha: CGFloat = 0
+
+         guard getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+             return nil
+         }
+
+         return (red: red, green: green, blue: blue, alpha: alpha)
+     }
+ }
+
 open class NSUIView: UIView
 {
     @objc var nsuiLayer: CALayer?
@@ -241,5 +257,26 @@ func NSUIMainScreen() -> NSUIScreen?
 {
     return NSUIScreen.main
 }
+
+extension NSUIColor
+ {
+     var nsuirgba: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
+         var red: CGFloat = 0
+         var green: CGFloat = 0
+         var blue: CGFloat = 0
+         var alpha: CGFloat = 0
+
+         guard let colorSpaceModel = cgColor.colorSpace?.model else {
+             return nil
+         }
+         guard colorSpaceModel == .rgb else {
+             return nil
+         }
+
+         getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+         return (red: red, green: green, blue: blue, alpha: alpha)
+     }
+ }
+
 
 #endif


### PR DESCRIPTION
Since the 4.0 branch has been stale for quite a while, but the **Gradient Line** feature was only implemented there, I decided to back-port it to the 3.4 branch.

All credits for the original implementation go to @larryonoff who developed the feature back in 2018.

Since this is a very important feature for me and I still want to be able to benefit from the improvements that are going on in version 3.x I decided to create a PR to have this feature in the current master branch.

Link to the original PR: https://github.com/danielgindi/Charts/pull/3142