### PR TITLE
Add double mark for compiler check related with issue #4835

### DIFF
--- a/Source/Charts/Animation/ChartAnimationEasing.swift
+++ b/Source/Charts/Animation/ChartAnimationEasing.swift
@@ -341,7 +341,7 @@ internal struct EasingFunctions
         let s: TimeInterval = 1.70158
         var position: TimeInterval = elapsed / duration
         position -= 1.0
-        return Double( position * position * ((s + 1.0) * position + s) + 1.0 )
+        return Double( position * position * ((s + Double(1.0)) * position + s) + Double(1.0) )
     }
     
     internal static let EaseInOutBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4835

in Xcode14 there is an compiler check error because of ambiguity of some math arithmetics, so this pr aim to fix it  

### Goals :soccer:
Because of this compiler error, i aim to fix this problem for xcode14-beta versions

### Implementation Details :construction:
There are no architectural changes, I just put Double casting into magic number as `1.0`
