### PR TITLE
Fix AxisBase Formatter Getter (Fixes #4365)

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -166,14 +166,17 @@ open class AxisBase: ComponentBase
     {
         get
         {
-            if _axisValueFormatter == nil ||
-                (_axisValueFormatter is DefaultAxisValueFormatter &&
-                    (_axisValueFormatter as! DefaultAxisValueFormatter).hasAutoDecimals &&
-                    (_axisValueFormatter as! DefaultAxisValueFormatter).decimals != decimals)
+            if _axisValueFormatter == nil
             {
                 _axisValueFormatter = DefaultAxisValueFormatter(decimals: decimals)
             }
-            
+            else if _axisValueFormatter is DefaultAxisValueFormatter &&
+            (_axisValueFormatter as! DefaultAxisValueFormatter).hasAutoDecimals &&
+                (_axisValueFormatter as! DefaultAxisValueFormatter).decimals != decimals
+            {
+                (self._axisValueFormatter as! DefaultAxisValueFormatter).decimals = self.decimals
+            }
+
             return _axisValueFormatter
         }
         set


### PR DESCRIPTION
Fixes issue where if you overrode the
formatter it didn't matter because a new one would
just replace it.

### Issue Link https://github.com/danielgindi/Charts/issues/4365