### PR TITLE
fix not displaying all lines in graph

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -100,8 +100,8 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
         {
             let phaseX = Swift.max(0.0, Swift.min(1.0, animator?.phaseX ?? 1.0))
             
-            let low = chart.lowestVisibleX
-            let high = chart.highestVisibleX
+            let low = chart.lowestVisibleX > dataSet.xMin ? chart.lowestVisibleX : dataSet.xMin
+            let high = chart.highestVisibleX > dataSet.xMax ? dataSet.xMax : chart.highestVisibleX
             
             let entryFrom = dataSet.entryForXValue(low, closestToY: .nan, rounding: .down)
             let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)


### PR DESCRIPTION
### Issue Link :link:
#4662 
### Goals :soccer:
When multiple lines with different xMin and xMax values are present and the view port includes all lines then all of the lines should be drawn.

### Implementation Details :construction:
Calculating Xbounds for the "shorter" line fails, due to not finding a valid index for highestVisibleX or lowestVisibleX.
Modifying the low and high marks for .entryForXValue() solves the issue.

### Testing Details :mag:
Observing to display lines that
a) have a higher xMin value than the lowestVisibleXValue
b) have a lower xMax value than the highestVisbleXValue