### PR TITLE
feat: Add radius corners to BarChartView / HorizontalBarChartView / CandleStickChartView

### DIFF
--- a/ChartsDemo-iOS/Objective-C/Demos/BarChartViewController.m
+++ b/ChartsDemo-iOS/Objective-C/Demos/BarChartViewController.m
@@ -157,6 +157,8 @@
         set1 = [[BarChartDataSet alloc] initWithEntries:yVals label:@"The year 2017"];
         [set1 setColors:ChartColorTemplates.material];
         set1.drawIconsEnabled = NO;
+        set1.barRadius = 3.0;
+        set1.barCorner = UIRectCornerAllCorners;
         
         NSMutableArray *dataSets = [[NSMutableArray alloc] init];
         [dataSets addObject:set1];

--- a/ChartsDemo-iOS/Objective-C/Demos/CandleStickChartViewController.m
+++ b/ChartsDemo-iOS/Objective-C/Demos/CandleStickChartViewController.m
@@ -118,6 +118,8 @@
     set1.increasingColor = [UIColor colorWithRed:122/255.f green:242/255.f blue:84/255.f alpha:1.f];
     set1.increasingFilled = NO;
     set1.neutralColor = UIColor.blueColor;
+    set1.barRadius = 3.0;
+    set1.barCorner = UIRectCornerAllCorners;
     
     CandleChartData *data = [[CandleChartData alloc] initWithDataSet:set1];
     

--- a/ChartsDemo-iOS/Objective-C/Demos/HorizontalBarChartViewController.m
+++ b/ChartsDemo-iOS/Objective-C/Demos/HorizontalBarChartViewController.m
@@ -136,6 +136,8 @@
         set1 = [[BarChartDataSet alloc] initWithEntries:yVals label:@"DataSet"];
         
         set1.drawIconsEnabled = NO;
+        set1.barRadius = 3.0;
+        set1.barCorner = UIRectCornerAllCorners;
         
         NSMutableArray *dataSets = [[NSMutableArray alloc] init];
         [dataSets addObject:set1];

--- a/ChartsDemo-iOS/Swift/Demos/BarChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/BarChartViewController.swift
@@ -133,6 +133,8 @@ class BarChartViewController: DemoBaseViewController {
             set1 = BarChartDataSet(entries: yVals, label: "The year 2017")
             set1.colors = ChartColorTemplates.material()
             set1.drawValuesEnabled = false
+            set1.barRadius = 3.0
+            set1.barCorner = .allCorners
             
             let data = BarChartData(dataSet: set1)
             data.setValueFont(UIFont(name: "HelveticaNeue-Light", size: 10)!)

--- a/ChartsDemo-iOS/Swift/Demos/CandleStickChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/CandleStickChartViewController.swift
@@ -100,6 +100,8 @@ class CandleStickChartViewController: DemoBaseViewController {
         set1.increasingColor = UIColor(red: 122/255, green: 242/255, blue: 84/255, alpha: 1)
         set1.increasingFilled = false
         set1.neutralColor = .blue
+        set1.barRadius = 3.0
+        set1.barCorner = .allCorners
         
         let data = CandleChartData(dataSet: set1)
         chartView.data = data

--- a/ChartsDemo-iOS/Swift/Demos/HorizontalBarChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/HorizontalBarChartViewController.swift
@@ -104,6 +104,8 @@ class HorizontalBarChartViewController: DemoBaseViewController {
         
         let set1 = BarChartDataSet(entries: yVals, label: "DataSet")
         set1.drawIconsEnabled = false
+        set1.barRadius = 3.0
+        set1.barCorner = .allCorners
         
         let data = BarChartData(dataSet: set1)
         data.setValueFont(UIFont(name:"HelveticaNeue-Light", size:10)!)

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -131,4 +131,10 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, BarChartData
         copy.highlightAlpha = highlightAlpha
         return copy
     }
+    
+    /// the corner used for drawing radius around the bars.
+    open var barCorner: UIRectCorner = .allCorners
+    
+    /// the radius used for drawing radius around the bars. If barRadius == 0, no radius will be drawn.
+    open var barRadius: CGFloat = 0
 }

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataSet.swift
@@ -114,4 +114,10 @@ open class CandleChartDataSet: LineScatterCandleRadarChartDataSet, CandleChartDa
     
     /// Are decreasing values drawn as filled?
     open var isDecreasingFilled: Bool { return decreasingFilled }
+    
+    /// the corner used for drawing radius around the bars.
+    open var barCorner: UIRectCorner = .allCorners
+    
+    /// the radius used for drawing radius around the bars. If barRadius == 0, no radius will be drawn.
+    open var barRadius: CGFloat = 0
 }

--- a/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
@@ -39,4 +39,10 @@ public protocol BarChartDataSetProtocol: BarLineScatterCandleBubbleChartDataSetP
     
     /// array of labels used to describe the different values of the stacked bars
     var stackLabels: [String] { get set }
+    
+    /// the corner used for drawing radius around the bars.
+    var barCorner: UIRectCorner {get set}
+    
+    /// the radius used for drawing radius around the bars. If barRadius == 0, no radius will be drawn.
+    var barRadius: CGFloat {get set}
 }

--- a/Source/Charts/Data/Interfaces/CandleChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/CandleChartDataSetProtocol.swift
@@ -63,4 +63,10 @@ public protocol CandleChartDataSetProtocol: LineScatterCandleRadarChartDataSetPr
     
     /// Are decreasing values drawn as filled?
     var isDecreasingFilled: Bool { get }
+    
+    /// the corner used for drawing radius around the bars.
+    var barCorner: UIRectCorner {get set}
+    
+    /// the radius used for drawing radius around the bars. If barRadius == 0, no radius will be drawn.
+    var barRadius: CGFloat {get set}
 }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -379,13 +379,14 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            context.fill(barRect)
-            
             if drawBorder
             {
                 context.setStrokeColor(borderColor.cgColor)
                 context.setLineWidth(borderWidth)
-                context.stroke(barRect)
+                drawChart(context: context, dataSet: dataSet, barRect: barRect, drawBorder: true)
+            }else
+            {
+                drawChart(context: context, dataSet: dataSet, barRect: barRect, drawBorder: false)
             }
 
             // Create and append the corresponding accessibility element to accessibilityOrderedElements
@@ -403,6 +404,8 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
 
                 accessibilityOrderedElements[j/stackSize].append(element)
             }
+            
+            
         }
     }
     
@@ -744,7 +747,7 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 setHighlightDrawPos(highlight: high, barRect: barRect)
                 
-                context.fill(barRect)
+                drawChart(context: context, dataSet: set, barRect: barRect, drawBorder: false)
             }
         }
     }
@@ -831,5 +834,74 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
         modifier(element)
 
         return element
+    }
+    
+    private func drawChart(context: CGContext, dataSet: BarChartDataSetProtocol, barRect: CGRect, drawBorder: Bool){
+        let radius = dataSet.barRadius
+        let barCorner = dataSet.barCorner
+        
+        if(radius > 0){
+            
+            let isTopLeftRadius = barCorner.contains(.topLeft)
+            let isTopRightRadius = barCorner.contains(.topRight)
+            let isBottomLeftRadius = barCorner.contains(.bottomLeft)
+            let isBottomRightRadius = barCorner.contains(.bottomRight)
+            
+            var topLeftRadius = 0.0
+            var topRightRadius = 0.0
+            var bottomLeftRadius = 0.0
+            var bottomRightRadius = 0.0
+            
+            if(isTopLeftRadius || isTopRightRadius || isBottomLeftRadius || isBottomRightRadius)
+            {
+                if(isTopLeftRadius){
+                    topLeftRadius = radius
+                }
+                if(isTopRightRadius){
+                    topRightRadius = radius
+                }
+                if(isBottomLeftRadius){
+                    bottomLeftRadius = radius
+                }
+                if(isBottomRightRadius){
+                    bottomRightRadius = radius
+                }
+            }else {
+                topRightRadius = radius
+                topLeftRadius = radius
+                bottomLeftRadius = radius
+                bottomRightRadius = radius
+            }
+            
+            let minx = CGRectGetMinX(barRect);
+            let midx = CGRectGetMidX(barRect);
+            let maxx = CGRectGetMaxX(barRect);
+            let miny = CGRectGetMinY(barRect);
+            let midy = CGRectGetMidY(barRect);
+            let maxy = CGRectGetMaxY(barRect);
+            
+            context.move(to: CGPoint(x: minx, y: midy))
+            context.addArc(tangent1End: CGPoint(x: minx, y: miny), tangent2End: CGPoint(x: midx, y: miny), radius: topLeftRadius)
+            context.addArc(tangent1End: CGPoint(x: maxx, y: miny), tangent2End: CGPoint(x: maxx, y: midy), radius: topRightRadius)
+            context.addArc(tangent1End: CGPoint(x: maxx, y: maxy), tangent2End: CGPoint(x: midx, y: maxy), radius: bottomRightRadius)
+            context.addArc(tangent1End: CGPoint(x: minx, y: maxy), tangent2End: CGPoint(x: minx, y: midy), radius: bottomLeftRadius)
+            context.closePath()
+            
+            if drawBorder
+            {
+                context.drawPath(using: .fillStroke)
+            }else{
+                context.drawPath(using: .fill)
+            }
+            
+        }else{
+            
+            context.fill(barRect)
+            
+            if drawBorder
+            {
+                context.stroke(barRect)
+            }
+        }
     }
 }

--- a/Source/Charts/Renderers/CandleStickChartRenderer.swift
+++ b/Source/Charts/Renderers/CandleStickChartRenderer.swift
@@ -169,12 +169,12 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     if dataSet.isDecreasingFilled
                     {
                         context.setFillColor(color.cgColor)
-                        context.fill(_bodyRect)
+                        drawChart(context: context, dataSet: dataSet, barRect: _bodyRect, drawBorder: false)
                     }
                     else
                     {
                         context.setStrokeColor(color.cgColor)
-                        context.stroke(_bodyRect)
+                        drawChart(context: context, dataSet: dataSet, barRect: _bodyRect, drawBorder: true)
                     }
                 }
                 else if open < close
@@ -186,12 +186,12 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     if dataSet.isIncreasingFilled
                     {
                         context.setFillColor(color.cgColor)
-                        context.fill(_bodyRect)
+                        drawChart(context: context, dataSet: dataSet, barRect: _bodyRect, drawBorder: false)
                     }
                     else
                     {
                         context.setStrokeColor(color.cgColor)
-                        context.stroke(_bodyRect)
+                        drawChart(context: context, dataSet: dataSet, barRect: _bodyRect, drawBorder: true)
                     }
                 }
                 else
@@ -199,7 +199,8 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
                     let color = dataSet.neutralColor ?? dataSet.color(atIndex: j)
                     
                     context.setStrokeColor(color.cgColor)
-                    context.stroke(_bodyRect)
+//                    context.stroke(_bodyRect)
+                    drawChart(context: context, dataSet: dataSet, barRect: _bodyRect, drawBorder: true)
                 }
             }
             else
@@ -413,5 +414,75 @@ open class CandleStickChartRenderer: LineScatterCandleRadarRenderer
         modifier(element)
 
         return element
+    }
+    
+    private func drawChart(context: CGContext, dataSet: CandleChartDataSetProtocol, barRect: CGRect, drawBorder: Bool){
+        let radius = dataSet.barRadius
+        let barCorner = dataSet.barCorner
+        
+        if(radius > 0){
+            
+            let isTopLeftRadius = barCorner.contains(.topLeft)
+            let isTopRightRadius = barCorner.contains(.topRight)
+            let isBottomLeftRadius = barCorner.contains(.bottomLeft)
+            let isBottomRightRadius = barCorner.contains(.bottomRight)
+            
+            var topLeftRadius = 0.0
+            var topRightRadius = 0.0
+            var bottomLeftRadius = 0.0
+            var bottomRightRadius = 0.0
+            
+            if(isTopLeftRadius || isTopRightRadius || isBottomLeftRadius || isBottomRightRadius)
+            {
+                if(isTopLeftRadius){
+                    topLeftRadius = radius
+                }
+                if(isTopRightRadius){
+                    topRightRadius = radius
+                }
+                if(isBottomLeftRadius){
+                    bottomLeftRadius = radius
+                }
+                if(isBottomRightRadius){
+                    bottomRightRadius = radius
+                }
+            }else {
+                topRightRadius = radius
+                topLeftRadius = radius
+                bottomLeftRadius = radius
+                bottomRightRadius = radius
+            }
+            
+            let minx = CGRectGetMinX(barRect);
+            let midx = CGRectGetMidX(barRect);
+            let maxx = CGRectGetMaxX(barRect);
+            let miny = CGRectGetMinY(barRect);
+            let midy = CGRectGetMidY(barRect);
+            let maxy = CGRectGetMaxY(barRect);
+            
+            context.move(to: CGPoint(x: minx, y: midy))
+            context.addArc(tangent1End: CGPoint(x: minx, y: miny), tangent2End: CGPoint(x: midx, y: miny), radius: topLeftRadius)
+            context.addArc(tangent1End: CGPoint(x: maxx, y: miny), tangent2End: CGPoint(x: maxx, y: midy), radius: topRightRadius)
+            context.addArc(tangent1End: CGPoint(x: maxx, y: maxy), tangent2End: CGPoint(x: midx, y: maxy), radius: bottomRightRadius)
+            context.addArc(tangent1End: CGPoint(x: minx, y: maxy), tangent2End: CGPoint(x: minx, y: midy), radius: bottomLeftRadius)
+            context.closePath()
+            
+            if drawBorder
+            {
+                context.drawPath(using: .stroke)
+            }else{
+                context.drawPath(using: .fill)
+            }
+            
+        }else{
+            
+            if drawBorder
+            {
+                context.stroke(barRect)
+            }else{
+                
+                context.fill(barRect)
+            }
+        }
     }
 }

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -264,14 +264,16 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 // Set the color for the currently drawn value. If the index is out of bounds, reuse colors.
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
-
-            context.fill(barRect)
-
+            
             if drawBorder
             {
                 context.setStrokeColor(borderColor.cgColor)
                 context.setLineWidth(borderWidth)
-                context.stroke(barRect)
+                drawChart(context: context, dataSet: dataSet, barRect: barRect, drawBorder: true)
+            }
+            else
+            {
+                drawChart(context: context, dataSet: dataSet, barRect: barRect, drawBorder: false)
             }
 
             // Create and append the corresponding accessibility element to accessibilityOrderedElements (see BarChartRenderer)
@@ -623,5 +625,74 @@ open class HorizontalBarChartRenderer: BarChartRenderer
     internal override func setHighlightDrawPos(highlight high: Highlight, barRect: CGRect)
     {
         high.setDraw(x: barRect.midY, y: barRect.origin.x + barRect.size.width)
+    }
+    
+    private func drawChart(context: CGContext, dataSet: BarChartDataSetProtocol, barRect: CGRect, drawBorder: Bool){
+        let radius = dataSet.barRadius
+        let barCorner = dataSet.barCorner
+        
+        if(radius > 0){
+            
+            let isTopLeftRadius = barCorner.contains(.topLeft)
+            let isTopRightRadius = barCorner.contains(.topRight)
+            let isBottomLeftRadius = barCorner.contains(.bottomLeft)
+            let isBottomRightRadius = barCorner.contains(.bottomRight)
+            
+            var topLeftRadius = 0.0
+            var topRightRadius = 0.0
+            var bottomLeftRadius = 0.0
+            var bottomRightRadius = 0.0
+            
+            if(isTopLeftRadius || isTopRightRadius || isBottomLeftRadius || isBottomRightRadius)
+            {
+                if(isTopLeftRadius){
+                    topLeftRadius = radius
+                }
+                if(isTopRightRadius){
+                    topRightRadius = radius
+                }
+                if(isBottomLeftRadius){
+                    bottomLeftRadius = radius
+                }
+                if(isBottomRightRadius){
+                    bottomRightRadius = radius
+                }
+            }else {
+                topRightRadius = radius
+                topLeftRadius = radius
+                bottomLeftRadius = radius
+                bottomRightRadius = radius
+            }
+            
+            let minx = CGRectGetMinX(barRect);
+            let midx = CGRectGetMidX(barRect);
+            let maxx = CGRectGetMaxX(barRect);
+            let miny = CGRectGetMinY(barRect);
+            let midy = CGRectGetMidY(barRect);
+            let maxy = CGRectGetMaxY(barRect);
+            
+            context.move(to: CGPoint(x: minx, y: midy))
+            context.addArc(tangent1End: CGPoint(x: minx, y: miny), tangent2End: CGPoint(x: midx, y: miny), radius: topLeftRadius)
+            context.addArc(tangent1End: CGPoint(x: maxx, y: miny), tangent2End: CGPoint(x: maxx, y: midy), radius: topRightRadius)
+            context.addArc(tangent1End: CGPoint(x: maxx, y: maxy), tangent2End: CGPoint(x: midx, y: maxy), radius: bottomRightRadius)
+            context.addArc(tangent1End: CGPoint(x: minx, y: maxy), tangent2End: CGPoint(x: minx, y: midy), radius: bottomLeftRadius)
+            context.closePath()
+            
+            if drawBorder
+            {
+                context.drawPath(using: .fillStroke)
+            }else{
+                context.drawPath(using: .fill)
+            }
+            
+        }else{
+            
+            context.fill(barRect)
+            
+            if drawBorder
+            {
+                context.stroke(barRect)
+            }
+        }
     }
 }


### PR DESCRIPTION
### Goals :soccer:
Add radius corners to BarChartView / HorizontalBarChartView / CandleStickChartView

### Implementation Details :construction:
Cylindrical charts use rounded corners to be more beautiful and more in line with human design

### Testing Details :mag:
usage:
BarChartView / HorizontalBarChartView:
let set = BarChartDataSet()
set.barRadius = 3.0
set.barCorner = [.topLeft, .topRight] //.allCorners

CandleStickChartView:
let set = CandleChartDataSet()
set.barRadius = 3.0
set.barCorner = [.topLeft, .topRight] //.allCorners