### PR TITLE
BuildFix: fix build as part of SPM

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -12,8 +12,10 @@
 import Foundation
 import CoreGraphics
 
-#if !os(OSX)
-    import UIKit
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 /// Base-class of LineChart, BarChart, ScatterChart and CandleStickChart.

--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -13,8 +13,10 @@
 import Foundation
 import CoreGraphics
 
-#if !os(OSX)
-    import UIKit
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 @objc

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -12,8 +12,10 @@
 import Foundation
 import CoreGraphics
 
-#if !os(OSX)
-    import UIKit
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 /// View that represents a pie chart. Draws cake like slices.

--- a/Source/Charts/Renderers/AxisRendererBase.swift
+++ b/Source/Charts/Renderers/AxisRendererBase.swift
@@ -13,8 +13,10 @@ import Foundation
 import CoreGraphics
 
 @objc(ChartAxisRendererBase)
-open class AxisRendererBase: Renderer
+open class AxisRendererBase: NSObject, Renderer
 {
+    public var viewPortHandler: ViewPortHandler
+    
     /// base axis this axis renderer works with
     @objc open var axis: AxisBase?
     
@@ -23,10 +25,10 @@ open class AxisRendererBase: Renderer
 
     @objc public init(viewPortHandler: ViewPortHandler, transformer: Transformer?, axis: AxisBase?)
     {
-        super.init(viewPortHandler: viewPortHandler)
-        
         self.transformer = transformer
         self.axis = axis
+        self.viewPortHandler = viewPortHandler
+        super.init()
     }
     
     /// Draws the axis labels on the specified context
@@ -106,7 +108,7 @@ open class AxisRendererBase: Renderer
         
         // Find out how much spacing (in y value space) between axis values
         let rawInterval = range / Double(labelCount)
-        var interval = rawInterval.roundedToNextSignficant()
+        var interval = rawInterval.roundedToNextSignificant()
         
         // If granularity is enabled, then do not allow the interval to go below specified granularity.
         // This is used to avoid repeated values when rounding values for display.
@@ -116,7 +118,7 @@ open class AxisRendererBase: Renderer
         }
         
         // Normalize interval
-        let intervalMagnitude = pow(10.0, Double(Int(log10(interval)))).roundedToNextSignficant()
+        let intervalMagnitude = pow(10.0, Double(Int(log10(interval)))).roundedToNextSignificant()
         let intervalSigDigit = Int(interval / intervalMagnitude)
         if intervalSigDigit > 5
         {

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -12,8 +12,10 @@
 import Foundation
 import CoreGraphics
 
-#if !os(OSX)
-    import UIKit
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 open class BarChartRenderer: BarLineScatterCandleBubbleRenderer

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -12,8 +12,10 @@
 import Foundation
 import CoreGraphics
 
-#if !os(OSX)
-    import UIKit
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -12,8 +12,10 @@
 import Foundation
 import CoreGraphics
 
-#if !os(OSX)
-    import UIKit
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -12,6 +12,11 @@
 import Foundation
 import CoreGraphics
 
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 @objc(ChartXAxisRenderer)
 open class XAxisRenderer: NSObject, AxisRenderer

--- a/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift
@@ -11,6 +11,11 @@
 
 import Foundation
 import CoreGraphics
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 open class XAxisRendererHorizontalBarChart: XAxisRenderer
 {

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -11,7 +11,11 @@
 
 import Foundation
 import CoreGraphics
-
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 @objc(ChartYAxisRenderer)
 open class YAxisRenderer: NSObject, AxisRenderer

--- a/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
+++ b/Source/Charts/Renderers/YAxisRendererHorizontalBarChart.swift
@@ -11,6 +11,11 @@
 
 import Foundation
 import CoreGraphics
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 open class YAxisRendererHorizontalBarChart: YAxisRenderer
 {

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -12,6 +12,12 @@
 import Foundation
 import CoreGraphics
 
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
 extension Comparable
 {
     func clamped(to range: ClosedRange<Self>) -> Self


### PR DESCRIPTION
### Issue Link :link:
<!-- https://github.com/danielgindi/Charts/issues/4016 -->
https://github.com/danielgindi/Charts/issues/4016

### Goals :soccer:

- During transition from CocoaPods to SPM, I've noticed multiple build failures originating from within Charts project
- The fixes seem trivial enough (missing imports, typos)

### Changes

- The most visible and common failure was that "NSTextAlignment" was failing to be located when building for iOS as target. (missing "import UIKit"). I'e made this import conditional based on the target OS. UIKit is imported for iOS and tvOS, AppKit is imported instead for macOS.
- "AxisRendererBase.swift" had two typos in "roundedToNextSignificant" call. 
- Also "AxisRendererBase.swift" did not conform to "Renderer" protocol properly. Fixed as suggested by Xcode.

### Testing Details :mag:
Performed some very basic testing by replacing the remote SPM dependency with a local one and adding it as a dependency to 3 projects that target macOS, tvOS and iOS. Build now successfully passes.
Tested basic graph cases in my own iOS project. Works fine in my use case.