### PR TITLE
feat: Add gradient highlight radar indicator to LineScatterCandleRadarChartDat…

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/LineScatterCandleRadarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/LineScatterCandleRadarChartDataSet.swift
@@ -23,12 +23,24 @@ open class LineScatterCandleRadarChartDataSet: BarLineScatterCandleBubbleChartDa
     
     /// Enables / disables the vertical highlight-indicator. If disabled, the indicator is not drawn.
     open var drawVerticalHighlightIndicatorEnabled = true
+
+    /// Enables / disables the horizontal radar highlight-indicator. If disabled, the indicator is not drawn.
+    open var drawHorizontalHighlightRadarIndicatorEnabled = true
+
+    /// Enables / disables the vertical radar highlight-indicator. If disabled, the indicator is not drawn.
+    open var drawVerticalHighlightRadarIndicatorEnabled = true
     
     /// `true` if horizontal highlight indicator lines are enabled (drawn)
     open var isHorizontalHighlightIndicatorEnabled: Bool { return drawHorizontalHighlightIndicatorEnabled }
     
     /// `true` if vertical highlight indicator lines are enabled (drawn)
     open var isVerticalHighlightIndicatorEnabled: Bool { return drawVerticalHighlightIndicatorEnabled }
+
+    /// `true` if horizontal highlight radar indicator lines are enabled (drawn)
+    open var isHorizontalHighlightRadarIndicatorEnabled: Bool { return drawHorizontalHighlightRadarIndicatorEnabled }
+
+    /// `true` if vertical highlight radar indicator lines are enabled (drawn)
+    open var isVerticalHighlightRadarIndicatorEnabled: Bool { return drawVerticalHighlightRadarIndicatorEnabled }
     
     /// Enables / disables both vertical and horizontal highlight-indicators.
     /// :param: enabled
@@ -36,6 +48,15 @@ open class LineScatterCandleRadarChartDataSet: BarLineScatterCandleBubbleChartDa
     {
         drawHorizontalHighlightIndicatorEnabled = enabled
         drawVerticalHighlightIndicatorEnabled = enabled
+    }
+
+    /// Enables / disables both vertical and horizontal radar highlight-indicators.
+    /// :param: enabled
+    open func setDrawHighlightRadarIndicators(_ enabled: Bool) {
+        drawHorizontalHighlightIndicatorEnabled = enabled
+        drawVerticalHighlightIndicatorEnabled = enabled
+        drawHorizontalHighlightRadarIndicatorEnabled = enabled
+        drawVerticalHighlightRadarIndicatorEnabled = enabled
     }
     
     // MARK: NSCopying
@@ -45,6 +66,8 @@ open class LineScatterCandleRadarChartDataSet: BarLineScatterCandleBubbleChartDa
         let copy = super.copy(with: zone) as! LineScatterCandleRadarChartDataSet
         copy.drawHorizontalHighlightIndicatorEnabled = drawHorizontalHighlightIndicatorEnabled
         copy.drawVerticalHighlightIndicatorEnabled = drawVerticalHighlightIndicatorEnabled
+        copy.drawHorizontalHighlightRadarIndicatorEnabled = drawHorizontalHighlightRadarIndicatorEnabled
+        copy.drawVerticalHighlightRadarIndicatorEnabled = drawVerticalHighlightRadarIndicatorEnabled
         return copy
     }
     

--- a/Source/Charts/Data/Interfaces/LineScatterCandleRadarChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/LineScatterCandleRadarChartDataSetProtocol.swift
@@ -23,14 +23,30 @@ public protocol LineScatterCandleRadarChartDataSetProtocol: BarLineScatterCandle
     
     /// Enables / disables the vertical highlight-indicator. If disabled, the indicator is not drawn.
     var drawVerticalHighlightIndicatorEnabled: Bool { get set }
+
+    /// Enables / disables the horizontal radar highlight-indicator. If disabled, the indicator is not drawn.
+    var drawHorizontalHighlightRadarIndicatorEnabled: Bool { get set }
+
+    /// Enables / disables the vertical radar highlight-indicator. If disabled, the indicator is not drawn.
+    var drawVerticalHighlightRadarIndicatorEnabled: Bool { get set }
     
     /// `true` if horizontal highlight indicator lines are enabled (drawn)
     var isHorizontalHighlightIndicatorEnabled: Bool { get }
     
     /// `true` if vertical highlight indicator lines are enabled (drawn)
     var isVerticalHighlightIndicatorEnabled: Bool { get }
+
+    /// `true` if horizontal highlight radar indicator lines are enabled (drawn)
+    var isHorizontalHighlightRadarIndicatorEnabled: Bool { get }
+
+    /// `true` if vertical highlight radar indicator lines are enabled (drawn)
+    var isVerticalHighlightRadarIndicatorEnabled: Bool { get }
     
     /// Enables / disables both vertical and horizontal highlight-indicators.
     /// :param: enabled
     func setDrawHighlightIndicators(_ enabled: Bool)
+
+    /// Enables / disables both vertical and horizontal radar highlight-indicators.
+    /// :param: enabled
+    func setDrawHighlightRadarIndicators(_ enabled: Bool)
 }

--- a/Source/Charts/Renderers/LineScatterCandleRadarRenderer.swift
+++ b/Source/Charts/Renderers/LineScatterCandleRadarRenderer.swift
@@ -32,6 +32,22 @@ open class LineScatterCandleRadarRenderer: BarLineScatterCandleBubbleRenderer
         if set.isVerticalHighlightIndicatorEnabled
         {
             context.beginPath()
+
+            if set.isVerticalHighlightRadarIndicatorEnabled {
+                let colorTop = UIColor.white.cgColor
+                let colorBottom = UIColor.clear.cgColor
+
+                var gradientOne = CGGradient(colorsSpace: .none, colors: [colorTop, colorBottom] as CFArray, locations: [0.0, 1.0])!
+                let startPointOne = CGPoint(x: point.x, y: point.y)
+                let endPointOne = CGPoint(x: point.x, y: viewPortHandler.contentBottom)
+                context.drawRadialGradient(gradientOne, startCenter: startPointOne, startRadius: 0.5, endCenter: endPointOne, endRadius: 0.5, options: .drawsAfterEndLocation)
+
+                var gradientTwo = CGGradient(colorsSpace: .none, colors: [colorBottom, colorTop] as CFArray, locations: [0.0, 1.0])!
+                let startPointTwo = CGPoint(x: point.x, y: viewPortHandler.contentTop)
+                let endPointTwo = CGPoint(x: point.x, y: point.y)
+                context.drawRadialGradient(gradientTwo, startCenter: startPointTwo, startRadius: 0.5, endCenter: endPointTwo, endRadius: 0.5, options: .drawsBeforeStartLocation)
+            }
+
             context.move(to: CGPoint(x: point.x, y: viewPortHandler.contentTop))
             context.addLine(to: CGPoint(x: point.x, y: viewPortHandler.contentBottom))
             context.strokePath()
@@ -41,6 +57,22 @@ open class LineScatterCandleRadarRenderer: BarLineScatterCandleBubbleRenderer
         if set.isHorizontalHighlightIndicatorEnabled
         {
             context.beginPath()
+
+            if set.isHorizontalHighlightRadarIndicatorEnabled {
+                let colorTop = UIColor.white.cgColor
+                let colorBottom = UIColor.clear.cgColor
+
+                var gradientOne = CGGradient(colorsSpace: .none, colors: [colorBottom, colorTop] as CFArray, locations: [0.0, 1.0])!
+                let startPointOne = CGPoint(x: viewPortHandler.contentLeft, y: point.y)
+                let endPointOne = CGPoint(x: point.x, y: point.y)
+                context.drawRadialGradient(gradientOne, startCenter: startPointOne, startRadius: 0.5, endCenter: endPointOne, endRadius: 0.5, options: .drawsBeforeStartLocation)
+
+                var gradientTwo = CGGradient(colorsSpace: .none, colors: [colorBottom, colorTop] as CFArray, locations: [0.0, 1.0])!
+                let startPointTwo = CGPoint(x: viewPortHandler.contentRight, y: point.y)
+                let endPointTwo = CGPoint(x: point.x, y: point.y)
+                context.drawRadialGradient(gradientTwo, startCenter: startPointTwo, startRadius: 0.5, endCenter: endPointTwo, endRadius: 0.5, options: .drawsBeforeStartLocation)
+            }
+
             context.move(to: CGPoint(x: viewPortHandler.contentLeft, y: point.y))
             context.addLine(to: CGPoint(x: viewPortHandler.contentRight, y: point.y))
             context.strokePath()


### PR DESCRIPTION
### Goals :soccer:
Add gradient highlight radar indicator to LineScatterCandleRadarChartDataSet

### Implementation Details :construction:
Simply just added  `setDrawHighlightRadarIndicators`  to draw radar of indicators in `LineScatterCandleRadarChartDataSet`

### Usage
`dataSet.setDrawHighlightIndicators(true)`

[Preview](https://i.stack.imgur.com/KI0Js.jpg)

