### PR TITLE
Fix for issue where data points are not highlighted

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -196,10 +196,7 @@ open class ChartDataSet: ChartBaseDataSet
     /// An empty array if no Entry object at that index.
     open override func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
     {
-        let match: (ChartDataEntry) -> Bool = { $0.x == xValue }
-        let i = partitioningIndex(where: match)
-        guard i < endIndex else { return [] }
-        return self[i...].prefix(while: match)
+        return self.filter { $0.x == xValue }
     }
     
     /// - Parameters:


### PR DESCRIPTION
### Issue Link :link:

Fixes #4609 and possibly also #4579 

### Goals :soccer:

Improve the highlighting / selection behavior of line charts

### Implementation Details :construction:

The `entriesForXValue` func finds the data entries for a given x-axis
value. It used an optimization where it would do a binary search to find
the first matching entry then take a slice of data stopping when no more
entries matched.

The optimization broke the highlight feature because data points that
should have matched were not matching resulting in no entries being
returned.

This commit replaces the optimized code with a call to `.filter` which
will be slower for larger data sets but correctly returns filtered
entries.

### Testing Details :mag:

Tested by altering the [demo project](https://github.com/gavynriebau/DemoChartsBug) to use the forked version of the code and confirming the broken behaviour works after the fix is applied