### PR TITLE
Allow for better inheritance/reuse of AnimatedViewPortJob

### DIFF
--- a/Source/Charts/Jobs/AnimatedMoveViewJob.swift
+++ b/Source/Charts/Jobs/AnimatedMoveViewJob.swift
@@ -14,7 +14,7 @@ import CoreGraphics
 
 open class AnimatedMoveViewJob: AnimatedViewPortJob
 {
-    internal override func animationUpdate()
+    open override func animationUpdate()
     {
         var pt = CGPoint(
             x: xOrigin + (CGFloat(xValue) - xOrigin) * phase,

--- a/Source/Charts/Jobs/AnimatedViewPortJob.swift
+++ b/Source/Charts/Jobs/AnimatedViewPortJob.swift
@@ -15,9 +15,9 @@ import QuartzCore
 
 open class AnimatedViewPortJob: ViewPortJob
 {
-    internal var phase: CGFloat = 1.0
-    internal var xOrigin: CGFloat = 0.0
-    internal var yOrigin: CGFloat = 0.0
+    public var phase: CGFloat = 1.0
+    public var xOrigin: CGFloat = 0.0
+    public var yOrigin: CGFloat = 0.0
     
     private var _startTime: TimeInterval = 0.0
     private var _displayLink: NSUIDisplayLink!
@@ -115,12 +115,12 @@ open class AnimatedViewPortJob: ViewPortJob
         }
     }
     
-    internal func animationUpdate()
+    open func animationUpdate()
     {
        // Override this
     }
     
-    internal func animationEnd()
+    open func animationEnd()
     {
         // Override this
     }

--- a/Source/Charts/Jobs/AnimatedZoomViewJob.swift
+++ b/Source/Charts/Jobs/AnimatedZoomViewJob.swift
@@ -60,7 +60,7 @@ open class AnimatedZoomViewJob: AnimatedViewPortJob
             easing: easing)
     }
     
-    internal override func animationUpdate()
+    open override func animationUpdate()
     {
         let scaleX = xOrigin + (self.scaleX - xOrigin) * phase
         let scaleY = yOrigin + (self.scaleY - yOrigin) * phase
@@ -82,7 +82,7 @@ open class AnimatedZoomViewJob: AnimatedViewPortJob
         viewPortHandler.refresh(newMatrix: matrix, chart: view, invalidate: true)
     }
     
-    internal override func animationEnd()
+    open override func animationEnd()
     {
         (view as? BarLineChartViewBase)?.calculateOffsets()
         view.setNeedsDisplay()


### PR DESCRIPTION
### Goals :soccer:
In my current project I'm doing custom animation updates via inheriting from the open class `AnimatedZoomViewJob`. However some properties and methods are not accessible from outside or are not open, so this leads to a lot of duplicated code (or having to maintain a private fork with the changes).

Since `AnimatedZoomViewJob` is already open (and thus meant to be used for inheritance), it would be good to also open up the essential methods and properties of this class for extension.