### PR TITLE
Remove misuse of `count`

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -312,7 +312,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         guard
             description.isEnabled,
             let descriptionText = description.text,
-            descriptionText.count > 0
+            !descriptionText.isEmpty
             else { return }
         
         let position = description.position ?? CGPoint(x: bounds.width - viewPortHandler.offsetRight - description.xOffset,

--- a/Source/Charts/Charts/CombinedChartView.swift
+++ b/Source/Charts/Charts/CombinedChartView.swift
@@ -213,7 +213,7 @@ open class CombinedChartView: BarLineChartViewBase, CombinedChartDataProvider
             isDrawMarkersEnabled && valuesToHighlight()
             else { return }
         
-        for i in 0 ..< highlighted.count
+        for i in highlighted.indices
         {
             let highlight = highlighted[i]
             

--- a/Source/Charts/Charts/PieRadarChartViewBase.swift
+++ b/Source/Charts/Charts/PieRadarChartViewBase.swift
@@ -678,7 +678,6 @@ open class PieRadarChartViewBase: ChartViewBase
 
         // Remove samples older than our sample time - 1 seconds
         // while keeping at least one sample
-        
         var i = 0, count = velocitySamples.count
         while (i < count - 2)
         {

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -135,7 +135,7 @@ open class AxisBase: ComponentBase
     {
         var longest = ""
         
-        for i in 0 ..< entries.count
+        for i in entries.indices
         {
             let text = getFormattedLabel(i)
             
@@ -151,10 +151,7 @@ open class AxisBase: ComponentBase
     /// - Returns: The formatted label at the specified index. This will either use the auto-formatter or the custom formatter (if one is set).
     @objc open func getFormattedLabel(_ index: Int) -> String
     {
-        if index < 0 || index >= entries.count
-        {
-            return ""
-        }
+        guard entries.indices.contains(index) else { return "" }
         
         return valueFormatter?.stringForValue(entries[index], axis: self) ?? ""
     }

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -229,7 +229,7 @@ open class Legend: ComponentBase
             
             var wasStacked = false
             
-            for i in 0 ..< entryCount
+            for i in entries.indices
             {
                 let e = entries[i]
                 let drawingForm = e.form != .none
@@ -311,7 +311,7 @@ open class Legend: ComponentBase
             var requiredWidth: CGFloat = 0.0
             var stackedStartIndex: Int = -1
             
-            for i in 0 ..< entryCount
+            for i in entries.indices
             {
                 let e = entries[i]
                 let drawingForm = e.form != .none
@@ -384,7 +384,7 @@ open class Legend: ComponentBase
             
             neededWidth = maxLineWidth
             neededHeight = labelLineHeight * CGFloat(calculatedLineSizes.count) +
-                yEntrySpace * CGFloat(calculatedLineSizes.count == 0 ? 0 : (calculatedLineSizes.count - 1))
+                yEntrySpace * CGFloat(calculatedLineSizes.isEmpty ? 0 : (calculatedLineSizes.count - 1))
         }
         
         neededWidth += xOffset

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -89,22 +89,14 @@ open class BarChartDataEntry: ChartDataEntry
         self.data = data
     }
     
-    @objc open func sumBelow(stackIndex :Int) -> Double
+    @objc open func sumBelow(stackIndex: Int) -> Double
     {
-        guard let yVals = _yVals else
+        guard let yVals = _yVals, yVals.indices.contains(stackIndex) else
         {
             return 0
         }
-        
-        var remainder: Double = 0.0
-        var index = yVals.count - 1
-        
-        while (index > stackIndex && index >= 0)
-        {
-            remainder += yVals[index]
-            index -= 1
-        }
-        
+
+        let remainder = yVals[stackIndex...].reduce(into: 0.0) { $0 += $1 }
         return remainder
     }
     

--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -258,7 +258,7 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     /// - Returns: The entry that is highlighted
     @objc open func entry(for highlight: Highlight) -> ChartDataEntry?
     {
-        guard highlight.dataSetIndex < dataSets.count else { return nil }
+        guard highlight.dataSetIndex < dataSets.endIndex else { return nil }
         return self[highlight.dataSetIndex].entryForXValue(highlight.x, closestToY: highlight.y)
     }
     
@@ -277,7 +277,7 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     @objc(dataSetAtIndex:)
     open func dataSet(at index: Index) -> Element?
     {
-        guard index >= 0 && index < dataSets.count else { return nil }
+        guard dataSets.indices.contains(index) else { return nil }
         return self[index]
     }
 
@@ -295,7 +295,7 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     @objc(addEntry:dataSetIndex:)
     open func appendEntry(_ e: ChartDataEntry, toDataSet dataSetIndex: Index)
     {
-        guard dataSets.count > dataSetIndex && dataSetIndex >= 0 else {
+        guard dataSets.indices.contains(dataSetIndex) else {
             return print("ChartData.addEntry() - Cannot add Entry because dataSetIndex too high or too low.", terminator: "\n")
         }
 
@@ -307,7 +307,7 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     /// Removes the given Entry object from the DataSet at the specified index.
     @objc @discardableResult open func removeEntry(_ entry: ChartDataEntry, dataSetIndex: Index) -> Bool
     {
-        guard dataSetIndex < dataSets.count else { return false }
+        guard dataSets.indices.contains(dataSetIndex) else { return false }
 
         // remove the entry from the dataset
         let removed = self[dataSetIndex].removeEntry(entry)
@@ -327,7 +327,7 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     @objc @discardableResult open func removeEntry(xValue: Double, dataSetIndex: Index) -> Bool
     {
         guard
-            dataSetIndex < dataSets.count,
+            dataSets.indices.contains(dataSetIndex),
             let entry = self[dataSetIndex].entryForXValue(xValue, closestToY: .nan)
             else { return false }
 

--- a/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/CombinedChartData.swift
@@ -252,20 +252,8 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
     /// - Returns: The entry that is highlighted
     @objc override open func entry(for highlight: Highlight) -> ChartDataEntry?
     {
-        if highlight.dataIndex >= allData.count
-        {
-            return nil
-        }
-        
-        let data = dataByIndex(highlight.dataIndex)
-        
-        if highlight.dataSetIndex >= data.endIndex
-        {
-            return nil
-        }
-        
         // The value of the highlighted entry could be NaN - if we are not interested in highlighting a specific value.
-        return data[highlight.dataSetIndex]
+        getDataSetByHighlight(highlight)?
             .entriesForXValue(highlight.x)
             .first { $0.y == highlight.y || highlight.y.isNaN }
     }
@@ -276,20 +264,21 @@ open class CombinedChartData: BarLineScatterCandleBubbleChartData
     ///   - highlight: current highlight
     /// - Returns: dataset related to highlight
     @objc open func getDataSetByHighlight(_ highlight: Highlight) -> ChartDataSetProtocol!
-    {  
-        if highlight.dataIndex >= allData.count
+    {
+        guard allData.indices.contains(highlight.dataIndex) else
         {
             return nil
         }
-        
+
         let data = dataByIndex(highlight.dataIndex)
-        
-        if highlight.dataSetIndex >= data.endIndex
+
+        guard data.indices.contains(highlight.dataSetIndex) else
         {
             return nil
         }
-        
-        return data.dataSets[highlight.dataSetIndex]
+
+        // The value of the highlighted entry could be NaN - if we are not interested in highlighting a specific value.
+        return data[highlight.dataSetIndex]
     }
 
     // MARK: Unsupported Collection Methods

--- a/Source/Charts/Data/Implementations/Standard/PieChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartData.swift
@@ -69,7 +69,7 @@ open class PieChartData: ChartData
     
     open override func dataSet(forLabel label: String, ignorecase: Bool) -> ChartDataSetProtocol?
     {
-        if dataSets.count == 0 || dataSets[0].label == nil
+        if dataSets.first?.label == nil
         {
             return nil
         }

--- a/Source/Charts/Filters/DataApproximator+N.swift
+++ b/Source/Charts/Filters/DataApproximator+N.swift
@@ -78,12 +78,12 @@ extension DataApproximator {
         var keep = [Bool](repeating: false, count: points.count)
         
         // first and last always stay
-        keep[0] = true
-        keep[points.count - 1] = true
+        keep[points.startIndex] = true
+        keep[points.endIndex - 1] = true
         var currentStoredPoints = 2
         
         var queue = [LineAlt]()
-        let line = LineAlt(start: 0, end: points.count - 1, points: points)
+        let line = LineAlt(start: points.startIndex, end: points.endIndex - 1, points: points)
         queue.append(line)
         
         repeat {

--- a/Source/Charts/Filters/DataApproximator.swift
+++ b/Source/Charts/Filters/DataApproximator.swift
@@ -27,14 +27,14 @@ open class DataApproximator: NSObject
         var keep = [Bool](repeating: false, count: points.count)
         
         // first and last always stay
-        keep[0] = true
-        keep[points.count - 1] = true
+        keep[points.startIndex] = true
+        keep[points.endIndex - 1] = true
         
         // first and last entry are entry point to recursion
         reduceWithDouglasPeuker(points: points,
                                 tolerance: tolerance,
-                                start: 0,
-                                end: points.count - 1,
+                                start: points.startIndex,
+                                end: points.endIndex - 1,
                                 keep: &keep)
         
         // create a new array with series, only take the kept ones

--- a/Source/Charts/Formatters/IndexAxisValueFormatter.swift
+++ b/Source/Charts/Formatters/IndexAxisValueFormatter.swift
@@ -15,22 +15,8 @@ import Foundation
 @objc(ChartIndexAxisValueFormatter)
 open class IndexAxisValueFormatter: NSObject, AxisValueFormatter
 {
-    private var _values: [String] = [String]()
-    private var _valueCount: Int = 0
-    
-    @objc public var values: [String]
-    {
-        get
-        {
-            return _values
-        }
-        set
-        {
-            _values = newValue
-            _valueCount = _values.count
-        }
-    }
-    
+    @objc public var values: [String] = [String]()
+
     public override init()
     {
         super.init()
@@ -54,6 +40,6 @@ open class IndexAxisValueFormatter: NSObject, AxisValueFormatter
     {
         let index = Int(value.rounded())
         guard values.indices.contains(index), index == Int(value) else { return "" }
-        return _values[index]
+        return values[index]
     }
 }

--- a/Source/Charts/Highlight/BarHighlighter.swift
+++ b/Source/Charts/Highlight/BarHighlighter.swift
@@ -74,7 +74,7 @@ open class BarHighlighter: ChartHighlighter
         
         guard
             let ranges = entry.ranges,
-            ranges.count > 0
+            !ranges.isEmpty
             else { return nil }
 
         let stackIndex = getClosestStackIndex(ranges: ranges, value: yValue)
@@ -101,7 +101,7 @@ open class BarHighlighter: ChartHighlighter
         if let stackIndex = ranges.firstIndex(where: { $0.contains(value) }) {
             return stackIndex
         } else {
-            let length = max(ranges.count - 1, 0)
+            let length = max(ranges.endIndex - 1, 0)
             return (value > ranges[length].to) ? length : 0
         }
     }

--- a/Source/Charts/Highlight/ChartHighlighter.swift
+++ b/Source/Charts/Highlight/ChartHighlighter.swift
@@ -93,7 +93,7 @@ open class ChartHighlighter : NSObject, Highlighter
         guard let chart = self.chart as? BarLineScatterCandleBubbleChartDataProvider else { return [] }
         
         var entries = set.entriesForXValue(xValue)
-        if entries.count == 0, let closest = set.entryForXValue(xValue, closestToY: .nan, rounding: rounding)
+        if entries.isEmpty, let closest = set.entryForXValue(xValue, closestToY: .nan, rounding: rounding)
         {
             // Try to find closest x-value and take all entries for that x-value
             entries = set.entriesForXValue(closest.x)

--- a/Source/Charts/Highlight/CombinedHighlighter.swift
+++ b/Source/Charts/Highlight/CombinedHighlighter.swift
@@ -35,7 +35,7 @@ open class CombinedHighlighter: ChartHighlighter
             let dataObjects = chart.combinedData?.allData
             else { return vals }
         
-        for i in 0..<dataObjects.count
+        for i in dataObjects.indices
         {
             let dataObject = dataObjects[i]
 

--- a/Source/Charts/Highlight/HorizontalBarHighlighter.swift
+++ b/Source/Charts/Highlight/HorizontalBarHighlighter.swift
@@ -43,7 +43,7 @@ open class HorizontalBarHighlighter: BarHighlighter
         guard let chart = self.chart as? BarLineScatterCandleBubbleChartDataProvider else { return [] }
         
         var entries = set.entriesForXValue(xValue)
-        if entries.count == 0, let closest = set.entryForXValue(xValue, closestToY: .nan, rounding: rounding)
+        if entries.isEmpty, let closest = set.entryForXValue(xValue, closestToY: .nan, rounding: rounding)
         {
             // Try to find closest x-value and take all entries for that x-value
             entries = set.entriesForXValue(closest.x)

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -58,7 +58,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
     {
         guard let barData = dataProvider?.barData else { return _buffers.removeAll() }
 
-        // Matche buffers count to dataset count
+        // Match buffers count to dataset count
         if _buffers.count != barData.count
         {
             while _buffers.count < barData.count
@@ -558,7 +558,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                             var posY = 0.0
                             var negY = -e.negativeSum
 
-                            for k in 0 ..< vals.count
+                            for k in vals.indices
                             {
                                 let value = vals[k]
                                 var y: Double
@@ -661,7 +661,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                             }
                         }
 
-                        bufferIndex = vals == nil ? (bufferIndex + 1) : (bufferIndex + vals!.count)
+                        bufferIndex += vals?.count ?? 1
                     }
                 }
             }
@@ -801,7 +801,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             let labelCount = min(dataSet.colors.count, stackSize)
 
             let stackLabel: String?
-            if (dataSet.stackLabels.count > 0 && labelCount > 0) {
+            if (!dataSet.stackLabels.isEmpty && labelCount > 0) {
                 let labelIndex = idx % labelCount
                 stackLabel = dataSet.stackLabels.indices.contains(labelIndex) ? dataSet.stackLabels[labelIndex] : nil
             } else {

--- a/Source/Charts/Renderers/BubbleChartRenderer.swift
+++ b/Source/Charts/Renderers/BubbleChartRenderer.swift
@@ -162,7 +162,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
 
         var pt = CGPoint()
 
-        for i in 0..<dataSets.count
+        for i in dataSets.indices
         {
             let dataSet = dataSets[i]
 

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -281,7 +281,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
             
             var pt = CGPoint()
             
-            for i in 0 ..< dataSets.count
+            for i in dataSets.indices
             {
                 guard let
                     dataSet = dataSets[i] as? BarLineScatterCandleBubbleChartDataSetProtocol,

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -170,19 +170,6 @@ open class CombinedChartRenderer: NSObject, DataRenderer
         return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
     }
 
-    /// - Returns: The sub-renderer object at the specified index.
-    @objc open func getSubRenderer(index: Int) -> DataRenderer?
-    {
-        if index >= _renderers.count || index < 0
-        {
-            return nil
-        }
-        else
-        {
-            return _renderers[index]
-        }
-    }
-
     /// All sub-renderers.
     @objc open var subRenderers: [DataRenderer]
     {
@@ -209,7 +196,7 @@ open class CombinedChartRenderer: NSObject, DataRenderer
         }
         set
         {
-            if newValue.count > 0
+            if !newValue.isEmpty
             {
                 _drawOrder = newValue
             }

--- a/Source/Charts/Renderers/DataRenderer.swift
+++ b/Source/Charts/Renderers/DataRenderer.swift
@@ -64,11 +64,10 @@ internal struct AccessibleHeader {
         let chartDescriptionText = chart.chartDescription.text ?? defaultDescription
         let dataSetDescriptions = data.dataSets.map { $0.label ?? "" }
         let dataSetDescriptionText = dataSetDescriptions.joined(separator: ", ")
-        let dataSetCount = data.dataSets.count
         
         let
         element = NSUIAccessibilityElement(accessibilityContainer: chart)
-        element.accessibilityLabel = chartDescriptionText + ". \(dataSetCount) dataset\(dataSetCount == 1 ? "" : "s"). \(dataSetDescriptionText)"
+        element.accessibilityLabel = chartDescriptionText + ". \(data.count) dataset\(data.count == 1 ? "" : "s"). \(dataSetDescriptionText)"
         element.accessibilityFrame = chart.bounds
         element.isHeader = true
         

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -129,7 +129,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 var yStart = 0.0
                 
                 // fill the stack
-                for k in 0 ..< vals!.count
+                for k in vals!.indices
                 {
                     let value = vals![k]
                     
@@ -245,7 +245,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
         let isStacked = dataSet.isStacked
         let stackSize = isStacked ? dataSet.stackSize : 1
 
-        for j in stride(from: 0, to: buffer.rects.count, by: 1)
+        for j in buffer.rects.indices
         {
             let barRect = buffer.rects[j]
             
@@ -518,7 +518,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                             var posY = 0.0
                             var negY = -e.negativeSum
                             
-                            for k in 0 ..< vals.count
+                            for k in vals.indices
                             {
                                 let value = vals[k]
                                 var y: Double
@@ -544,7 +544,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                             
                             trans.pointValuesToPixel(&transformed)
                             
-                            for k in 0 ..< transformed.count
+                            for k in transformed.indices
                             {
                                 let val = vals[k]
                                 let valueText = formatter.stringForValue(
@@ -607,7 +607,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                             }
                         }
                         
-                        bufferIndex = vals == nil ? (bufferIndex + 1) : (bufferIndex + vals!.count)
+                        bufferIndex += vals?.count ?? 1
                     }
                 }
             }

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -54,7 +54,7 @@ open class LegendRenderer: NSObject, Renderer
                     for j in 0..<minEntries
                     {
                         let label: String?
-                        if sLabels.count > 0 && minEntries > 0
+                        if !sLabels.isEmpty && minEntries > 0
                         {
                             let labelIndex = j % minEntries
                             label = sLabels.indices.contains(labelIndex) ? sLabels[labelIndex] : nil
@@ -295,13 +295,13 @@ open class LegendRenderer: NSObject, Renderer
             
             var lineIndex: Int = 0
             
-            for i in 0 ..< entries.count
+            for i in entries.indices
             {
                 let e = entries[i]
                 let drawingForm = e.form != .none
                 let formSize = e.formSize.isNaN ? defaultFormSize : e.formSize
                 
-                if i < calculatedLabelBreakPoints.count &&
+                if i < calculatedLabelBreakPoints.endIndex &&
                     calculatedLabelBreakPoints[i]
                 {
                     posX = originPosX
@@ -310,7 +310,7 @@ open class LegendRenderer: NSObject, Renderer
                 
                 if posX == originPosX &&
                     horizontalAlignment == .center &&
-                    lineIndex < calculatedLineSizes.count
+                    lineIndex < calculatedLineSizes.endIndex
                 {
                     posX += (direction == .rightToLeft
                         ? calculatedLineSizes[lineIndex].width
@@ -400,7 +400,7 @@ open class LegendRenderer: NSObject, Renderer
                 posY = viewPortHandler.chartHeight / 2.0 - legend.neededHeight / 2.0 + legend.yOffset
             }
             
-            for i in 0 ..< entries.count
+            for i in entries.indices
             {
                 let e = entries[i]
                 let drawingForm = e.form != .none
@@ -526,7 +526,7 @@ open class LegendRenderer: NSObject, Renderer
             
             context.setLineWidth(formLineWidth)
             
-            if formLineDashLengths != nil && formLineDashLengths!.count > 0
+            if formLineDashLengths != nil && !formLineDashLengths!.isEmpty
             {
                 context.setLineDash(phase: formLineDashPhase, lengths: formLineDashLengths!)
             }

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -367,11 +367,8 @@ open class LineChartRenderer: LineRadarRenderer
                     _lineSegments[1] = _lineSegments[0]
                 }
 
-                for i in 0..<_lineSegments.count
-                {
-                    _lineSegments[i] = _lineSegments[i].applying(valueToPixelMatrix)
-                }
-                
+                _lineSegments = _lineSegments.map { $0.applying(valueToPixelMatrix) }
+
                 if (!viewPortHandler.isInBoundsRight(_lineSegments[0].x))
                 {
                     break
@@ -536,7 +533,7 @@ open class LineChartRenderer: LineRadarRenderer
             
             var pt = CGPoint()
             
-            for i in 0 ..< dataSets.count
+            for i in dataSets.indices
             {
                 guard let
                     dataSet = dataSets[i] as? LineChartDataSetProtocol,
@@ -641,7 +638,7 @@ open class LineChartRenderer: LineRadarRenderer
 
         context.saveGState()
 
-        for i in 0 ..< dataSets.count
+        for i in dataSets.indices
         {
             guard let dataSet = lineData[i] as? LineChartDataSetProtocol else { continue }
 

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -340,7 +340,7 @@ open class PieChartRenderer: NSObject, DataRenderer
         context.saveGState()
         defer { context.restoreGState() }
 
-        for i in 0 ..< dataSets.count
+        for i in dataSets.indices
         {
             guard let dataSet = dataSets[i] as? PieChartDataSetProtocol else { continue }
             
@@ -704,7 +704,7 @@ open class PieChartRenderer: NSObject, DataRenderer
         }
     }
     
-    open func drawHighlighted(context: CGContext, indices: [Highlight])
+    open func drawHighlighted(context: CGContext, highlights: [Highlight])
     {
         guard
             let chart = chart,
@@ -729,18 +729,17 @@ open class PieChartRenderer: NSObject, DataRenderer
         // Append highlighted accessibility slices into this array, so we can prioritize them over unselected slices
         var highlightedAccessibleElements: [NSUIAccessibilityElement] = []
 
-        for i in 0 ..< indices.count
+        for hightlight in highlights
         {
             // get the index to highlight
-            let index = Int(indices[i].x)
-            if index >= drawAngles.count
+            let index = Int(hightlight.x)
+            guard index < drawAngles.count,
+                  let set = data[hightlight.dataSetIndex] as? PieChartDataSetProtocol,
+                  set.isHighlightEnabled
+            else
             {
                 continue
             }
-            
-            guard let set = data[indices[i].dataSetIndex] as? PieChartDataSetProtocol else { continue }
-            
-            if !set.isHighlightEnabled { continue }
 
             let entryCount = set.entryCount
             var visibleAngleCount = 0

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -704,7 +704,7 @@ open class PieChartRenderer: NSObject, DataRenderer
         }
     }
     
-    open func drawHighlighted(context: CGContext, highlights: [Highlight])
+    open func drawHighlighted(context: CGContext, indices highlights: [Highlight])
     {
         guard
             let chart = chart,

--- a/Source/Charts/Utils/ChartColorTemplates.swift
+++ b/Source/Charts/Utils/ChartColorTemplates.swift
@@ -89,41 +89,37 @@ open class ChartColorTemplates: NSObject
         if colorString.hasPrefix("#")
         {
             var argb: [UInt] = [255, 0, 0, 0]
-            let colorString = colorString.unicodeScalars
-            var length = colorString.count
+            let colorString = colorString.unicodeScalars.dropFirst()
+            let length = colorString.count
             var index = colorString.startIndex
             let endIndex = colorString.endIndex
-            
-            index = colorString.index(after: index)
-            length = length - 1
-            
-            if length == 3 || length == 6 || length == 8
+
+            guard [3, 6, 8].contains(length) else { return .black }
+
+            var i = length == 8 ? 0 : 1
+            while index < endIndex
             {
-                var i = length == 8 ? 0 : 1
-                while index < endIndex
+                var c = colorString[index]
+                index = colorString.index(after: index)
+
+                var val = (c.value >= 0x61 && c.value <= 0x66) ? (c.value - 0x61 + 10) : c.value - 0x30
+                argb[i] = UInt(val) * 16
+                if length == 3
                 {
-                    var c = colorString[index]
-                    index = colorString.index(after: index)
-                    
-                    var val = (c.value >= 0x61 && c.value <= 0x66) ? (c.value - 0x61 + 10) : c.value - 0x30
-                    argb[i] = UInt(val) * 16
-                    if length == 3
-                    {
-                        argb[i] = argb[i] + UInt(val)
-                    }
-                    else
-                    {
-                        c = colorString[index]
-                        index = colorString.index(after: index)
-                        
-                        val = (c.value >= 0x61 && c.value <= 0x66) ? (c.value - 0x61 + 10) : c.value - 0x30
-                        argb[i] = argb[i] + UInt(val)
-                    }
-                    
-                    i += 1
+                    argb[i] = argb[i] + UInt(val)
                 }
+                else
+                {
+                    c = colorString[index]
+                    index = colorString.index(after: index)
+
+                    val = (c.value >= 0x61 && c.value <= 0x66) ? (c.value - 0x61 + 10) : c.value - 0x30
+                    argb[i] = argb[i] + UInt(val)
+                }
+
+                i += 1
             }
-            
+
             return NSUIColor(red: CGFloat(argb[1]) / 255.0, green: CGFloat(argb[2]) / 255.0, blue: CGFloat(argb[3]) / 255.0, alpha: CGFloat(argb[0]) / 255.0)
         }
         else if colorString.hasPrefix("rgba")

--- a/Source/Charts/Utils/ChartColorTemplates.swift
+++ b/Source/Charts/Utils/ChartColorTemplates.swift
@@ -86,8 +86,6 @@ open class ChartColorTemplates: NSObject
 
         let colorString = colorString.lowercased()
         
-        let fallbackColor = NSUIColor(red: CGFloat(argb[1]) / 255.0, green: CGFloat(argb[2]) / 255.0, blue: CGFloat(argb[3]) / 255.0, alpha: CGFloat(argb[0]) / 255.0)
-        
         if colorString.hasPrefix("#")
         {
             var argb: [UInt] = [255, 0, 0, 0]
@@ -96,7 +94,7 @@ open class ChartColorTemplates: NSObject
             var index = colorString.startIndex
             let endIndex = colorString.endIndex
 
-            guard [3, 6, 8].contains(length) else { return fallbackColor }
+            guard [3, 6, 8].contains(length) else { return .black }
 
             var i = length == 8 ? 0 : 1
             while index < endIndex
@@ -122,7 +120,7 @@ open class ChartColorTemplates: NSObject
                 i += 1
             }
 
-            return fallbackColor
+            return NSUIColor(red: CGFloat(argb[1]) / 255.0, green: CGFloat(argb[2]) / 255.0, blue: CGFloat(argb[3]) / 255.0, alpha: CGFloat(argb[0]) / 255.0)
         }
         else if colorString.hasPrefix("rgba")
         {

--- a/Source/Charts/Utils/ChartColorTemplates.swift
+++ b/Source/Charts/Utils/ChartColorTemplates.swift
@@ -86,6 +86,8 @@ open class ChartColorTemplates: NSObject
 
         let colorString = colorString.lowercased()
         
+        let fallbackColor = NSUIColor(red: CGFloat(argb[1]) / 255.0, green: CGFloat(argb[2]) / 255.0, blue: CGFloat(argb[3]) / 255.0, alpha: CGFloat(argb[0]) / 255.0)
+        
         if colorString.hasPrefix("#")
         {
             var argb: [UInt] = [255, 0, 0, 0]
@@ -94,7 +96,7 @@ open class ChartColorTemplates: NSObject
             var index = colorString.startIndex
             let endIndex = colorString.endIndex
 
-            guard [3, 6, 8].contains(length) else { return .black }
+            guard [3, 6, 8].contains(length) else { return fallbackColor }
 
             var i = length == 8 ? 0 : 1
             while index < endIndex
@@ -120,7 +122,7 @@ open class ChartColorTemplates: NSObject
                 i += 1
             }
 
-            return NSUIColor(red: CGFloat(argb[1]) / 255.0, green: CGFloat(argb[2]) / 255.0, blue: CGFloat(argb[3]) / 255.0, alpha: CGFloat(argb[0]) / 255.0)
+            return fallbackColor
         }
         else if colorString.hasPrefix("rgba")
         {


### PR DESCRIPTION
`count` is frequently used on collections to infer other semantic meaning. These uses have been replaced with the correct version.