### PR TITLE
Don't overwrite a valueFormatter when adding a DataSet to a chart

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -62,7 +62,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             // calculate how many digits are needed
             setupDefaultFormatter(min: data.yMin, max: data.yMax)
 
-            for set in data where set.valueFormatter is DefaultValueFormatter
+            for set in data where set.valueFormatter == nil
             {
                 set.valueFormatter = defaultValueFormatter
             }

--- a/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
+++ b/Source/Charts/Data/Implementations/ChartBaseDataSet.swift
@@ -273,7 +273,7 @@ open class ChartBaseDataSet: NSObject, ChartDataSetProtocol, NSCopying
     open var isHighlightEnabled: Bool { return highlightEnabled }
         
     /// Custom formatter that is used instead of the auto-formatter if set
-    open lazy var valueFormatter: ValueFormatter = DefaultValueFormatter()
+    open lazy var valueFormatter: ValueFormatter? = nil
 
     /// Sets/get a single color for value text.
     /// Setting the color clears the colors array and adds a single color.

--- a/Source/Charts/Data/Interfaces/ChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/ChartDataSetProtocol.swift
@@ -195,8 +195,10 @@ public protocol ChartDataSetProtocol
     /// `true` if value highlighting is enabled for this dataset
     var isHighlightEnabled: Bool { get }
     
-    /// Custom formatter that is used instead of the auto-formatter if set
-    var valueFormatter: ValueFormatter { get set }
+    /// Custom formatter that is used instead of the auto-formatter if set.
+    /// The ChartView will set a default formatter if this is nil when the DataSet is added to the
+    /// chart.
+    var valueFormatter: ValueFormatter? { get set }
     
     /// Sets/get a single color for value text.
     /// Setting the color clears the colors array and adds a single color.

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -467,7 +467,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 let buffer = _buffers[dataSetIndex]
                 
-                let formatter = dataSet.valueFormatter
+                let formatter = dataSet.valueFormatter!
                 
                 let trans = dataProvider.getTransformer(forAxis: dataSet.axisDependency)
                 
@@ -789,7 +789,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         // there is the possibility of some labels being rounded up. A floor() might fix this, but seems to be a brute force solution.
         let label = xAxis.valueFormatter?.stringForValue(e.x, axis: xAxis) ?? "\(e.x)"
 
-        var elementValueText = dataSet.valueFormatter.stringForValue(
+        var elementValueText = dataSet.valueFormatter!.stringForValue(
             e.y,
             entry: e,
             dataSetIndex: dataSetIndex,
@@ -810,7 +810,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
             //Handles empty array of yValues
             let yValue = vals.isEmpty ? 0.0 : vals[idx % vals.count]
 
-            elementValueText = dataSet.valueFormatter.stringForValue(
+            elementValueText = dataSet.valueFormatter!.stringForValue(
                 yValue,
                 entry: e,
                 dataSetIndex: dataSetIndex,

--- a/Source/Charts/Renderers/BubbleChartRenderer.swift
+++ b/Source/Charts/Renderers/BubbleChartRenderer.swift
@@ -171,7 +171,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
                 continue
             }
 
-            let formatter = dataSet.valueFormatter
+            let formatter = dataSet.valueFormatter!
             let alpha = phaseX == 1 ? phaseY : phaseX
 
             _xBounds.set(chart: dataProvider, dataSet: dataSet, animator: animator)
@@ -343,7 +343,7 @@ open class BubbleChartRenderer: BarLineScatterCandleBubbleRenderer
         // there is the possibility of some labels being rounded up. A floor() might fix this, but seems to be a brute force solution.
         let label = xAxis.valueFormatter?.stringForValue(e.x, axis: xAxis) ?? "\(e.x)"
 
-        let elementValueText = dataSet.valueFormatter.stringForValue(e.y,
+        let elementValueText = dataSet.valueFormatter!.stringForValue(e.y,
                                                                       entry: e,
                                                                       dataSetIndex: dataSetIndex,
                                                                       viewPortHandler: viewPortHandler)

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -288,7 +288,7 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                 
                 let valueFont = dataSet.valueFont
                 
-                let formatter = dataSet.valueFormatter
+                let formatter = dataSet.valueFormatter!
                 
                 let trans = dataProvider.getTransformer(forAxis: dataSet.axisDependency)
                 let valueToPixelMatrix = trans.valueToPixelMatrix

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -345,7 +345,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 let valueFont = dataSet.valueFont
                 let yOffset = -valueFont.lineHeight / 2.0
                 
-                let formatter = dataSet.valueFormatter
+                let formatter = dataSet.valueFormatter!
                 
                 let trans = dataProvider.getTransformer(forAxis: dataSet.axisDependency)
                 

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -536,7 +536,7 @@ open class LineChartRenderer: LineRadarRenderer
                 
                 let valueFont = dataSet.valueFont
                 
-                let formatter = dataSet.valueFormatter
+                let formatter = dataSet.valueFormatter!
                 
                 let angleRadians = dataSet.valueLabelAngle.DEG2RAD
                 
@@ -892,7 +892,7 @@ open class LineChartRenderer: LineRadarRenderer
         // there is the possibility of some labels being rounded up. A floor() might fix this, but seems to be a brute force solution.
         let label = xAxis.valueFormatter?.stringForValue(e.x, axis: xAxis) ?? "\(e.x)"
 
-        let elementValueText = dataSet.valueFormatter.stringForValue(e.y,
+        let elementValueText = dataSet.valueFormatter!.stringForValue(e.y,
                                                                      entry: e,
                                                                      dataSetIndex: dataSetIndex,
                                                                      viewPortHandler: viewPortHandler)

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -355,7 +355,7 @@ open class PieChartRenderer: NSObject, DataRenderer
             let entryLabelFont = dataSet.entryLabelFont
             let lineHeight = valueFont.lineHeight
             
-            let formatter = dataSet.valueFormatter
+            let formatter = dataSet.valueFormatter!
             
             for j in 0 ..< dataSet.entryCount
             {
@@ -900,7 +900,7 @@ open class PieChartRenderer: NSObject, DataRenderer
         guard let e = dataSet.entryForIndex(idx) else { return element }
         guard let data = container.data as? PieChartData else { return element }
 
-        let formatter = dataSet.valueFormatter
+        let formatter = dataSet.valueFormatter!
         
         var elementValueText = formatter.stringForValue(
             e.y,

--- a/Source/Charts/Renderers/RadarChartRenderer.swift
+++ b/Source/Charts/Renderers/RadarChartRenderer.swift
@@ -230,7 +230,7 @@ open class RadarChartRenderer: LineRadarRenderer
                 
                 let valueFont = dataSet.valueFont
                 
-                let formatter = dataSet.valueFormatter
+                let formatter = dataSet.valueFormatter!
                 
                 if dataSet.isDrawValuesEnabled
                 {

--- a/Source/Charts/Renderers/ScatterChartRenderer.swift
+++ b/Source/Charts/Renderers/ScatterChartRenderer.swift
@@ -122,7 +122,7 @@ open class ScatterChartRenderer: LineScatterCandleRadarRenderer
                 
                 let valueFont = dataSet.valueFont
                 
-                let formatter = dataSet.valueFormatter
+                let formatter = dataSet.valueFormatter!
                 
                 let trans = dataProvider.getTransformer(forAxis: dataSet.axisDependency)
                 let valueToPixelMatrix = trans.valueToPixelMatrix


### PR DESCRIPTION
Previously a `DataSet`'s `valueFormatter` would be replaced with the default if it was any instance of the `DefaultValueFormatter` class, even one that had been customised.

This PR changes the `valueFormatter` to be optional, and will set it to the default when it's added to a chart only if it hasn't already been set by the user.

This fixes the formatting in some of the demo app charts too:
1. The [Positive/negative demo](https://github.com/danielgindi/Charts/blob/master/ChartsDemo-iOS/Objective-C/Demos/PositiveNegativeBarChartViewController.m#L159) tries to set maximumFractionDigits to 1: [before](https://user-images.githubusercontent.com/314463/191893466-694ecc77-d449-4c35-8fe2-a5946c52efeb.png), [after](https://user-images.githubusercontent.com/314463/191893462-8ffa15d3-ab30-4840-9784-4c39bfa03f3c.png)
2. The [Pie Chart demo](https://github.com/danielgindi/Charts/blob/master/ChartsDemo-iOS/Objective-C/Demos/PieChartViewController.m#L122) tries to set a percent suffix: [before](https://user-images.githubusercontent.com/314463/191893467-c8f8333b-fac1-4f59-8b5e-eb4e69527cf3.png), [after](https://user-images.githubusercontent.com/314463/191893464-904c5a5a-311b-455a-a586-4dd9762d57cb.png)

Fixes #4595, fixes #4599, fixes #4690, fixes #4802.