### PR TITLE
fix perfomance issues for very large dataSets

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -78,11 +78,11 @@ open class BarLineScatterCandleBubbleRenderer: DataRenderer
             let low = chart.lowestVisibleX
             let high = chart.highestVisibleX
             
-            let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
-            let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)
-            
-            self.min = entryFrom == nil ? 0 : dataSet.entryIndex(entry: entryFrom!)
-            self.max = entryTo == nil ? 0 : dataSet.entryIndex(entry: entryTo!)
+            let indexFrom = dataSet.entryIndex(x:low, closestToY: .nan, rounding: .down)
+            let indexTo = dataSet.entryIndex(x:high, closestToY: .nan, rounding: .up)
+
+            self.min = indexFrom > -1 ? indexFrom : 0;
+            self.max = indexTo > -1 ? indexTo : 0;
             range = Int(Double(self.max - self.min) * phaseX)
         }
     }


### PR DESCRIPTION
replaces linear search implicit in call dataSet.entryForXValue(..)) by existing binary search via dataSet.entryIndex(...).

### Goals :soccer:
This pull requests aims to improve performance on very large DataSets.
We observed perfomance issues for LineCharts with very large number of Entries.
It is caused by a use of a linear search using the default firstIndexOf() method called in ChartDataSet.firstIndex().

### Implementation Details :construction:
No architectural changes.

### Testing Details :mag:
No added Tests.