### PR TITLE
Fix Multi-Data Set Bar Chart Crash

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -423,7 +423,6 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     @objc open var maxEntryCountSet: Element?
     {
         return self.max(by: \.entryCount)
-//        return self.max { $0.entryCount > $1.entryCount }
     }
 }
 

--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -422,7 +422,8 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     /// The DataSet object with the maximum number of entries or null if there are no DataSets.
     @objc open var maxEntryCountSet: Element?
     {
-        return self.max { $0.entryCount > $1.entryCount }
+        return self.max(by: \.entryCount)
+//        return self.max { $0.entryCount > $1.entryCount }
     }
 }
 

--- a/Tests/ChartsTests/ChartDataTests.swift
+++ b/Tests/ChartsTests/ChartDataTests.swift
@@ -65,4 +65,3 @@ class ChartDataTests: XCTestCase {
         XCTAssertTrue(data.dataSet(forLabel: SetLabels.badLabel, ignorecase: false) == nil)
     }
 }
-

--- a/Tests/ChartsTests/ChartDataTests.swift
+++ b/Tests/ChartsTests/ChartDataTests.swift
@@ -66,35 +66,3 @@ class ChartDataTests: XCTestCase {
     }
 }
 
-class ChartDataDifferentSizeDataSetsTests: XCTestCase {
-    var data: BarChartData!
-
-    private enum SetLabels {
-        static let one = "label1"
-        static let two = "label2"
-        static let badLabel = "Bad label"
-    }
-
-    override func setUp() {
-        super.setUp()
-
-        let values1 = (0 ..< 50).map { (i) -> ChartDataEntry in
-            let val = Double(arc4random_uniform(range) + 3)
-            return ChartDataEntry(x: Double(i), y: val)
-        }
-        let values2 = (0 ..< 30).map { (i) -> ChartDataEntry in
-            let val = Double(arc4random_uniform(range) + 3)
-            return ChartDataEntry(x: Double(i), y: val)
-        }
-
-        let set1 = ScatterChartDataSet(entries: values1, label: SetLabels.one)
-        let set2 = ScatterChartDataSet(entries: values2, label: SetLabels.two)
-
-        data = BarChartData(dataSets: [set1, set2, set3])
-    }
-
-    func testMaxEntry() {
-        let maxEntryCountSet = data.maxEntryCountSet
-        
-    }
-}

--- a/Tests/ChartsTests/ChartDataTests.swift
+++ b/Tests/ChartsTests/ChartDataTests.swift
@@ -65,3 +65,36 @@ class ChartDataTests: XCTestCase {
         XCTAssertTrue(data.dataSet(forLabel: SetLabels.badLabel, ignorecase: false) == nil)
     }
 }
+
+class ChartDataDifferentSizeDataSetsTests: XCTestCase {
+    var data: BarChartData!
+
+    private enum SetLabels {
+        static let one = "label1"
+        static let two = "label2"
+        static let badLabel = "Bad label"
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        let values1 = (0 ..< 50).map { (i) -> ChartDataEntry in
+            let val = Double(arc4random_uniform(range) + 3)
+            return ChartDataEntry(x: Double(i), y: val)
+        }
+        let values2 = (0 ..< 30).map { (i) -> ChartDataEntry in
+            let val = Double(arc4random_uniform(range) + 3)
+            return ChartDataEntry(x: Double(i), y: val)
+        }
+
+        let set1 = ScatterChartDataSet(entries: values1, label: SetLabels.one)
+        let set2 = ScatterChartDataSet(entries: values2, label: SetLabels.two)
+
+        data = BarChartData(dataSets: [set1, set2, set3])
+    }
+
+    func testMaxEntry() {
+        let maxEntryCountSet = data.maxEntryCountSet
+        
+    }
+}


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4633

### Goals :soccer:
Prevent the Charts library from crashing when a bar chart is displayed with two data sets of different sizes.

### Implementation Details :construction:
Previously, line 425 of `ChartData.swift` was not correctly returning the largest data set. This caused a crash when a BarChart would create accessibility elements and there were two or more data sets of differing sizes. I've fixed this crash by correcting the code to ensure that the larger data set is returned.

### Testing Details :mag:
No automated tests have been added here. I have tested this in the sample application provided in the [issue](https://github.com/danielgindi/Charts/issues/4633) as well as my own app and verified that it works.