### PR TITLE
Fixes for Swift 5.7 compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ DerivedData
 *.ipa
 *.dSYM.zip
 *.dSYM
+*.dia
 
 ## Playgrounds
 timeline.xctimeline

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-algorithms",
         "state": {
           "branch": null,
-          "revision": "bb3bafeca0e164ece3403a9de646b7d38c07dd49",
-          "version": "0.0.2"
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
-          "revision": "6b24333510e9044cf4716a07bed65eeed6bc6393",
-          "version": "0.0.8"
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -435,6 +435,12 @@ extension ChartDataSet: RandomAccessCollection {
 
 // MARK: RangeReplaceableCollection
 extension ChartDataSet: RangeReplaceableCollection {
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Index>, with newElements: C) where C : Collection, Element == C.Element
+    {
+        entries.replaceSubrange(subrange, with: newElements)
+        notifyDataSetChanged()
+    }
+    
     public func append(_ newElement: Element) {
         calcMinMax(entry: newElement)
         entries.append(newElement)

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -119,7 +119,7 @@ extension CGPoint
 extension CGContext
 {
 
-    open func drawImage(_ image: NSUIImage, atCenter center: CGPoint, size: CGSize)
+    public func drawImage(_ image: NSUIImage, atCenter center: CGPoint, size: CGSize)
     {
         var drawOffset = CGPoint()
         drawOffset.x = center.x - (size.width / 2)
@@ -157,7 +157,7 @@ extension CGContext
         NSUIGraphicsPopContext()
     }
 
-    open func drawText(_ text: String, at point: CGPoint, align: TextAlignment, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5), angleRadians: CGFloat = 0.0, attributes: [NSAttributedString.Key : Any]?)
+    public func drawText(_ text: String, at point: CGPoint, align: TextAlignment, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5), angleRadians: CGFloat = 0.0, attributes: [NSAttributedString.Key : Any]?)
     {
         let drawPoint = getDrawPoint(text: text, point: point, align: align, attributes: attributes)
         
@@ -175,7 +175,7 @@ extension CGContext
         }
     }
     
-    open func drawText(_ text: String, at point: CGPoint, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5), angleRadians: CGFloat, attributes: [NSAttributedString.Key : Any]?)
+    public func drawText(_ text: String, at point: CGPoint, anchor: CGPoint = CGPoint(x: 0.5, y: 0.5), angleRadians: CGFloat, attributes: [NSAttributedString.Key : Any]?)
     {
         var drawOffset = CGPoint()
 


### PR DESCRIPTION
### Issue Link :link:
I'm currently experimenting with the latest development Swift 5.7 toolchain and the Charts library was not compiling due to a bug in the implementation of `RangeReplaceableCollection` on `ChartDataItem`.

This PR fixes that by adding the missing protocol method and also fixes a couple of compiler warnings (which I think also exist on the latest stable toolchain).

More info on this here: https://github.com/apple/swift/issues/58737 - the reason this compiled pre-5.7 was due to a bug in Swift which was due to be fixed in 5.6, reverted and will ship in 5.7 by the looks of it.

### Goals :soccer:
Library can now be compiled with Swift 5.7.

### Testing Details :mag:
Library continues to compile under 5.6.

I wasn't able to get the snapshots to pass on my M1 Max laptop - maybe I'm using the wrong simulator. The failures were very subtle and I don't think are related to this change.