### PR TITLE
Adding in round rect as a form option

### DIFF
--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -30,6 +30,9 @@ open class Legend: ComponentBase
         /// Draw a square
         case square
         
+        /// Draw a roundRect
+        case roundRect
+        
         /// Draw a circle
         case circle
         

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -543,6 +543,15 @@ open class LegendRenderer: Renderer
             context.setFillColor(formColor.cgColor)
             context.fill(CGRect(x: x, y: y - formSize / 2.0, width: formSize, height: formSize))
             
+        case .roundRect:
+            
+            context.setFillColor(formColor.cgColor)
+            let path = CGMutablePath()
+            path.addRoundedRect(in: CGRect(x: x, y: y - formSize / 2.0, width: formSize, height: formSize), cornerWidth: formSize / 3, cornerHeight: formSize / 3)
+            context.addPath(path)
+            context.closePath()
+            context.fillPath()
+            
         case .line:
             
             let formLineWidth = entry.formLineWidth.isNaN ? legend.formLineWidth : entry.formLineWidth


### PR DESCRIPTION
### Goals :soccer:

To allow users to draw a round rectangle in the legend, as opposed to the current options.

### Implementation Details :construction:

You can now specify the form on your chart be a `.roundRect` - like so: `barChartView.legend.form = .roundRect` 

This looks like this in the demo mac app (bar chart):

<img width="106" alt="Screen Shot 2020-05-20 at 3 59 09 AM" src="https://user-images.githubusercontent.com/305211/82421208-b3081780-9a4e-11ea-9c55-93448a14102b.png">

Should there be a way to have a customizable ratio? Currently it just divides each dimension by `3` - but other divisors would be useful for people too.


### Testing Details :mag:

Looking for ideas here
