### PR TITLE
Fix possible crash if viewPortHandler scale is infinite

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -65,7 +65,8 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
 
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
-        guard let data = dataProvider?.data else { return false }
+        guard let data = dataProvider?.data,
+              viewPortHandler.scaleX.isFinite else { return false }
         return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
     }
 

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -161,7 +161,8 @@ open class CombinedChartRenderer: NSObject, DataRenderer
 
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
-        guard let data = dataProvider?.data else { return false }
+        guard let data = dataProvider?.data,
+              viewPortHandler.scaleX.isFinite else { return false }
         return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
     }
 

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -614,7 +614,8 @@ open class HorizontalBarChartRenderer: BarChartRenderer
     
     open override func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
-        guard let data = dataProvider?.data
+        guard let data = dataProvider?.data,
+              viewPortHandler.scaleY.isFinite
             else { return false }
         return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * self.viewPortHandler.scaleY)
     }

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -588,7 +588,8 @@ open class PieChartRenderer: NSObject, DataRenderer
 
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
-        guard let data = dataProvider?.data else { return false }
+        guard let data = dataProvider?.data,
+              viewPortHandler.scaleX.isFinite else { return false }
         return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
     }
 


### PR DESCRIPTION
Fix a crash that occurs if the viewPortHandler scale Double value is infinite.