### PR TITLE
Fix Type 'ChartDataSet' does not conform to protocol 'RangeReplaceabl…

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataEntry.swift
@@ -17,7 +17,7 @@ open class BarChartDataEntry: ChartDataEntry
     private var _yVals: [Double]?
     
     /// the ranges for the individual stack values - automatically calculated
-    private var _ranges: [Range]?
+    private var _ranges: [ChartRange]?
     
     /// the sum of all negative values this entry (if stacked) contains
     private var _negativeSum: Double = 0.0
@@ -145,7 +145,7 @@ open class BarChartDataEntry: ChartDataEntry
 
         if _ranges == nil
         {
-            _ranges = [Range]()
+            _ranges = [ChartRange]()
         }
         else
         {
@@ -161,12 +161,12 @@ open class BarChartDataEntry: ChartDataEntry
         {
             if value < 0
             {
-                _ranges!.append(Range(from: negRemain, to: negRemain - value))
+                _ranges!.append(ChartRange(from: negRemain, to: negRemain - value))
                 negRemain -= value
             }
             else
             {
-                _ranges!.append(Range(from: posRemain, to: posRemain + value))
+                _ranges!.append(ChartRange(from: posRemain, to: posRemain + value))
                 posRemain += value
             }
         }
@@ -191,7 +191,7 @@ open class BarChartDataEntry: ChartDataEntry
     }
     
     /// The ranges of the individual stack-entries. Will return null if this entry is not stacked.
-    @objc open var ranges: [Range]?
+    @objc open var ranges: [ChartRange]?
     {
         return _ranges
     }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -527,7 +527,7 @@ extension ChartDataSet: RandomAccessCollection {
 }
 
 // MARK: RangeReplaceableCollection
-extension ChartDataSet: RangeReplaceableCollection {
+extension ChartDataSet: RangeReplaceableCollection {    
     public func append(_ newElement: Element) {
         calcMinMax(entry: newElement)
         entries.append(newElement)
@@ -569,6 +569,14 @@ extension ChartDataSet: RangeReplaceableCollection {
     @objc
     public func removeAll(keepingCapacity keepCapacity: Bool) {
         entries.removeAll(keepingCapacity: keepCapacity)
+        notifyDataSetChanged()
+    }
+    
+    public func replaceSubrange<C>(
+        _ subrange: Range<Index>,
+        with newElements: C
+    ) where C : Collection, Element == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
         notifyDataSetChanged()
     }
 }

--- a/Source/Charts/Highlight/BarHighlighter.swift
+++ b/Source/Charts/Highlight/BarHighlighter.swift
@@ -95,7 +95,7 @@ open class BarHighlighter: ChartHighlighter
     ///   - entry:
     ///   - value:
     /// - Returns: The index of the closest value inside the values array / ranges (stacked barchart) to the value given as a parameter.
-    @objc open func getClosestStackIndex(ranges: [Range]?, value: Double) -> Int
+    @objc open func getClosestStackIndex(ranges: [ChartRange]?, value: Double) -> Int
     {
         guard let ranges = ranges else { return 0 }
         if let stackIndex = ranges.firstIndex(where: { $0.contains(value) }) {

--- a/Source/Charts/Highlight/ChartRange.swift
+++ b/Source/Charts/Highlight/ChartRange.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 @objc(ChartRange)
-open class Range: NSObject
+open class ChartRange: NSObject
 {
     @objc open var from: Double
     @objc open var to: Double


### PR DESCRIPTION
For some reason I got this error on xCode - beta.

Fix implemented by:
* implementing method of RangeReplaceableCollection protocol for ChartDataSet 
* renaming of Range(objc ChartsRange) class cause it Shadows swift Range class that leads to compile errors.
