### PR TITLE
Remove internal use of datasets

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -62,7 +62,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             // calculate how many digits are needed
             setupDefaultFormatter(min: data.yMin, max: data.yMax)
 
-            for set in data.dataSets
+            for set in data
             {
                 if set.valueFormatter is DefaultValueFormatter
                 {

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -320,7 +320,7 @@ open class PieChartView: PieRadarChartViewBase
     @objc open func dataSetIndexForIndex(_ xValue: Double) -> Int
     {
         // TODO: Return nil instead of -1
-        return data?.dataSets.firstIndex {
+        return data?.firstIndex {
             $0.entryForXValue(xValue, closestToY: .nan) != nil
         } ?? -1
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -375,7 +375,7 @@ open class ChartDataSet: ChartBaseDataSet
     ///   - e: the entry to add
     /// - Returns: True
     // TODO: This should return `Void` to follow Swift convention
-    @available(*, deprecated, message: "Use `append(_:)` instead")
+    @available(*, deprecated, message: "Use `append(_:)` instead", renamed: "append(_:)")
     open override func addEntry(_ e: ChartDataEntry) -> Bool
     {
         append(e)

--- a/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
@@ -119,8 +119,7 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
         {
             data.calcMinMax()
             
-            let sets = data.dataSets
-            _dataSets.append(contentsOf: sets)
+            _dataSets.append(contentsOf: data)
             
             if data.yMax > yMax
             {
@@ -142,28 +141,28 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
                 xMin = data.xMin
             }
 
-            for dataset in sets
+            for set in data
             {
-                if dataset.axisDependency == .left
+                if set.axisDependency == .left
                 {
-                    if dataset.yMax > leftAxisMax
+                    if set.yMax > leftAxisMax
                     {
-                        leftAxisMax = dataset.yMax
+                        leftAxisMax = set.yMax
                     }
-                    if dataset.yMin < leftAxisMin
+                    if set.yMin < leftAxisMin
                     {
-                        leftAxisMin = dataset.yMin
+                        leftAxisMin = set.yMin
                     }
                 }
                 else
                 {
-                    if dataset.yMax > rightAxisMax
+                    if set.yMax > rightAxisMax
                     {
-                        rightAxisMax = dataset.yMax
+                        rightAxisMax = set.yMax
                     }
-                    if dataset.yMin < rightAxisMin
+                    if set.yMin < rightAxisMin
                     {
-                        rightAxisMin = dataset.yMin
+                        rightAxisMin = set.yMin
                     }
                 }
             }

--- a/Source/Charts/Highlight/PieHighlighter.swift
+++ b/Source/Charts/Highlight/PieHighlighter.swift
@@ -18,7 +18,7 @@ open class PieHighlighter: PieRadarHighlighter
     open override func closestHighlight(index: Int, x: CGFloat, y: CGFloat) -> Highlight?
     {
         guard
-            let set = chart?.data?.dataSets[0],
+            let set = chart?.data?[0],
             let entry = set.entryForIndex(index)
             else { return nil }
                 

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -71,7 +71,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             }
         }
 
-        _buffers = zip(_buffers, barData.dataSets).map { buffer, set -> Buffer in
+        _buffers = zip(_buffers, barData).map { buffer, set -> Buffer in
             let set = set as! BarChartDataSetProtocol
             let size = set.entryCount * (set.isStacked ? set.stackSize : 1)
             return buffer.count == size
@@ -436,17 +436,15 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 let barData = dataProvider.barData
                 else { return }
 
-            let dataSets = barData.dataSets
-
             let valueOffsetPlus: CGFloat = 4.5
             var posOffset: CGFloat
             var negOffset: CGFloat
             let drawValueAboveBar = dataProvider.isDrawValueAboveBarEnabled
             
-            for dataSetIndex in barData.dataSets.indices
+            for dataSetIndex in barData.indices
             {
                 guard
-                    let dataSet = dataSets[dataSetIndex] as? BarChartDataSetProtocol,
+                    let dataSet = barData[dataSetIndex] as? BarChartDataSetProtocol,
                     shouldDrawValues(forDataSet: dataSet)
                     else { continue }
                 

--- a/Source/Charts/Renderers/BubbleChartRenderer.swift
+++ b/Source/Charts/Renderers/BubbleChartRenderer.swift
@@ -170,8 +170,6 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
                 continue
             }
 
-            guard shouldDrawValues(forDataSet: dataSet) else { continue }
-
             let formatter = dataSet.valueFormatter
             let alpha = phaseX == 1 ? phaseY : phaseX
 

--- a/Source/Charts/Renderers/BubbleChartRenderer.swift
+++ b/Source/Charts/Renderers/BubbleChartRenderer.swift
@@ -45,7 +45,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
             accessibleChartElements.append(element)
         }
 
-        for (i, set) in (bubbleData.dataSets as! [BubbleChartDataSetProtocol]).enumerated() where set.isVisible
+        for case let (i, set) as (Int, BubbleChartDataSetProtocol) in bubbleData.enumerated() where set.isVisible
         {
             drawDataSet(context: context, dataSet: set, dataSetIndex: i)
         }
@@ -153,8 +153,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
         guard let
             dataProvider = dataProvider,
             let bubbleData = dataProvider.bubbleData,
-            isDrawingValuesAllowed(dataProvider: dataProvider),
-            let dataSets = bubbleData.dataSets as? [BubbleChartDataSetProtocol]
+            isDrawingValuesAllowed(dataProvider: dataProvider)
             else { return }
 
         let phaseX = max(0.0, min(1.0, animator.phaseX))
@@ -162,9 +161,14 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
 
         var pt = CGPoint()
 
-        for i in dataSets.indices
+        for i in bubbleData.indices
         {
-            let dataSet = dataSets[i]
+            guard let dataSet = bubbleData[i] as? BubbleChartDataSetProtocol,
+                  shouldDrawValues(forDataSet: dataSet)
+            else
+            {
+                continue
+            }
 
             guard shouldDrawValues(forDataSet: dataSet) else { continue }
 

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -38,7 +38,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
             accessibleChartElements.append(element)
         }
 
-        for set in candleData.dataSets as! [CandleChartDataSetProtocol] where set.isVisible
+        for case let set as CandleChartDataSetProtocol in candleData where set.isVisible
         {
             drawDataSet(context: context, dataSet: set)
         }
@@ -81,7 +81,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
             let high = e.high
             let low = e.low
             
-            let doesContainMultipleDataSets = (dataProvider.candleData?.dataSets.count ?? 1) > 1
+            let doesContainMultipleDataSets = (dataProvider.candleData?.count ?? 1) > 1
             var accessibilityMovementDescription = "neutral"
             var accessibilityRect = CGRect(x: CGFloat(xPos) + 0.5 - barSpace,
                                            y: CGFloat(low * phaseY),
@@ -275,16 +275,14 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
         // if values are drawn
         if isDrawingValuesAllowed(dataProvider: dataProvider)
         {
-            let dataSets = candleData.dataSets
-            
             let phaseY = animator.phaseY
             
             var pt = CGPoint()
             
-            for i in dataSets.indices
+            for i in candleData.indices
             {
                 guard let
-                    dataSet = dataSets[i] as? BarLineScatterCandleBubbleChartDataSetProtocol,
+                    dataSet = candleData[i] as? BarLineScatterCandleBubbleChartDataSetProtocol,
                     shouldDrawValues(forDataSet: dataSet)
                     else { continue }
                 

--- a/Source/Charts/Renderers/DataRenderer.swift
+++ b/Source/Charts/Renderers/DataRenderer.swift
@@ -64,10 +64,8 @@ internal struct AccessibleHeader {
         let chartDescriptionText = chart.chartDescription.text ?? defaultDescription
         let dataSetDescriptions = data.map { $0.label ?? "" }
         let dataSetDescriptionText = dataSetDescriptions.joined(separator: ", ")
-        let dataSetCount = data.count
-        
-        let
-        element = NSUIAccessibilityElement(accessibilityContainer: chart)
+
+        let element = NSUIAccessibilityElement(accessibilityContainer: chart)
         element.accessibilityLabel = chartDescriptionText + ". \(data.count) dataset\(data.count == 1 ? "" : "s"). \(dataSetDescriptionText)"
         element.accessibilityFrame = chart.bounds
         element.isHeader = true

--- a/Source/Charts/Renderers/DataRenderer.swift
+++ b/Source/Charts/Renderers/DataRenderer.swift
@@ -62,8 +62,9 @@ internal struct AccessibleHeader {
                                 withDefaultDescription defaultDescription: String = "Chart") -> NSUIAccessibilityElement
     {
         let chartDescriptionText = chart.chartDescription.text ?? defaultDescription
-        let dataSetDescriptions = data.dataSets.map { $0.label ?? "" }
+        let dataSetDescriptions = data.map { $0.label ?? "" }
         let dataSetDescriptionText = dataSetDescriptions.joined(separator: ", ")
+        let dataSetCount = data.count
         
         let
         element = NSUIAccessibilityElement(accessibilityContainer: chart)

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -51,7 +51,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
             
             for i in barData.indices
             {
-                let set = barData.dataSets[i] as! BarChartDataSetProtocol
+                let set = barData[i] as! BarChartDataSetProtocol
                 let size = set.entryCount * (set.isStacked ? set.stackSize : 1)
                 if _buffers[i].rects.count != size
                 {
@@ -323,9 +323,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 let dataProvider = dataProvider,
                 let barData = dataProvider.barData
                 else { return }
-            
-            let dataSets = barData.dataSets
-            
+
             let textAlign = NSTextAlignment.left
             
             let valueOffsetPlus: CGFloat = 5.0
@@ -336,7 +334,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
             for dataSetIndex in barData.indices
             {
                 guard let
-                    dataSet = dataSets[dataSetIndex] as? BarChartDataSetProtocol,
+                    dataSet = barData[dataSetIndex] as? BarChartDataSetProtocol,
                     shouldDrawValues(forDataSet: dataSet)
                     else { continue }
                 

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -527,16 +527,14 @@ open class LineChartRenderer: LineRadarRenderer
 
         if isDrawingValuesAllowed(dataProvider: dataProvider)
         {
-            let dataSets = lineData.dataSets
-            
             let phaseY = animator.phaseY
             
             var pt = CGPoint()
             
-            for i in dataSets.indices
+            for i in lineData.indices
             {
                 guard let
-                    dataSet = dataSets[i] as? LineChartDataSetProtocol,
+                    dataSet = lineData[i] as? LineChartDataSetProtocol,
                     shouldDrawValues(forDataSet: dataSet)
                     else { continue }
                 
@@ -618,8 +616,6 @@ open class LineChartRenderer: LineRadarRenderer
             else { return }
         
         let phaseY = animator.phaseY
-
-        let dataSets = lineData.dataSets
         
         var pt = CGPoint()
         var rect = CGRect()
@@ -638,7 +634,7 @@ open class LineChartRenderer: LineRadarRenderer
 
         context.saveGState()
 
-        for i in dataSets.indices
+        for i in lineData.indices
         {
             guard let dataSet = lineData[i] as? LineChartDataSetProtocol else { continue }
 

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -38,20 +38,15 @@ open class PieChartRenderer: NSObject, DataRenderer
     
     open func drawData(context: CGContext)
     {
-        guard let chart = chart else { return }
+        guard let chart = chart, let pieData = chart.data else { return }
 
-        let pieData = chart.data
+        // If we redraw the data, remove and repopulate accessible elements to update label values and frames
+        accessibleChartElements.removeAll()
 
-        if pieData != nil
+        for case let set as PieChartDataSetProtocol in pieData where
+            set.isVisible && set.entryCount > 0
         {
-            // If we redraw the data, remove and repopulate accessible elements to update label values and frames
-            accessibleChartElements.removeAll()
-
-            for set in pieData!.dataSets as! [PieChartDataSetProtocol]
-                where set.isVisible && set.entryCount > 0
-            {
-                drawDataSet(context: context, dataSet: set)
-            }
+            drawDataSet(context: context, dataSet: set)
         }
     }
 
@@ -326,8 +321,6 @@ open class PieChartRenderer: NSObject, DataRenderer
 
         let labelRadius = radius - labelRadiusOffset
 
-        let dataSets = data.dataSets
-
         let yValueSum = (data as! PieChartData).yValueSum
 
         let drawEntryLabels = chart.isDrawEntryLabelsEnabled
@@ -340,9 +333,9 @@ open class PieChartRenderer: NSObject, DataRenderer
         context.saveGState()
         defer { context.restoreGState() }
 
-        for i in dataSets.indices
+        for i in data.indices
         {
-            guard let dataSet = dataSets[i] as? PieChartDataSetProtocol else { continue }
+            guard let dataSet = data[i] as? PieChartDataSetProtocol else { continue }
             
             let drawValues = dataSet.isDrawValuesEnabled
 

--- a/Source/Charts/Renderers/RadarChartRenderer.swift
+++ b/Source/Charts/Renderers/RadarChartRenderer.swift
@@ -35,29 +35,26 @@ open class RadarChartRenderer: LineRadarRenderer
     
     open override func drawData(context: CGContext)
     {
-        guard let chart = chart else { return }
-        
-        let radarData = chart.data
-        
-        if radarData != nil
+        guard let chart = chart,
+              let radarData = chart.data as? RadarChartData else
         {
-            let mostEntries = radarData?.maxEntryCountSet?.entryCount ?? 0
+            return
+        }
+        
+        let mostEntries = radarData.maxEntryCountSet?.entryCount ?? 0
 
-            // If we redraw the data, remove and repopulate accessible elements to update label values and frames
-            self.accessibleChartElements.removeAll()
+        // If we redraw the data, remove and repopulate accessible elements to update label values and frames
+        self.accessibleChartElements.removeAll()
 
-            // Make the chart header the first element in the accessible elements array
-            if let accessibilityHeaderData = radarData as? RadarChartData {
-                let element = createAccessibleHeader(usingChart: chart,
-                                                     andData: accessibilityHeaderData,
-                                                     withDefaultDescription: "Radar Chart")
-                self.accessibleChartElements.append(element)
-            }
+        // Make the chart header the first element in the accessible elements array
+        let element = createAccessibleHeader(usingChart: chart,
+                                             andData: radarData,
+                                             withDefaultDescription: "Radar Chart")
+        self.accessibleChartElements.append(element)
 
-            for set in radarData!.dataSets as! [RadarChartDataSetProtocol] where set.isVisible
-            {
-                drawDataSet(context: context, dataSet: set, mostEntries: mostEntries)
-            }
+        for case let set as RadarChartDataSetProtocol in radarData where set.isVisible
+        {
+            drawDataSet(context: context, dataSet: set, mostEntries: mostEntries)
         }
     }
     

--- a/Source/Charts/Renderers/ScatterChartRenderer.swift
+++ b/Source/Charts/Renderers/ScatterChartRenderer.swift
@@ -113,18 +113,15 @@ open class ScatterChartRenderer: LineScatterCandleRadarRenderer
         
         // if values are drawn
         if isDrawingValuesAllowed(dataProvider: dataProvider)
-        {
-            guard let dataSets = scatterData.dataSets as? [ScatterChartDataSetProtocol] else { return }
-            
+        {            
             let phaseY = animator.phaseY
             
             var pt = CGPoint()
             
             for i in scatterData.indices
             {
-                let dataSet = dataSets[i]
-
-                guard shouldDrawValues(forDataSet: dataSet)
+                guard let dataSet = scatterData[i] as? ScatterChartDataSetProtocol,
+                      shouldDrawValues(forDataSet: dataSet)
                     else { continue }
                 
                 let valueFont = dataSet.valueFont


### PR DESCRIPTION
### Goals :soccer:
New Collection API is encouraged for access to data sets in ChartData. DataSets is only exposed for custom chart use cases (like PieChartData). We should not be relying on it internally. There are a couple oddities that (have always) exist like down casting elements to a specific type. Those won't be resolved until objc support is either removed, or refactored out of the main chart data types.