### PR TITLE
iOS 15 Crash has been fixed.

### DIFF
--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -110,7 +110,7 @@ open class PieChartView: PieRadarChartViewBase
         
         if (valuesToHighlight())
         {
-            renderer.drawHighlighted(context: context, indices: highlighted)
+            renderer.drawHighlighted(context: context, indices: highlighted.compactMap { $0 })
         }
         
         renderer.drawExtras(context: context)


### PR DESCRIPTION
### Issue Link :link:
If you want all the pies to be highlighted in the piechart, you will get an error in ios 15. Cannot convert NSArray to Array.

### Goals :soccer:

### Implementation Details :construction:

### Testing Details :mag: