### PR TITLE
Update ChartDataSet.swift

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -435,6 +435,11 @@ extension ChartDataSet: RandomAccessCollection {
 
 // MARK: RangeReplaceableCollection
 extension ChartDataSet: RangeReplaceableCollection {
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Index>, with newElements: C) where C : Collection, Element == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
+        notifyDataSetChanged()
+    }
+    
     public func append(_ newElement: Element) {
         calcMinMax(entry: newElement)
         entries.append(newElement)


### PR DESCRIPTION
Missing method.

Xcode 14 Beta 3 issues. 
Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'

### Issue
Xcode 14 Beta 3 issues. 
Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'

### Goals :soccer:
Instance method 'replaceSubrange(_:with:)' need to adding.

### Implementation Details :construction:
Added unavailable instance method 'replaceSubrange(_:with:)'.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->