### PR TITLE
better

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -409,9 +409,12 @@ open class LineChartRenderer: LineRadarRenderer
                         y: CGFloat(e1.y * phaseY))
                     .applying(valueToPixelMatrix)
                 
+                if firstPoint || (dataSet.drawCirclesEnabled) {
+                    path.move(to: startPoint)
+                }
+                
                 if firstPoint
                 {
-                    path.move(to: startPoint)
                     firstPoint = false
                 }
                 else

--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -409,7 +409,7 @@ open class LineChartRenderer: LineRadarRenderer
                         y: CGFloat(e1.y * phaseY))
                     .applying(valueToPixelMatrix)
                 
-                if firstPoint || (dataSet.drawCirclesEnabled) {
+                if firstPoint || (dataSet.drawCirclesEnabled && !isDrawSteppedEnabled) {
                     path.move(to: startPoint)
                 }
                 


### PR DESCRIPTION
### Goals :soccer:

Jagged lines stick out from behind the data points

Before | After
--- | ---
![jagged](https://user-images.githubusercontent.com/6655924/227306380-814c81c3-6163-4de1-9823-7431aa55e3e3.jpg)|![Simulator Screen Shot - iPhone 14 - 2023-03-23 at 11 10 00](https://user-images.githubusercontent.com/6655924/227306385-09f167d1-17a7-4732-82b5-aaccd99ea9ea.png)

### Implementation Details :construction:

Because this disconnects each line segment, I limited it only to the case where there's a data point circle covering the line join. If we want to be stricter about that check, we could also make sure that the circle size is greater than the line width, and that the color of the circle is fully opaque.

I also have a fix for the case where the disjoint isn't covered up, see `improve-jagged-lines-extra`

### Testing Details :mag:
 - demo app