### PR TITLE
CandleStickChart Correction of maximum element index

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -217,6 +217,9 @@ open class ChartDataSet: ChartBaseDataSet
         rounding: ChartDataSetRounding) -> Int
     {
         var closest = partitioningIndex { $0.x >= xValue }
+        if closest == endIndex {
+            closest -= 1
+        }
         guard closest < endIndex else { return rounding == .closest ? (endIndex-1) : -1 }
 
         var closestXValue = self[closest].x


### PR DESCRIPTION
When retrieving the element that approximates the maximum value on the x-axis, the index range is exceeded at the maximum value.

### Issue Link :link:
CandleStickChart, including the demo, only shows the first data.

### Testing Details :mag:
Demo application, visual confirmation only by moving the slider left and right.