### PR TITLE
fixed no used warning

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -310,7 +310,7 @@ open class ChartDataSet: ChartBaseDataSet
     /// - Parameters:
     ///   - e: the entry to add
     /// - Returns: True
-    // TODO: This should return `Void` to follow Swift convention
+    @discardableResult
     open override func addEntryOrdered(_ e: ChartDataEntry) -> Bool
     {
         if let last = last, last.x > e.x


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

there will be no warning in demo project

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

As I noticed in the demo project, it was giving a warning that the addEntryOrdered(_ e: ChartDataEntry) function is not used. That's why I made the development

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->