### PR TITLE
Issue 4780 Y Axis Labels properly sized - clean fix

### DIFF
--- a/Source/Charts/Components/YAxis.swift
+++ b/Source/Charts/Components/YAxis.swift
@@ -120,8 +120,13 @@ open class YAxis: AxisBase
     
     @objc open func requiredSize() -> CGSize
     {
-        let label = getLongestLabel() as NSString
-        var size = label.size(withAttributes: [.font: labelFont])
+        var size = entries.indices.map { index -> CGSize in
+            getFormattedLabel(index).size(withAttributes: [.font: labelFont])
+        }.reduce(CGSize.zero) { partialResult, size in
+            CGSize(width: partialResult.width > size.width ? partialResult.width : size.width,
+                   height: partialResult.height > size.height ? partialResult.height : size.height)
+        }
+
         size.width += xOffset * 2.0
         size.height += yOffset * 2.0
         size.width = max(minWidth, min(size.width, maxWidth > 0.0 ? maxWidth : size.width))


### PR DESCRIPTION
### Issue Link :https://github.com/danielgindi/Charts/issues/4780:
Y axis labels are improperly sized in some cases


### Implementation Details :construction:
Old broken logic: Label size was determined by the CGSize of the label with the largest number of characters
New logic: Label size is determined by the CGSize of the label with the largest CGSize

