### PR TITLE
Fix for issue where data points are not highlighted

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -197,7 +197,7 @@ open class ChartDataSet: ChartBaseDataSet
     open override func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
     {
         let match: (ChartDataEntry) -> Bool = { $0.x == xValue }
-        let i = partitioningIndex(where: match)
+        let i = partitioningIndex { $0.x >= xValue }
         guard i < endIndex else { return [] }
         return self[i...].prefix(while: match)
     }


### PR DESCRIPTION
### Issue Link :link:

Fixes #4609 and possibly also #4579 

### Goals :soccer:

Improve the highlighting / selection behavior of line charts

### Implementation Details :construction:

The `entriesForXValue` func finds the data entries for a given x-axis
value. It used an optimization where it would do a binary search to find
the first matching entry then take a slice of data stopping when no more
entries matched.

The optimized code uses the `partitionIndex` function but the filter predicate
used in this function was incorrect.

### Testing Details :mag:

Tested by altering the [demo project](https://github.com/gavynriebau/DemoChartsBug) to use the forked version of the code and confirming the broken behaviour works after the fix is applied