### PR TITLE
Add rounder corners to CandleStickChart 

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
@@ -72,6 +72,11 @@ open class CandleChartDataSet: LineScatterCandleRadarChartDataSet, CandleChartDa
         }
     }
     
+    /// the corner radius of the canlde bar,
+    ///
+    /// **default**: 0.0
+    open var barCornerRadius = CGFloat(0.0)
+    
     /// should the candle bars show?
     /// when false, only "ticks" will show
     ///

--- a/Source/Charts/Data/Interfaces/CandleChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/CandleChartDataSetProtocol.swift
@@ -23,6 +23,10 @@ public protocol CandleChartDataSetProtocol: LineScatterCandleRadarChartDataSetPr
     /// **default**: 0.1 (10%), max 0.45, min 0.0
     var barSpace: CGFloat { get set }
     
+    /// the corner radius of the canlde bar,
+    /// **default**: 0.0
+    var barCornerRadius: CGFloat { get set }
+    
     /// should the candle bars show?
     /// when false, only "ticks" will show
     ///

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -158,6 +158,10 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                 
                 trans.rectValueToPixel(&_bodyRect)
                 
+                
+                // define roundedRect for corner radius
+                let roundedRect = UIBezierPath(roundedRect: _bodyRect, cornerRadius: dataSet.cornerRadius)
+                
                 // draw body differently for increasing and decreasing entry
 
                 if open > close
@@ -169,7 +173,8 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     if dataSet.isDecreasingFilled
                     {
                         context.setFillColor(color.cgColor)
-                        context.fill(_bodyRect)
+                        context.addPath(bezierPath.cgPath)
+                        context.drawPath(using: .fill)
                     }
                     else
                     {
@@ -186,7 +191,8 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     if dataSet.isIncreasingFilled
                     {
                         context.setFillColor(color.cgColor)
-                        context.fill(_bodyRect)
+                        context.addPath(bezierPath.cgPath)
+                        context.drawPath(using: .fill)
                     }
                     else
                     {


### PR DESCRIPTION
### Issue Link :link:
#4140 

### Goals :soccer:
provides a computed property to set corner radius of bars in CandleStickChart.

### Implementation Details :construction:
added barCornerRadius property in `CandleChartDataSetProtocol` and `CandleChartDataSet`
then the logic for corner radius is using a Bezierpath roundedReactangle and is implemented in `CandleStickChartRenderer`.