### PR TITLE
Properties on axis renderers to Objc (Fixes #4800)

### DIFF
--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -16,9 +16,9 @@ import CoreGraphics
 @objc(ChartXAxisRenderer)
 open class XAxisRenderer: NSObject, AxisRenderer
 {
-    public let viewPortHandler: ViewPortHandler
-    public let axis: XAxis
-    public let transformer: Transformer?
+    @objc public let viewPortHandler: ViewPortHandler
+    @objc public let axis: XAxis
+    @objc public let transformer: Transformer?
 
     @objc public init(viewPortHandler: ViewPortHandler, axis: XAxis, transformer: Transformer?)
     {

--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -16,9 +16,9 @@ import CoreGraphics
 @objc(ChartYAxisRenderer)
 open class YAxisRenderer: NSObject, AxisRenderer
 {
-    public let viewPortHandler: ViewPortHandler
-    public let axis: YAxis
-    public let transformer: Transformer?
+    @objc public let viewPortHandler: ViewPortHandler
+    @objc public let axis: YAxis
+    @objc public let transformer: Transformer?
 
     @objc public init(viewPortHandler: ViewPortHandler, axis: YAxis, transformer: Transformer?)
     {


### PR DESCRIPTION
This makes the three public properties on XAxisRenderer and YAxisRenderer, available for access from Objc.

### Issue Link [#4800](https://github.com/danielgindi/Charts/issues/4800)

### Goals :soccer:
To make it possible to use these classes from Objc

### Implementation Details :construction:
These classes and many of the functions in them are already accessible from Objc. I think that the properties should also be (and indeed, they were until the move from `AxisRendererBase` to `AxisRenderer` in [#4456](https://github.com/danielgindi/Charts/pull/4456,))