### PR TITLE
Allow to set longest label manually

### DIFF
--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -131,8 +131,14 @@ open class AxisBase: ComponentBase
     /// if true, the set number of y-labels will be forced
     @objc open var forceLabelsEnabled = false
     
+    @objc open var longestLabel: String?
+    
     @objc open func getLongestLabel() -> String
     {
+        if let longestLabel = longestLabel {
+            return longestLabel
+        }
+        
         let longest = entries.indices
             .lazy
             .map(getFormattedLabel(_:))


### PR DESCRIPTION
### Goals :soccer:
X-axis labels might have different widths even for the same character count depending on the font. If `getLongestLabel()` is unable to properly compute the longest label there is the `longestLabel` property to set it explicitly.
