### PR TITLE
Fix CandleChartDataSet calcMinMaxY 

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
@@ -44,11 +44,11 @@ open class CandleChartDataSet: LineScatterCandleRadarChartDataSet, CandleChartDa
         guard let e = e as? CandleChartDataEntry
             else { return }
 
-        _yMin = Swift.min(e.low, _yMin)
-        _yMax = Swift.max(e.high, _yMin)
-
-        _yMin = Swift.min(e.low, _yMax)
+        _yMin = Swift.min(e.high, _yMin)
         _yMax = Swift.max(e.high, _yMax)
+
+        _yMin = Swift.min(e.low, _yMin)
+        _yMax = Swift.max(e.low, _yMax)
     }
     
     // MARK: - Styling functions and accessors


### PR DESCRIPTION
`autoScaleMinMaxEnabled` does not working correctly with candle chart.

### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
The rewrite of [this commit](https://github.com/danielgindi/Charts/commit/84b501f311a38bc700c9b07e763721848a78b645) seems incorrect and created a fix.
![スクリーンショット 2022-08-19 18 21 03](https://user-images.githubusercontent.com/13185779/185590744-27f4caf1-a5c0-4b8a-a826-a526ad1ecbe8.png)

Sorry i'm not good at english.
Could you please have a moment to take a look at it?

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->