### PR TITLE
Fix RangeReplaceableCollection protocol implementation for 3.6 version

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -27,7 +27,7 @@ open class ChartDataSet: ChartBaseDataSet
     public required init()
     {
         entries = []
-
+        
         super.init()
     }
     
@@ -39,9 +39,9 @@ open class ChartDataSet: ChartBaseDataSet
     @objc public init(entries: [ChartDataEntry]?, label: String?)
     {
         self.entries = entries ?? []
-
+        
         super.init(label: label)
-
+        
         self.calcMinMax()
     }
     
@@ -51,17 +51,17 @@ open class ChartDataSet: ChartBaseDataSet
     }
     
     // MARK: - Data functions and accessors
-
+    
     /// - Note: Calls `notifyDataSetChanged()` after setting a new value.
     /// - Returns: The array of y-values that this DataSet represents.
     /// the entries that this dataset represents / holds together
     @available(*, unavailable, renamed: "entries")
     @objc
     open var values: [ChartDataEntry] { return entries }
-
+    
     @objc
     open private(set) var entries: [ChartDataEntry]
-
+    
     /// Used to replace all entries of a data set while retaining styling properties.
     /// This is a separate method from a setter on `entries` to encourage usage
     /// of `Collection` conformances.
@@ -72,7 +72,7 @@ open class ChartDataSet: ChartBaseDataSet
         self.entries = entries
         notifyDataSetChanged()
     }
-
+    
     /// maximum y-value in the value array
     internal var _yMax: Double = -Double.greatestFiniteMagnitude
     
@@ -91,9 +91,9 @@ open class ChartDataSet: ChartBaseDataSet
         _yMin = Double.greatestFiniteMagnitude
         _xMax = -Double.greatestFiniteMagnitude
         _xMin = Double.greatestFiniteMagnitude
-
+        
         guard !isEmpty else { return }
-
+        
         forEach(calcMinMax)
     }
     
@@ -101,7 +101,7 @@ open class ChartDataSet: ChartBaseDataSet
     {
         _yMax = -Double.greatestFiniteMagnitude
         _yMin = Double.greatestFiniteMagnitude
-
+        
         guard !isEmpty else { return }
         
         let indexFrom = entryIndex(x: fromX, closestToY: Double.nan, rounding: .down)
@@ -429,7 +429,7 @@ open class ChartDataSet: ChartBaseDataSet
     {
         return remove(entry)
     }
-
+    
     /// Removes an Entry from the DataSet dynamically.
     /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
     ///
@@ -442,7 +442,7 @@ open class ChartDataSet: ChartBaseDataSet
         _ = remove(at: index)
         return true
     }
-
+    
     /// Removes the first Entry (at index 0) of this DataSet from the entries array.
     ///
     /// - Returns: `true` if successful, `false` if not.
@@ -462,7 +462,7 @@ open class ChartDataSet: ChartBaseDataSet
         let entry: ChartDataEntry? = isEmpty ? nil : removeLast()
         return entry != nil
     }
-
+    
     /// Removes all values from this DataSet and recalculates min and max value.
     @available(*, deprecated, message: "Use `removeAll(keepingCapacity:)` instead.")
     open override func clear()
@@ -471,7 +471,7 @@ open class ChartDataSet: ChartBaseDataSet
     }
     
     // MARK: - Data functions and accessors
-
+    
     // MARK: - NSCopying
     
     open override func copy(with zone: NSZone? = nil) -> Any
@@ -483,7 +483,7 @@ open class ChartDataSet: ChartBaseDataSet
         copy._yMin = _yMin
         copy._xMax = _xMax
         copy._xMin = _xMin
-
+        
         return copy
     }
 }
@@ -492,19 +492,19 @@ open class ChartDataSet: ChartBaseDataSet
 extension ChartDataSet: MutableCollection {
     public typealias Index = Int
     public typealias Element = ChartDataEntry
-
+    
     public var startIndex: Index {
         return entries.startIndex
     }
-
+    
     public var endIndex: Index {
         return entries.endIndex
     }
-
+    
     public func index(after: Index) -> Index {
         return entries.index(after: after)
     }
-
+    
     @objc
     public subscript(position: Index) -> Element {
         get {
@@ -532,43 +532,48 @@ extension ChartDataSet: RangeReplaceableCollection {
         calcMinMax(entry: newElement)
         entries.append(newElement)
     }
-
+    
     public func remove(at position: Index) -> Element {
         let element = entries.remove(at: position)
         notifyDataSetChanged()
         return element
     }
-
+    
     public func removeFirst() -> Element {
         let element = entries.removeFirst()
         notifyDataSetChanged()
         return element
     }
-
+    
     public func removeFirst(_ n: Int) {
         entries.removeFirst(n)
         notifyDataSetChanged()
     }
-
+    
     public func removeLast() -> Element {
         let element = entries.removeLast()
         notifyDataSetChanged()
         return element
     }
-
+    
     public func removeLast(_ n: Int) {
         entries.removeLast(n)
         notifyDataSetChanged()
     }
-
+    
     public func removeSubrange<R>(_ bounds: R) where R : RangeExpression, Index == R.Bound {
         entries.removeSubrange(bounds)
         notifyDataSetChanged()
     }
-
+    
     @objc
     public func removeAll(keepingCapacity keepCapacity: Bool) {
         entries.removeAll(keepingCapacity: keepCapacity)
+        notifyDataSetChanged()
+    }
+    
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Int>, with newElements: C) where C : Collection, ChartDataEntry == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
         notifyDataSetChanged()
     }
 }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -27,7 +27,7 @@ open class ChartDataSet: ChartBaseDataSet
     public required init()
     {
         entries = []
-        
+
         super.init()
     }
     
@@ -39,9 +39,9 @@ open class ChartDataSet: ChartBaseDataSet
     @objc public init(entries: [ChartDataEntry]?, label: String?)
     {
         self.entries = entries ?? []
-        
+
         super.init(label: label)
-        
+
         self.calcMinMax()
     }
     
@@ -51,17 +51,17 @@ open class ChartDataSet: ChartBaseDataSet
     }
     
     // MARK: - Data functions and accessors
-    
+
     /// - Note: Calls `notifyDataSetChanged()` after setting a new value.
     /// - Returns: The array of y-values that this DataSet represents.
     /// the entries that this dataset represents / holds together
     @available(*, unavailable, renamed: "entries")
     @objc
     open var values: [ChartDataEntry] { return entries }
-    
+
     @objc
     open private(set) var entries: [ChartDataEntry]
-    
+
     /// Used to replace all entries of a data set while retaining styling properties.
     /// This is a separate method from a setter on `entries` to encourage usage
     /// of `Collection` conformances.
@@ -72,7 +72,7 @@ open class ChartDataSet: ChartBaseDataSet
         self.entries = entries
         notifyDataSetChanged()
     }
-    
+
     /// maximum y-value in the value array
     internal var _yMax: Double = -Double.greatestFiniteMagnitude
     
@@ -91,9 +91,9 @@ open class ChartDataSet: ChartBaseDataSet
         _yMin = Double.greatestFiniteMagnitude
         _xMax = -Double.greatestFiniteMagnitude
         _xMin = Double.greatestFiniteMagnitude
-        
+
         guard !isEmpty else { return }
-        
+
         forEach(calcMinMax)
     }
     
@@ -101,7 +101,7 @@ open class ChartDataSet: ChartBaseDataSet
     {
         _yMax = -Double.greatestFiniteMagnitude
         _yMin = Double.greatestFiniteMagnitude
-        
+
         guard !isEmpty else { return }
         
         let indexFrom = entryIndex(x: fromX, closestToY: Double.nan, rounding: .down)
@@ -429,7 +429,7 @@ open class ChartDataSet: ChartBaseDataSet
     {
         return remove(entry)
     }
-    
+
     /// Removes an Entry from the DataSet dynamically.
     /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
     ///
@@ -442,7 +442,7 @@ open class ChartDataSet: ChartBaseDataSet
         _ = remove(at: index)
         return true
     }
-    
+
     /// Removes the first Entry (at index 0) of this DataSet from the entries array.
     ///
     /// - Returns: `true` if successful, `false` if not.
@@ -462,7 +462,7 @@ open class ChartDataSet: ChartBaseDataSet
         let entry: ChartDataEntry? = isEmpty ? nil : removeLast()
         return entry != nil
     }
-    
+
     /// Removes all values from this DataSet and recalculates min and max value.
     @available(*, deprecated, message: "Use `removeAll(keepingCapacity:)` instead.")
     open override func clear()
@@ -471,7 +471,7 @@ open class ChartDataSet: ChartBaseDataSet
     }
     
     // MARK: - Data functions and accessors
-    
+
     // MARK: - NSCopying
     
     open override func copy(with zone: NSZone? = nil) -> Any
@@ -483,7 +483,7 @@ open class ChartDataSet: ChartBaseDataSet
         copy._yMin = _yMin
         copy._xMax = _xMax
         copy._xMin = _xMin
-        
+
         return copy
     }
 }
@@ -492,19 +492,19 @@ open class ChartDataSet: ChartBaseDataSet
 extension ChartDataSet: MutableCollection {
     public typealias Index = Int
     public typealias Element = ChartDataEntry
-    
+
     public var startIndex: Index {
         return entries.startIndex
     }
-    
+
     public var endIndex: Index {
         return entries.endIndex
     }
-    
+
     public func index(after: Index) -> Index {
         return entries.index(after: after)
     }
-    
+
     @objc
     public subscript(position: Index) -> Element {
         get {
@@ -532,40 +532,40 @@ extension ChartDataSet: RangeReplaceableCollection {
         calcMinMax(entry: newElement)
         entries.append(newElement)
     }
-    
+
     public func remove(at position: Index) -> Element {
         let element = entries.remove(at: position)
         notifyDataSetChanged()
         return element
     }
-    
+
     public func removeFirst() -> Element {
         let element = entries.removeFirst()
         notifyDataSetChanged()
         return element
     }
-    
+
     public func removeFirst(_ n: Int) {
         entries.removeFirst(n)
         notifyDataSetChanged()
     }
-    
+
     public func removeLast() -> Element {
         let element = entries.removeLast()
         notifyDataSetChanged()
         return element
     }
-    
+
     public func removeLast(_ n: Int) {
         entries.removeLast(n)
         notifyDataSetChanged()
     }
-    
+
     public func removeSubrange<R>(_ bounds: R) where R : RangeExpression, Index == R.Bound {
         entries.removeSubrange(bounds)
         notifyDataSetChanged()
     }
-    
+
     @objc
     public func removeAll(keepingCapacity keepCapacity: Bool) {
         entries.removeAll(keepingCapacity: keepCapacity)
@@ -576,4 +576,5 @@ extension ChartDataSet: RangeReplaceableCollection {
         entries.replaceSubrange(subrange, with: newElements)
         notifyDataSetChanged()
     }
+
 }


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4873

### Goals :soccer:
I fix problem related to RangeReplaceableCollection protocol implemented on ChartDataSet adding replaceSubrange method for 3.6 version.

### Implementation Details :construction:

### Testing Details :mag:
I just rebuild project and no build errors occur on Xcode 14.0.