### PR TITLE
fix(ChartDataSet): highlight not being invoked for expected user interactions #4719

### DIFF
--- a/ChartsDemo-iOS/Swift/Demos/LineChart2ViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/LineChart2ViewController.swift
@@ -192,13 +192,13 @@ class LineChart2ViewController: DemoBaseViewController {
 //}
     // TODO: Declarations in extensions cannot override yet.
 //extension LineChart2ViewController {
-    override func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
-        super.chartValueSelected(chartView, entry: entry, highlight: highlight)
-        
-        self.chartView.centerViewToAnimated(xValue: entry.x, yValue: entry.y,
-                                            axis: self.chartView.data![highlight.dataSetIndex].axisDependency,
-                                            duration: 1)
-        //[_chartView moveViewToAnimatedWithXValue:entry.x yValue:entry.y axis:[_chartView.data getDataSetByIndex:dataSetIndex].axisDependency duration:1.0];
-        //[_chartView zoomAndCenterViewAnimatedWithScaleX:1.8 scaleY:1.8 xValue:entry.x yValue:entry.y axis:[_chartView.data getDataSetByIndex:dataSetIndex].axisDependency duration:1.0];
-    }
+//    override func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
+//        super.chartValueSelected(chartView, entry: entry, highlight: highlight)
+//
+//        self.chartView.centerViewToAnimated(xValue: entry.x, yValue: entry.y,
+//                                            axis: self.chartView.data![highlight.dataSetIndex].axisDependency,
+//                                            duration: 1)
+//        //[_chartView moveViewToAnimatedWithXValue:entry.x yValue:entry.y axis:[_chartView.data getDataSetByIndex:dataSetIndex].axisDependency duration:1.0];
+//        //[_chartView zoomAndCenterViewAnimatedWithScaleX:1.8 scaleY:1.8 xValue:entry.x yValue:entry.y axis:[_chartView.data getDataSetByIndex:dataSetIndex].axisDependency duration:1.0];
+//    }
 }


### PR DESCRIPTION
(Fixes #4719)

Updates made in the ChartDataSet instance methods enforced by the protocol entriesForXValue and entryIndex to resolve #4719. 

The method entriesForXValue used partitionIndex with a predicate that could rarely find the value, as partitionIndex uses equality checks on only one node as it halves recursively. The other change is to, a swiftui provided method for lazy rendering views, prefix, the match predicate for filtering within the partition. 

There is an additional change how closest is calculated by entryIndex, possibly not needed. Previously, during the case of no entires, when a an xValue was tapped the next highest xValue was used. Example of the prior mentioned, xValue = 6.2 returns closest as 7 or even 12 whichever one was directly preceding its own position. It's now updated to return the shortest distance between x values for user touch accuracy; example: user taps x = 6.2, in an ascending array, the closest value to the left is 6 and to the right is 12; instead of returning back 12 it returns back the x value with the least difference 6. 

Note: (Have no idea why but Xcode was not letting me use min with the obj-c doubles in ChartDataEntry...wasn't even recognizing it as a function 🤷‍♂️

### Issue Link :link:
[ChartViewDelegate Function func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) is not being called for every tap/touch inside the ChartView](https://github.com/danielgindi/Charts/issues/4719)

### Goals :soccer:
To make charts work again
