### PR TITLE
Fix Node 12 deprecation warning

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         destination: ["OS=16.0,name=iPhone 14 Pro"] #, "OS=14.4,name=iPhone 12 Pro", "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: iOS - ${{ matrix.destination }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "Charts.xcworkspace" -scheme "Charts" -destination "${{ matrix.destination }}" clean test | xcpretty
 
@@ -29,7 +29,7 @@ jobs:
       matrix:
         destination: ["OS=16.0,name=Apple TV 4K (2nd generation)"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: tvOS - ${{ matrix.destination }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "Charts.xcworkspace" -scheme "Charts" -destination "${{ matrix.destination }}" clean test | xcpretty
 
@@ -38,7 +38,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: macOS
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "Charts.xcworkspace" -scheme "ChartsDemo-macOS" -destination "platform=macOS" clean build | xcpretty
 
@@ -50,7 +50,7 @@ jobs:
       matrix:
         destination: ["OS=16.0,name=iPhone 14 Pro"] #, "OS=14.4,name=iPhone 12 Pro", "OS=12.4,name=iPhone XS", "OS=11.4,name=iPhone X", "OS=10.3.1,name=iPhone SE"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: iOS - ${{ matrix.destination }}
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "Charts.xcworkspace" -scheme "ChartsDemo-iOS" -destination "${{ matrix.destination }}" clean build | xcpretty
 
@@ -60,6 +60,6 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: SPM Test
         run: swift build -c debug


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
The GitHub checkout action v2 uses Node.js 12. This version of Node is deprecated and will be fully removed in summer 2023, see [this blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
<img width="1552" alt="Screenshot 2023-04-10 at 15 55 30" src="https://user-images.githubusercontent.com/42500484/230917611-020c4002-0350-458e-bd9b-ea5916d3f4af.png">

### Implementation Details :construction:
I have updated all checkout actions to us v3 instead of v2.

### Testing Details :mag:
I couldn't test it with this repo, but I have not experienced any issues with the other workflows where I have done the upgrade.

_Edit_: CI is not failing and the warnings are gone: https://github.com/danielgindi/Charts/actions/runs/4658235640