### PR TITLE
Fix for crash when indexing into collection using invalid range

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -105,6 +105,9 @@ open class ChartDataSet: ChartBaseDataSet
         let indexTo = entryIndex(x: toX, closestToY: .nan, rounding: .up)
         
         guard indexTo >= indexFrom else { return }
+        guard indexFrom >= 0 else { return }
+        guard indexTo < self.endIndex else { return }
+
         // only recalculate y
         self[indexFrom...indexTo].forEach(calcMinMaxY)
     }


### PR DESCRIPTION
### Issue Link :link:

#4614 

### Goals :soccer:

Fix a crash caused by invalid indexing

### Implementation Details :construction:

The min/max indexes were calculated incorrectly in some cases which lead to an attempt to index into an array using an invalid range.
Adding some guard conditions prevents this.

### Testing Details :mag:

Tested patch on work project and confirmed the crash is fixed