### PR TITLE
Fully restore previous XBounds logic

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -70,34 +70,33 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
     }
 
     /// Class representing the bounds of the current viewport in terms of indices in the values array of a DataSet.
-    open class XBounds
+    public final class XBounds
     {
         /// minimum visible entry index
-        open var min: Int = 0
+        public private(set) var min = 0
 
         /// maximum visible entry index
-        open var max: Int = 0
+        public private(set) var max = 0
 
         /// range of visible entry indices
-        open var range: Int = 0
+        public private(set) var range = 0
 
-        public init()
-        {
-            
-        }
-        
-        public init(chart: BarLineScatterCandleBubbleChartDataProvider,
-                    dataSet: BarLineScatterCandleBubbleChartDataSetProtocol,
-                    animator: Animator?)
-        {
+        public init() { }
+
+        public init(
+            chart: BarLineScatterCandleBubbleChartDataProvider,
+            dataSet: BarLineScatterCandleBubbleChartDataSetProtocol,
+            animator: Animator?
+        ) {
             self.set(chart: chart, dataSet: dataSet, animator: animator)
         }
         
         /// Calculates the minimum and maximum x values as well as the range between them.
-        open func set(chart: BarLineScatterCandleBubbleChartDataProvider,
-                      dataSet: BarLineScatterCandleBubbleChartDataSetProtocol,
-                      animator: Animator?)
-        {
+        public func set(
+            chart: BarLineScatterCandleBubbleChartDataProvider,
+            dataSet: BarLineScatterCandleBubbleChartDataSetProtocol,
+            animator: Animator?
+        ) {
             let phaseX = Swift.max(0.0, Swift.min(1.0, animator?.phaseX ?? 1.0))
             
             let low = chart.lowestVisibleX
@@ -117,33 +116,9 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
     }
 }
 
-extension BarLineScatterCandleBubbleRenderer.XBounds: RangeExpression {
-    public func relative<C>(to collection: C) -> Swift.Range<Int>
-        where C : Collection, Bound == C.Index
-    {
-        return Swift.Range<Int>(min...min + range)
-    }
-
-    public func contains(_ element: Int) -> Bool {
-        return (min...min + range).contains(element)
-    }
-}
-
 extension BarLineScatterCandleBubbleRenderer.XBounds: Sequence {
-    public struct Iterator: IteratorProtocol {
-        private var iterator: IndexingIterator<ClosedRange<Int>>
-        
-        fileprivate init(min: Int, max: Int) {
-            self.iterator = (min...max).makeIterator()
-        }
-        
-        public mutating func next() -> Int? {
-            return self.iterator.next()
-        }
-    }
-    
-    public func makeIterator() -> Iterator {
-        return Iterator(min: self.min, max: self.min + self.range)
+    public func makeIterator() -> StrideThrough<Int>.Iterator {
+        stride(from: min, through: min + range, by: 1).makeIterator()
     }
 }
 


### PR DESCRIPTION
### Issue Link :link:
#4049 #4184 #4592

### Goals :soccer:
Use StrideThrough.Iterator as the Xbounds iterator to restore the functionality of the previous implementation (prior to Xbounds' Sequence conformance).

### Implementation Details :construction:
Using the `IndexingIterator` was a mistake when we introduced `Sequence` conformance to `XBounds`, as it's behaviour always followed that of `StrideThrough.Iterator`. This PR simplifies the `Sequence` conformance and corrects this mistake.

### Testing Details :mag:
Would like assistance in testing this. #4592 has a test that correctly validates that an invalid Range is not formed, however `XBounds` requires that in can have a range that is considered invalid by Swift.Range. I am uncertain of all the rules, around `XBounds`, but this reinstates all of the previous behaviour with the exception of [one instance](https://github.com/danielgindi/Charts/commit/2a1ecb4e6f175f91e91d77d039be342138fe0e3c#r48044716) that I think was never a problem since `range` can never be greater than `max-min`.