### PR TITLE
[Xcode 14] Add missing implementation to ensure ChartDataSet: RangeReplaceableCollection can compile

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -571,4 +571,9 @@ extension ChartDataSet: RangeReplaceableCollection {
         entries.removeAll(keepingCapacity: keepCapacity)
         notifyDataSetChanged()
     }
+    
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Int>, with newElements: C) where C : Collection, ChartDataEntry == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
+        notifyDataSetChanged()
+    }
 }


### PR DESCRIPTION
### Goals :soccer:
Resolve compilation errors for `ChartDataSet: RangeReplaceableCollection` in Xcode 14 betas.

### Implementation Details :construction:
This workaround is found here: https://github.com/danielgindi/Charts/issues/4873#issuecomment-1198416198
This works on both the 4.x master branch, as well as 3.x releases of Charts.

### Testing Details :mag:
N/A