### PR TITLE
Highlighted property of ChartViewBase is now open

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -126,7 +126,7 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     private var offsetsCalculated = false
 
     /// The array of currently highlighted values. This might an empty if nothing is highlighted.
-    @objc open internal(set) var highlighted = [Highlight]()
+    @objc open var highlighted = [Highlight]()
     
     /// `true` if drawing the marker is enabled when tapping on values
     /// (use the `marker` property to specify a marker)


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
This modification is necessary to implement ability to add multiple markers on the chart via <CustomHighlighter>.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
In <CustomHighlighter> code we have to be able change `@objc open internal(set) var highlighted: [Highlight]` property to properly implement our logic.
<!-- Highlight any new functionality. -->
Now we able to modify `highlighted` property of ChartView in it's heirs.