### PR TITLE
Add @objc to fix dynamic inference

### DIFF
--- a/Source/Charts/Utils/Platform+Touch Handling.swift
+++ b/Source/Charts/Utils/Platform+Touch Handling.swift
@@ -37,22 +37,22 @@ extension NSUIView {
         self.nsuiTouchesCancelled(touches, withEvent: event)
     }
 
-    open func nsuiTouchesBegan(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
+    @objc open func nsuiTouchesBegan(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         super.touchesBegan(touches, with: event!)
     }
 
-    open func nsuiTouchesMoved(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
+    @objc open func nsuiTouchesMoved(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         super.touchesMoved(touches, with: event!)
     }
 
-    open func nsuiTouchesEnded(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
+    @objc open func nsuiTouchesEnded(_ touches: Set<NSUITouch>, withEvent event: NSUIEvent?)
     {
         super.touchesEnded(touches, with: event!)
     }
 
-    open func nsuiTouchesCancelled(_ touches: Set<NSUITouch>?, withEvent event: NSUIEvent?)
+    @objc open func nsuiTouchesCancelled(_ touches: Set<NSUITouch>?, withEvent event: NSUIEvent?)
     {
         super.touchesCancelled(touches!, with: event!)
     }


### PR DESCRIPTION
### Goals :soccer:
Building on Xcode 11.6 using Swift 5 the compilation failed with the message "marking non-'@objc' swift declaration 'dynamic' in library evolution mode is not supported"

### Implementation Details :construction:
I added @objc and the Build goes Successfully.

### Testing Details :mag:
No tests required.