### PR TITLE
Fix navigation bar transparent issue

### DIFF
--- a/ChartsDemo-iOS/Objective-C/AppDelegate.m
+++ b/ChartsDemo-iOS/Objective-C/AppDelegate.m
@@ -24,6 +24,12 @@
     
     DemoListViewController *vc = [[DemoListViewController alloc] init];
     UINavigationController *nvc = [[UINavigationController alloc] initWithRootViewController:vc];
+    if (@available(iOS 13.0, *)) {
+        UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+        [appearance configureWithOpaqueBackground];
+        nvc.navigationBar.standardAppearance = appearance;
+        nvc.navigationBar.scrollEdgeAppearance = appearance;
+    }
     
     _window.rootViewController = nvc;
     [_window makeKeyAndVisible];

--- a/ChartsDemo-iOS/Swift/AppDelegate.swift
+++ b/ChartsDemo-iOS/Swift/AppDelegate.swift
@@ -22,6 +22,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         let vc = DemoListViewController()
         let nav = UINavigationController(rootViewController: vc)
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            nav.navigationBar.standardAppearance = appearance
+            nav.navigationBar.scrollEdgeAppearance = appearance
+        }
         
         window?.rootViewController = nav
         window?.makeKeyAndVisible()


### PR DESCRIPTION
### Issue Link :link:
Issue: iOS demo project navigation bar transparent 

### Goals :soccer:

### Implementation Details :construction:
Objc:
![1658900760227](https://user-images.githubusercontent.com/15813435/181170577-d8271082-d47d-4fcf-ae35-f4dd9f0ea737.jpg)

Swift:
![1658900820092](https://user-images.githubusercontent.com/15813435/181170669-fa360323-35b1-4ca0-8a56-a2585df62986.jpg)



### Testing Details :mag:
| Before Fix    | After Fix |
| ----------- | ----------- |
|   ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-07-27 at 13 41 59](https://user-images.githubusercontent.com/15813435/181170839-474afaec-112f-4cd6-93df-d4d85992bc28.png)    | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-07-27 at 13 41 30](https://user-images.githubusercontent.com/15813435/181170860-49a0d4de-7009-466d-ba7d-caa0397823fc.png)       |




