### PR TITLE
Fix bounds checks on binary search

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -214,7 +214,7 @@ open class ChartDataSet: ChartBaseDataSet
         rounding: ChartDataSetRounding) -> Int
     {
         var closest = partitioningIndex { $0.x >= xValue }
-        guard closest < endIndex else { return closest }
+        guard closest < endIndex else { return -1 }
 
         let closestXValue = self[closest].x
 
@@ -237,8 +237,6 @@ open class ChartDataSet: ChartBaseDataSet
             break
         }
 
-        guard closest < endIndex else { return endIndex }
-            
         // Search by closest to y-value
         if !yValue.isNaN
         {
@@ -250,7 +248,7 @@ open class ChartDataSet: ChartBaseDataSet
             var closestYValue = self[closest].y
             var closestYIndex = closest
 
-            while closest < endIndex
+            while closest < index(before: endIndex)
             {
                 formIndex(after: &closest)
                 let value = self[closest]


### PR DESCRIPTION
### Issue Link :link:
#4571 

### Implementation Details :construction:
Incorrectly returned index beyond the last valid index. This is now corrected
