### PR TITLE
优化ViewPortHandler对isInBoundsTop的判断

### DIFF
--- a/Source/Charts/Utils/ViewPortHandler.swift
+++ b/Source/Charts/Utils/ViewPortHandler.swift
@@ -354,7 +354,7 @@ open class ViewPortHandler: NSObject
     
     @objc open func isInBoundsTop(_ y: CGFloat) -> Bool
     {
-        return contentRect.origin.y <= y
+        return contentRect.origin.y <= y + 1.0
     }
     
     @objc open func isInBoundsBottom(_ y: CGFloat) -> Bool


### PR DESCRIPTION
do the same as 'isInBoundsLeft' function, change 'y' to 'y + 1.0'