### PR TITLE
Remove unnecessary ternary in boolean expression

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -123,7 +123,7 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, IBarChartDat
     /// `true` if this DataSet is stacked (stacksize > 1) or not.
     open var isStacked: Bool
     {
-        return _stackSize > 1 ? true : false
+        return _stackSize > 1
     }
     
     /// The overall entry count, including counting each stack-value individually


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
Remove unnecessary ternary expression in boolean return statement.
