### PR TITLE
Add logic for relative positioning of pie chart icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In order to correctly compile:
 #### Video tutorials
 
 * [Chart in Swift - Setting Up a Basic Line Chart Using iOS Charts(Alex Nagy)](https://www.youtube.com/watch?v=mWhwe_tLNE8&list=PL_csAAO9PQ8bjzg-wxEff1Fr0Y5W1hrum&index=5)
+* [Charts Framework in SwiftUI - Bar Chart (Stewart Lynch)](https://youtu.be/csd7pyfEXgw)
 
 #### Blog posts
 * [Using Realm and Charts with Swift 3 in iOS 10 (Sami Korpela)](https://medium.com/@skoli/using-realm-and-charts-with-swift-3-in-ios-10-40c42e3838c0#.2gyymwfh8)

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
@@ -21,6 +21,13 @@ open class PieChartDataSet: ChartDataSet, PieChartDataSetProtocol
         case outsideSlice
     }
 
+    @objc(PieChartIconsPosition)
+    public enum IconsPosition: Int
+    {
+        case iconCenterOnOuterSliceRim
+        case iconCenterInTheMiddleOfSlice
+    }
+
     private func initialize()
     {
         self.valueTextColor = NSUIColor.white
@@ -75,6 +82,9 @@ open class PieChartDataSet: ChartDataSet, PieChartDataSetProtocol
 
     open var xValuePosition: ValuePosition = .insideSlice
     open var yValuePosition: ValuePosition = .insideSlice
+    
+    /// relative icons position
+    open var iconsPosition: IconsPosition = .iconCenterInTheMiddleOfSlice
 
     /// When valuePosition is OutsideSlice, indicates line color
     open var valueLineColor: NSUIColor? = NSUIColor.black

--- a/Source/Charts/Data/Interfaces/PieChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/PieChartDataSetProtocol.swift
@@ -31,6 +31,9 @@ public protocol PieChartDataSetProtocol: ChartDataSetProtocol
     var xValuePosition: PieChartDataSet.ValuePosition { get set }
     var yValuePosition: PieChartDataSet.ValuePosition { get set }
 
+    /// relative icons position
+    var iconsPosition: PieChartDataSet.IconsPosition { get set }
+
     /// When valuePosition is OutsideSlice, indicates line color
     var valueLineColor: NSUIColor? { get set }
 

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -563,9 +563,9 @@ open class PieChartRenderer: NSObject, DataRenderer
                 if let icon = e.icon, dataSet.isDrawIconsEnabled
                 {
                     // calculate the icon's position
-
-                    let x = (labelRadius + iconsOffset.y) * sliceXBase + center.x
-                    var y = (labelRadius + iconsOffset.y) * sliceYBase + center.y
+                    let r = dataSet.iconsPosition == .iconCenterInTheMiddleOfSlice ? labelRadius : radius
+                    let x = (r + iconsOffset.y) * sliceXBase + center.x
+                    var y = (r + iconsOffset.y) * sliceYBase + center.y
                     y += iconsOffset.x
                     
                     context.drawImage(icon,


### PR DESCRIPTION
### Goals :soccer:
Sometimes for pie charts with icons we want to be able to position icons not only with respect to the middle of the slice but with respect to the outer edge of the slice. Example:

<img width="288" alt="Screenshot 2021-02-26 at 11 27 28" src="https://user-images.githubusercontent.com/1381440/109282098-c50cb700-7825-11eb-8ae4-0f59584efc88.png">

Currently the only possible way to achieve this (that I've found) is to use `PieChartDataSet.iconsOffset` property. It allows absolute adjustments of the icon position but fails when we need to do that dinamically (for different pie chart sizes e.g.). 

### Implementation Details :construction:
New property (`iconsPosition`) added to `PieChartDataSetProtocol`. Depending on the value of this property pie chart renderer will calculate and place the icon either with respect to the middle of the slice (for `.iconCenterInTheMiddleOfSlice` option, default behaviour) or with respect to the outer edge of the slice (for `.iconCenterOnOuterSliceRim` option).