### PR TITLE
Make public drawMultilineText in ChartUtils

### DIFF
--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -242,7 +242,7 @@ extension CGContext
         return point
     }
     
-    func drawMultilineText(_ text: String, at point: CGPoint, constrainedTo size: CGSize, anchor: CGPoint, knownTextSize: CGSize, angleRadians: CGFloat, attributes: [NSAttributedString.Key : Any]?)
+    public func drawMultilineText(_ text: String, at point: CGPoint, constrainedTo size: CGSize, anchor: CGPoint, knownTextSize: CGSize, angleRadians: CGFloat, attributes: [NSAttributedString.Key : Any]?)
     {
         var rect = CGRect(origin: .zero, size: knownTextSize)
 
@@ -290,7 +290,7 @@ extension CGContext
         NSUIGraphicsPopContext()
     }
 
-    func drawMultilineText(_ text: String, at point: CGPoint, constrainedTo size: CGSize, anchor: CGPoint, angleRadians: CGFloat, attributes: [NSAttributedString.Key : Any]?)
+    public func drawMultilineText(_ text: String, at point: CGPoint, constrainedTo size: CGSize, anchor: CGPoint, angleRadians: CGFloat, attributes: [NSAttributedString.Key : Any]?)
     {
         let rect = text.boundingRect(with: size, options: .usesLineFragmentOrigin, attributes: attributes, context: nil)
         drawMultilineText(text, at: point, constrainedTo: size, anchor: anchor, knownTextSize: rect.size, angleRadians: angleRadians, attributes: attributes)


### PR DESCRIPTION
### Goals :soccer:
I'm using a `HorizontalBarChartView` and i need to show a multilines label with text alignment to the right like this:
![Simulator Screenshot - iPhone 14 - 2023-04-21 at 12 38 28](https://user-images.githubusercontent.com/32682698/233615984-ee683602-f105-4340-bc7d-c2a347feffe5.png)
To do this i need to create my own `XAxisRendererHorizontalBarChart` and to override `func drawLabel()` with `context.drawMultilineText` 