### PR TITLE
fix: avoid range crash

### DIFF
--- a/Source/Charts/Renderers/YAxisRenderer.swift
+++ b/Source/Charts/Renderers/YAxisRenderer.swift
@@ -133,7 +133,7 @@ open class YAxisRenderer: NSObject, AxisRenderer
         
         let xOffset = axis.labelXOffset
         
-        for i in from..<to
+        for i in stride(from: from, to: to, by: 1)
         {
             let text = axis.getFormattedLabel(i)
             context.drawText(text,


### PR DESCRIPTION
### Issue Link :link:
🔗 https://github.com/danielgindi/Charts/issues/4908

### Goals :soccer:
Revert to the previous function.

### Implementation Details :construction:
Replace `from..<to` with `stride(from: from, to: to, by: 1)`.

### Testing Details :mag:
The issues link has demo project can test.