### PR TITLE
Fix chart only drawing first entry

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-algorithms",
         "state": {
           "branch": null,
-          "revision": "bb3bafeca0e164ece3403a9de646b7d38c07dd49",
-          "version": "0.0.2"
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
-          "revision": "6b24333510e9044cf4716a07bed65eeed6bc6393",
-          "version": "0.0.8"
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -240,10 +240,13 @@ open class ChartDataSet: ChartBaseDataSet
             // The closest value in the beginning of this function
             // `var closest = partitioningIndex { $0.x >= xValue }`
             // doesn't guarantee closest rounding method
-            if closest > 0 {
+            if closest > startIndex {
                 let distanceAfter = abs(self[closest].x - xValue)
-                let distanceBefore = abs(self[closest-1].x - xValue)
-                distanceBefore < distanceAfter ? closest -= 1 : ()
+                let distanceBefore = abs(self[index(before: closest)].x - xValue)
+                if distanceBefore < distanceAfter
+                {
+                    closest = index(before: closest)
+                }
                 closestXValue = self[closest].x
             }
         }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -217,7 +217,7 @@ open class ChartDataSet: ChartBaseDataSet
         rounding: ChartDataSetRounding) -> Int
     {
         var closest = partitioningIndex { $0.x >= xValue }
-        guard closest < endIndex else { return rounding == .closest ? (endIndex-1) : -1 }
+        guard closest < endIndex else { return index(before: endIndex) }
 
         var closestXValue = self[closest].x
 


### PR DESCRIPTION
### Issue Link :link:
#4819 #4792 #4753 #4739 #4722 #4699 (and possibly a lot more)

### Goals :soccer:
Fixing line chart only drawing first entry when spaceMax on xAxis is not 0.
This will fix the candle stick chart only drawing first value as well!

### Implementation Details :construction:
With the addition of the swift-algorithms package in v4.0.0 many search algorithms have changed, including the one in [ChartDataSet.entryIndex(x:closestToY:rounding:)](https://github.com/danielgindi/Charts/blob/b38b8d45a8cbda9f0f2a3566778ed114f06056b7/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift#L214).

It turns out that [partitioningIndex](https://github.com/apple/swift-algorithms/blob/195e0316d7ba71e134d0f6c677f64b4db6160c46/Sources/Algorithms/Partition.swift#L188) works different in one situation: when the given value is greater than the greatest value in the array.
<img width="1853" alt="Screen Shot 2022-05-26 at 23 39 32" src="https://user-images.githubusercontent.com/42500484/170584874-b4eee67b-c476-4e2d-9b12-e84d2723f6a7.png">

Because of that, we need some kind of check that ensures we don't get an index out of bounds.
#4577 #4721 and the initial implementation #4497 do those checks, but wrong. The initial implementation is the best, the index is just one too high as shown in the screenshot above. We simply need to return the last possible index if a higher value is requested. Returning -1 in this situation will result in only drawing the first value!

In addition to that, I replaced all the raw index manipulation with the standard lib APIs and fixed Package.resolved to reflect the versions from the Package.swift!

### Testing Details :mag:
I tested in the demo projects and my personal one.

Before Fix | After Fix
:---------:|:---------:
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-26 at 22 24 17](https://user-images.githubusercontent.com/42500484/170586833-9dc2bdf5-03a3-47dc-8c7d-255d49283923.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-26 at 22 25 51](https://user-images.githubusercontent.com/42500484/170587351-8c3fb59e-e999-4095-84d7-ef62e62743eb.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-26 at 22 24 52](https://user-images.githubusercontent.com/42500484/170586849-ddce2c8d-a237-439b-b7dc-ee6639ea4de8.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-26 at 22 25 32](https://user-images.githubusercontent.com/42500484/170587467-b34ea62f-df57-429f-81cb-de33cd98ebab.png)

