### PR TITLE
Increase iOS version to 9 in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Charts",
     platforms: [
-          .iOS(.v8),
+          .iOS(.v9),
           .tvOS(.v9),
           .macOS(.v10_11),
     ],


### PR DESCRIPTION
Fixes Xcode 12 beta warning: `The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99.`