### PR TITLE
Add functionality for setting line dash in bar charts

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -112,6 +112,14 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, BarChartData
 
     /// the color drawing borders around the bars.
     open var barBorderColor = NSUIColor.black
+    
+    /// This is how far (in pixels) into the dash pattern we are starting from.
+    open var barBorderDashPhase = CGFloat(0.0)
+    
+    /// The dash pattern of the bar border line.
+    /// I.e. [2, 3] will paint [--   --   ]
+    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    open var barBorderDashLengths: [CGFloat]?
 
     /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     open var highlightAlpha = CGFloat(120.0 / 255.0)

--- a/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
@@ -33,6 +33,14 @@ public protocol BarChartDataSetProtocol: BarLineScatterCandleBubbleChartDataSetP
 
     /// the color drawing borders around the bars.
     var barBorderColor: NSUIColor { get set }
+    
+    /// This is how far (in pixels) into the dash pattern we are starting from.
+    var barBorderDashPhase: CGFloat { get }
+    
+    /// The dash pattern of the bar border line.
+    /// I.e. [2, 3] will paint [--   --   ]
+    /// [1, 3, 4, 2] will paint [-   ----  -   ----  ]
+    var barBorderDashLengths: [CGFloat]? { get set }
 
     /// the alpha value (transparency) that is used for drawing the highlight indicator bar. min = 0.0 (fully transparent), max = 1.0 (fully opaque)
     var highlightAlpha: CGFloat { get set }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -381,6 +381,15 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             
             context.fill(barRect)
             
+            if let borderDashLengths = dataSet.barBorderDashLengths
+            {
+                context.setLineDash(phase: dataSet.barBorderDashPhase, lengths: borderDashLengths)
+            }
+            else
+            {
+                context.setLineDash(phase: 0.0, lengths: [])
+            }
+            
             if drawBorder
             {
                 context.setStrokeColor(borderColor.cgColor)


### PR DESCRIPTION
### Goals :soccer:
Make it possible for users to create bar chart data sets with dashed bar borders. 
A nice feature to have when one for example wants to communicate a predicted future value or other values that are currently missing.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Users can make bar chart data sets with dashed lines by providing an array of dash lengths, just like they can for `LineChartDataSet`. The `barBorderWidth` naturally has to be set as well:
```swift
let entries = [BarChartDataEntry(x: 42.0, y: 42)]
let set = BarChartDataSet(entries: entries)
set.barBorderWidth = 1
set.barBorderDashLengths = [10, 5]
```

Example result:
<img width="396" alt="Screenshot 2021-03-11 at 13 31 10" src="https://user-images.githubusercontent.com/9058089/110787765-0bbed000-826e-11eb-9c42-1fcff54a5bc4.png">
