### PR TITLE
Fix crash about pinch zoom gesture when tapping with 3 fingers on iOS 15

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -587,7 +587,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     #if !os(tvOS)
     @objc private func pinchGestureRecognized(_ recognizer: NSUIPinchGestureRecognizer)
     {
-        if recognizer.state == NSUIGestureRecognizerState.began
+        if recognizer.state == NSUIGestureRecognizerState.began && recognizer.numberOfTouches > 1
         {
             stopDeceleration()
             


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
Fix crash in line chart when tapping with 3 fingers on iOS 15:
Fatal Exception: NSRangeException
-[UIPinchGestureRecognizer locationOfTouch:inView:]: index (1) beyond bounds (1).

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->