### PR TITLE
Fix disappearing horizontal bar chart data labels on chart zoom/pan

### DIFF
--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -365,18 +365,15 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                         let rect = buffer.rects[j]
                         
                         let y = rect.origin.y + rect.size.height / 2.0
+                        let x = rect.origin.x + rect.size.width
                         
-                        if !viewPortHandler.isInBoundsTop(rect.origin.y)
+                        if !viewPortHandler.isInBoundsTop(y)
                         {
                             break
                         }
                         
-                        if !viewPortHandler.isInBoundsX(rect.origin.x)
-                        {
-                            continue
-                        }
-                        
-                        if !viewPortHandler.isInBoundsBottom(rect.origin.y)
+                        if !viewPortHandler.isInBoundsX(x)
+                            || !viewPortHandler.isInBoundsBottom(y)
                         {
                             continue
                         }


### PR DESCRIPTION


### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
When data values are enabled for horizontal bar charts, the data values vanish if the chart is zoomed/panned so that the left axis is no longer visible.

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
Change the show/hide logic for horizontal bar chart data values to match that of regular bar chart data values.
<!-- Include any relevant context. -->
For regular bar charts, `drawValues` will skip over drawing a data value if the centre of a bar is outside of either the left/right bounds of the view port, as well as if the top of the bar is outside of the top bound of the view port.

This second part is accomplished using a simple `rect.origin.y` call, since Y-coordinates increase as you move down on the screen, so `rect.origin.y` will always be the top point of a vertical bar. I assume that when `drawValues` in the `HorizontalBarChartRenderer` was first implemented, the logic of the regular `BarChartRenderer` was copied over with `x`s and `y`s swapped, but in this case, there wasn't a perfect 1:1 correspondence since X-coordinates are left-to-right, so the "top" of a bar will not be at `rect.origin.x` when they are being drawn starting at the left axis.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
We are calculating `let y = rect.origin.y + rect.size.height / 2.0`, but not using the result of this calculation when checking if the bar is within the top/bottom bounds. My PR changes it so that we check against `y` instead of `rect.origin.y`. I also merged the second `if ... { continue }` block into the first (this mirrors the setup in `BarChartRenderer.drawValues` as well).

<!-- Highlight any new functionality. -->
I added the calculation `let x = rect.origin.x + rect.size.width`, and I changed the `if` statement to check `x` rather than checking `rect.origin.x`. This way, we are checking if the top of the horizontal bar is within the viewport, and not the left-most point of the bar (which is going to be the left axis). This way, the data values don't vanish when the left axis is not within the current view port, but rather disappear when the top of the bar is outside of the view port, which is the behaviour of regular bar charts.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
None