### PR TITLE
Added clipping to scale for zoom (Fixes #3111 #3602)

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -652,11 +652,19 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
                         location.y = -(viewPortHandler.chartHeight - location.y - viewPortHandler.offsetBottom)
                     }
                     
-                    let scaleX = canZoomMoreX ? recognizer.nsuiScale : 1.0
-                    let scaleY = canZoomMoreY ? recognizer.nsuiScale : 1.0
+                    let scaleXFactor = canZoomMoreX ? recognizer.nsuiScale : 1.0
+                    let scaleYFactor = canZoomMoreY ? recognizer.nsuiScale : 1.0
+                    
+                    //Clip scale to limits
+                    let clippedScaleX = min(max(viewPortHandler.minScaleX, self.scaleX * scaleXFactor), viewPortHandler.maxScaleX)
+                    let clippedScaleY = min(max(viewPortHandler.minScaleY,  self.scaleY * scaleYFactor), viewPortHandler.maxScaleY)
+
+                    //Recreate scale factors but clipped to limits
+                    let clippedScaleXFactor = clippedScaleX / self.scaleX
+                    let clippedScaleYFactor = clippedScaleY / self.scaleY
                     
                     var matrix = CGAffineTransform(translationX: location.x, y: location.y)
-                    matrix = matrix.scaledBy(x: scaleX, y: scaleY)
+                    matrix = matrix.scaledBy(x: clippedScaleXFactor, y: clippedScaleYFactor)
                     matrix = matrix.translatedBy(x: -location.x, y: -location.y)
                     
                     matrix = viewPortHandler.touchMatrix.concatenating(matrix)
@@ -665,7 +673,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
 
                     if delegate !== nil
                     {
-                        delegate?.chartScaled?(self, scaleX: scaleX, scaleY: scaleY)
+                        delegate?.chartScaled?(self, scaleX: clippedScaleXFactor, scaleY: clippedScaleYFactor)
                     }
                 }
                 


### PR DESCRIPTION
Fixes bug where the chart would jump after reaching max zoom out. This
is caused by a translation offset being calculated before applying chart
scale limits. Since the translation offset depends on the scale and
applying chart limits changes the scale, the results causes the chart to
shift by an unexpected offset. The fix applies the chart limits before
calculating the chart offset.

### Issue Link :link:
https://github.com/danielgindi/Charts/issues/3111
https://github.com/danielgindi/Charts/issues/3602

There has already been a PR approved for the issue, however it was abandoned by the author. My solution is simplifies that PR
https://github.com/danielgindi/Charts/pull/2114

Possibly also related to: 
https://github.com/danielgindi/Charts/issues/1880 

