### PR TITLE
Fixed build phases order in main target compilation

### DIFF
--- a/Charts.xcodeproj/project.pbxproj
+++ b/Charts.xcodeproj/project.pbxproj
@@ -743,8 +743,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F1D4AA9E26EA32041FC0E3B6 /* Build configuration list for PBXNativeTarget "Charts" */;
 			buildPhases = (
-				B2B2DD73E237562739EE1F83 /* Headers */,
 				B5996DB2D9B6F0DB0E9D3F3E /* Sources */,
+				B2B2DD73E237562739EE1F83 /* Headers */,
 				E257C254E738A8AE047C6FB6 /* Resources */,
 				C16A09321DC2DCF289FF0E3B /* Frameworks */,
 			);


### PR DESCRIPTION
See [Xcode 10's known issues](https://developer.apple.com/documentation/xcode-release-notes/build-system-release-notes-for-xcode-10) in the release notes:

> Targets with Copy Headers build phases ordered after Compile Sources build phases may fail to build and emit a diagnostic regarding build cycles. (39880168)
>*Workaround*: Arrange any Copy Headers build phases before Compile Sources build phases.

This has been an issue for nearly 4 years, and now with Xcode 13.3 it leads to `XCBBuildService` to crash consistently.