### PR TITLE
Xcode 14 replaceRange patch

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -566,6 +566,11 @@ extension ChartDataSet: RangeReplaceableCollection {
         notifyDataSetChanged()
     }
 
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Index>, with newElements: C) where C : Collection, Element == C.Element {
+         entries.replaceSubrange(subrange, with: newElements)
+         notifyDataSetChanged()
+    }
+
     @objc
     public func removeAll(keepingCapacity keepCapacity: Bool) {
         entries.removeAll(keepingCapacity: keepCapacity)


### PR DESCRIPTION
### Issue Link :link:
Back-port patch for Xcode 14 for 3.x release

### Goals :soccer:
4.x branch is not compatible with iOS 11, we are not able to move to iOS 12 yet, allow building on Xcode14 while maintaining compatibility with iOS 11

### Testing Details :mag:
Tested on compiled app with Xcode 14