### PR TITLE
Prevent creation of invalid range in XBounds (fixes #4184 and #4049)

### DIFF
--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		135F11CE20425AF600D655A3 /* PieChartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135F11CD20425AF600D655A3 /* PieChartTests.swift */; };
 		146EE16342C2BADC92E45BF2 /* LineScatterCandleRadarChartDataSetProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9249AD9AEC8C85772365A128 /* LineScatterCandleRadarChartDataSetProtocol.swift */; };
 		17E994DA88777AA1D8CCFC58 /* BarChartDataSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31AA65EA27776F8C653C7E8 /* BarChartDataSet.swift */; };
+		194ECA1825EED8FC00BC6251 /* RangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194ECA1725EED8FC00BC6251 /* RangeTests.swift */; };
 		219192CA6B4895319AB49DCA /* BarLineScatterCandleBubbleRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1C588E9DF6FFD56D7ADF8E /* BarLineScatterCandleBubbleRenderer.swift */; };
 		221CA2922588FCBC00C2DD1E /* Sequence+KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221CA2912588FCBC00C2DD1E /* Sequence+KeyPath.swift */; };
 		2243BBFD1FF156EC00B49D0B /* EquatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2243BBFB1FF156D000B49D0B /* EquatableTests.swift */; };
@@ -193,6 +194,7 @@
 		135F11CD20425AF600D655A3 /* PieChartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieChartTests.swift; sourceTree = "<group>"; };
 		18462BFDD9DEE76D51D40503 /* ScatterChartView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScatterChartView.swift; path = Source/Charts/Charts/ScatterChartView.swift; sourceTree = "<group>"; };
 		18BFB0A14A5C47A302A597D9 /* CandleChartDataSetProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CandleChartDataSetProtocol.swift; path = Source/Charts/Data/Interfaces/CandleChartDataSetProtocol.swift; sourceTree = "<group>"; };
+		194ECA1725EED8FC00BC6251 /* RangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeTests.swift; sourceTree = "<group>"; };
 		1C02C3AF5C92FCFC18224C35 /* XAxisRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XAxisRenderer.swift; path = Source/Charts/Renderers/XAxisRenderer.swift; sourceTree = "<group>"; };
 		1CBBC58C6CE1EBEE9852CE41 /* ChartsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChartsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F3D55A7E6176D52DC957D27 /* XAxisRendererHorizontalBarChart.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = XAxisRendererHorizontalBarChart.swift; path = Source/Charts/Renderers/XAxisRendererHorizontalBarChart.swift; sourceTree = "<group>"; };
@@ -598,6 +600,7 @@
 				135F11CD20425AF600D655A3 /* PieChartTests.swift */,
 				064989451F5C99C7006E8BB3 /* Utilities.swift */,
 				C03E6D8023DAAB2600083010 /* ChartDataTests.swift */,
+				194ECA1725EED8FC00BC6251 /* RangeTests.swift */,
 			);
 			name = Charts;
 			path = Tests/ChartsTests;
@@ -1001,6 +1004,7 @@
 				135F11CE20425AF600D655A3 /* PieChartTests.swift in Sources */,
 				064989461F5C99C7006E8BB3 /* Utilities.swift in Sources */,
 				C03E6D8123DAAB2600083010 /* ChartDataTests.swift in Sources */,
+				194ECA1825EED8FC00BC6251 /* RangeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -106,8 +106,11 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
             let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
             let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)
             
-            self.min = entryFrom == nil ? 0 : dataSet.entryIndex(entry: entryFrom!)
-            self.max = entryTo == nil ? 0 : dataSet.entryIndex(entry: entryTo!)
+            let minValue: Int? = entryFrom == nil ? nil : dataSet.entryIndex(entry: entryFrom!)
+            let maxValue: Int? = entryTo == nil ? nil : dataSet.entryIndex(entry: entryTo!)
+
+            self.min = minValue ?? maxValue ?? 0
+            self.max = maxValue ?? minValue ?? 0
             range = Int(Double(self.max - self.min) * phaseX)
         }
     }

--- a/Tests/ChartsTests/RangeTests.swift
+++ b/Tests/ChartsTests/RangeTests.swift
@@ -1,0 +1,38 @@
+//
+//  RangeTests.swift
+//  ChartsTests
+//
+//  Created by Berend Klein Haneveld on 02/03/2021.
+//
+
+@testable import Charts
+import XCTest
+
+class RangeTests: XCTestCase {
+
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testChartOutOfBoundsLower() throws {
+        let dataset = ScatterChartDataSet(entries: [
+            ChartDataEntry(x: 0.0, y: 2.0),
+            ChartDataEntry(x: 1.0, y: 2.0),
+            ChartDataEntry(x: 2.0, y: 2.0),
+        ])
+
+        let data = ScatterChartData(dataSet: dataset)
+
+        let scatterView = ScatterChartView()
+        scatterView.data = data
+        scatterView.xAxis.axisMinimum = 2.0
+        scatterView.xAxis.axisMaximum = 5.0
+
+        let xrange = BarLineScatterCandleBubbleRenderer.XBounds(chart: scatterView, dataSet: dataset, animator: nil)
+        print(xrange)
+        XCTAssert(xrange.min == 2)
+        XCTAssert(xrange.max == 2)
+    }
+}

--- a/Tests/ChartsTests/RangeTests.swift
+++ b/Tests/ChartsTests/RangeTests.swift
@@ -31,7 +31,6 @@ class RangeTests: XCTestCase {
         scatterView.xAxis.axisMaximum = 5.0
 
         let xrange = BarLineScatterCandleBubbleRenderer.XBounds(chart: scatterView, dataSet: dataset, animator: nil)
-        print(xrange)
         XCTAssert(xrange.min == 2)
         XCTAssert(xrange.max == 2)
     }


### PR DESCRIPTION
### Issue Links 🔗 

The issues #4184 and #4049 mention crashes which are caused by an invalid range in the XBounds. This fix might not really solve all underlying problems, but at least it will make it stop crashing. Might need some further investigation.

### Goals :soccer:
This PR should prevent crashes due to invalid ranges in BarLineScatterCandleBubbleRenderer.XBounds (max > min). An negative range will cause a crash when the iterator is called upon.
I traced the problem to the `set(chart, dataset, animator)` function in `BarLineScatterCandleBubbleRenderer.XBounds`. If `entryFrom` is not nil but `entryTo` is, and there are entries outside/below the visible range (or when the entries are not sorted), then the `entryIndex(entry:)` function will/can return an index larger than zero. This results in `min` becoming larger than zero while `max` will default to 0. This creates an invalid range.

### Implementation Details :construction:
I've made sure that when the `entryFrom` value is nil while the `entryTo` values is non-nil, that the min value will be the max value (instead of the default 0). And when `entryFrom` is non-nil but `entryTo` is nil, then the max value will be set to the min value to prevent a negative/invalid range.

### Testing Details :mag:
The test uses a ScatterChartView with a custom `axisMinimum` and `axisMaximum` and a simple dataset where two values are below/outside the range. The last value lies exactly on the lower range. This results in a nil value for `entryTo` and a non-nil value for `entryFrom`. And this would result in an invalid range with the previous code.

The call stack is as follows: `entryForXValue(_:closestToY:rounding:) => entryIndex(x:closestToY:rounding:) => entryIndex(x:closestToY:rounding:) => Collection.partitioningIndex`.
The `partitioningIndex` function relies on the premise that the collection is already partitioned/sorted(!). Would be good to add a notion somewhere in the documentation that it is a good idea to keep datasets sorted, so if anybody has a good idea of where I could put that, I'd be happy to add it in the PR. I don't have a lot of experience with the code base so I don't know exactly the ramifications of the proposed change, but at least it prevents some nasty crashes and I haven't seen any side effects yet in my (limited) testing.