### PR TITLE
fix crash max < min when entryTo is not found

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -107,7 +107,7 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
             let entryTo = dataSet.entryForXValue(high, closestToY: .nan, rounding: .up)
             
             self.min = entryFrom == nil ? 0 : dataSet.entryIndex(entry: entryFrom!)
-            self.max = entryTo == nil ? 0 : dataSet.entryIndex(entry: entryTo!)
+            self.max = entryTo == nil ? dataSet.entryCount : dataSet.entryIndex(entry: entryTo!)
             range = Int(Double(self.max - self.min) * phaseX)
         }
     }


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4798

### Goals :soccer:
Fix the crash when entry to is not found max can be lower than min.
It's not a perfect fix as I still have issue with fill under charts line.
Would probably be better to fix the `entryForXValue` returning nil instead

### Implementation Details :construction:
As `entryFrom` is found but `entryTo` is not min may be higher than max. Just use the last index of datset instead of 0 to make sure max is always bigger than min

### Testing Details :mag:
Run integration into my app and the app doesn't crash anymore while building the chart.