### PR TITLE
Update ChartData.swift

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartData.swift
@@ -422,7 +422,7 @@ open class ChartData: NSObject, ExpressibleByArrayLiteral
     /// The DataSet object with the maximum number of entries or null if there are no DataSets.
     @objc open var maxEntryCountSet: Element?
     {
-        return self.max { $0.entryCount > $1.entryCount }
+        return self.max { $0.entryCount < $1.entryCount }
     }
 }
 

--- a/Tests/ChartsTests/ChartDataTests.swift
+++ b/Tests/ChartsTests/ChartDataTests.swift
@@ -64,4 +64,18 @@ class ChartDataTests: XCTestCase {
         XCTAssertTrue(data.dataSet(forLabel: SetLabels.badLabel, ignorecase: true) == nil)
         XCTAssertTrue(data.dataSet(forLabel: SetLabels.badLabel, ignorecase: false) == nil)
     }
+
+    func testMaxEntryCountSet() throws {
+        let dataSet1 = BarChartDataSet(entries: (0 ..< 4).map { BarChartDataEntry(x: Double($0), y: Double($0)) },
+                                       label: "data-set-1")
+        let dataSet2 = BarChartDataSet(entries: (0 ..< 3).map { BarChartDataEntry(x: Double($0), y: Double($0)) },
+                                       label: "data-set-2")
+        let dataSet3 = BarChartDataSet(entries: [BarChartDataEntry(x: 0, y: 0)],
+                                       label: "data-set-3")
+        let data = BarChartData(dataSets: [dataSet1, dataSet2, dataSet3])
+
+        let maxEntryCountSet = try XCTUnwrap(data.maxEntryCountSet as? BarChartDataSet)
+
+        XCTAssertEqual(maxEntryCountSet, dataSet1)
+    }
 }


### PR DESCRIPTION
Fix the wrong implementation of max function

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
https://github.com/danielgindi/Charts/issues/4821

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Fix the wrong implementation

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
In order to find the data set with max entry, we should sort ascending by ( $0.entryCount < $1.entryCount }.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
testMaxEntryCountSet