### PR TITLE
fix XAxisRenderer for centered entries

### DIFF
--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -268,11 +268,11 @@ open class XAxisRenderer: NSObject, AxisRenderer
             labelMaxSize.width = axis.wordWrapWidthPercent * valueToPixelMatrix.a
         }
         
-        let entries = axis.entries
+        let entries = isCenteringEnabled ? axis.centeredEntries : axis.entries
         
         for i in entries.indices
         {
-            let px = isCenteringEnabled ? CGFloat(axis.centeredEntries[i]) : CGFloat(entries[i])
+            let px = CGFloat(entries[i])
             position = CGPoint(x: px, y: 0)
                 .applying(valueToPixelMatrix)
 


### PR DESCRIPTION
### Issue Link :link:
https://github.com/danielgindi/Charts/issues/4929

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
After Enabling xAxis.centerAxisLabelsEnabled, entries x-point should lookup in centered entires. some times entries and centered entries are not the same length which caused the crash "Index out of range". This pr fix the crash

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->