### PR TITLE
fix ChartViewBase.data assgin bug

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -62,9 +62,12 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
             // calculate how many digits are needed
             setupDefaultFormatter(min: data.yMin, max: data.yMax)
 
-            for set in data where set.valueFormatter is DefaultValueFormatter
+            for set in data
             {
-                set.valueFormatter = defaultValueFormatter
+                let valueFormatter: ValueFormatter? = set.valueFormatter
+                if valueFormatter == nil {
+                    set.valueFormatter = defaultValueFormatter
+                }
             }
 
             // let the chart know there is new data


### PR DESCRIPTION
### Issue Link :link:
If I call ChartData `setValueFormatter:DefaultValueFormatter` func before I call ChartView data assign(`chartView.data = data`), the valueFormatter won't work.
Here is my issue code....
```
 let pFormatter = NumberFormatter()
pFormatter.numberStyle = .percent
pFormatter.maximumFractionDigits = 2
pFormatter.multiplier = 1
pFormatter.percentSymbol = "%"
data.setValueFont(.systemFont(ofSize: 11, weight: .light))
data.setValueTextColor(.black)
chartView.data = data
data.setValueFormatter(DefaultValueFormatter(formatter: pFormatter))
```
### Goals :soccer:
None

### Implementation Details :construction:
None

### Testing Details :mag:
Just test for myself project.