### PR TITLE
Shorten type checking times by shortening expressions and avoiding type conversions

### DIFF
--- a/Source/Charts/Animation/ChartAnimationEasing.swift
+++ b/Source/Charts/Animation/ChartAnimationEasing.swift
@@ -211,25 +211,25 @@ internal struct EasingFunctions
     
     internal static let EaseInSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( -cos(position * Double.pi / 2) + 1.0 )
+        return -cos(position * Double.pi / 2) + 1.0
     }
     
     internal static let EaseOutSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( sin(position * Double.pi / 2) )
+        return sin(position * Double.pi / 2)
     }
     
     internal static let EaseInOutSine = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / duration
-        return Double( -0.5 * (cos(Double.pi * position) - 1.0) )
+        return -0.5 * (cos(Double.pi * position) - 1.0)
     }
     
     internal static let EaseInExpo = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
-        return (elapsed == 0) ? 0.0 : Double(pow(2.0, 10.0 * (elapsed / duration - 1.0)))
+        return (elapsed == 0) ? 0.0 : pow(2.0, 10.0 * (elapsed / duration - 1.0))
     }
     
     internal static let EaseOutExpo = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
-        return (elapsed == duration) ? 1.0 : (-Double(pow(2.0, -10.0 * elapsed / duration)) + 1.0)
+        return (elapsed == duration) ? 1.0 : -(pow(2.0, -10.0 * elapsed / duration)) + 1.0
     }
     
     internal static let EaseInOutExpo = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -245,32 +245,32 @@ internal struct EasingFunctions
         var position: TimeInterval = elapsed / (duration / 2.0)
         if position < 1.0
         {
-            return Double( 0.5 * pow(2.0, 10.0 * (position - 1.0)) )
+            return 0.5 * pow(2.0, 10.0 * (position - 1.0))
         }
         
         position = position - 1.0
-        return Double( 0.5 * (-pow(2.0, -10.0 * position) + 2.0) )
+        return 0.5 * (-pow(2.0, -10.0 * position) + 2.0)
     }
     
     internal static let EaseInCirc = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position = Double(elapsed / duration)
-        return -(Double(sqrt(1.0 - position * position)) - 1.0)
+        return -((sqrt(1.0 - position * position)) - 1.0)
     }
     
     internal static let EaseOutCirc = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position = Double(elapsed / duration)
         position -= 1.0
-        return Double( sqrt(1 - position * position) )
+        return sqrt(1 - position * position)
     }
     
     internal static let EaseInOutCirc = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         var position: TimeInterval = elapsed / (duration / 2.0)
         if position < 1.0
         {
-            return Double( -0.5 * (sqrt(1.0 - position * position) - 1.0) )
+            return -0.5 * (sqrt(1.0 - (position * position)) - 1.0)
         }
         position -= 2.0
-        return Double( 0.5 * (sqrt(1.0 - position * position) + 1.0) )
+        return 0.5 * (sqrt(1.0 - (position * position)) + 1.0)
     }
     
     internal static let EaseInElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -288,7 +288,7 @@ internal struct EasingFunctions
         var p = duration * 0.3
         var s = p / (2.0 * Double.pi) * asin(1.0)
         position -= 1.0
-        return Double( -(pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p)) )
+        return -(pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p))
     }
     
     internal static let EaseOutElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -305,7 +305,7 @@ internal struct EasingFunctions
         
         var p = duration * 0.3
         var s = p / (2.0 * Double.pi) * asin(1.0)
-        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) + 1.0 )
+        return pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) + 1.0
     }
     
     internal static let EaseInOutElastic = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -325,23 +325,23 @@ internal struct EasingFunctions
         if position < 1.0
         {
             position -= 1.0
-            return Double( -0.5 * (pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p)) )
+            return -0.5 * (pow(2.0, 10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p))
         }
         position -= 1.0
-        return Double( pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) * 0.5 + 1.0 )
+        return pow(2.0, -10.0 * position) * sin((position * duration - s) * (2.0 * Double.pi) / p) * 0.5 + 1.0
     }
     
     internal static let EaseInBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         let s: TimeInterval = 1.70158
         var position: TimeInterval = elapsed / duration
-        return Double( position * position * ((s + 1.0) * position - s) )
+        return position * position * ((s + 1.0) * position - s)
     }
     
     internal static let EaseOutBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
         let s: TimeInterval = 1.70158
         var position: TimeInterval = elapsed / duration
         position -= 1.0
-        return Double( position * position * ((s + Double(1.0)) * position + s) + Double(1.0) )
+        return position * position * ((s + 1.0) * position + s) + 1.0
     }
     
     internal static let EaseInOutBack = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -350,11 +350,11 @@ internal struct EasingFunctions
         if position < 1.0
         {
             s *= 1.525
-            return Double( 0.5 * (position * position * ((s + 1.0) * position - s)) )
+            return 0.5 * (position * position * ((s + 1.0) * position - s))
         }
         s *= 1.525
         position -= 2.0
-        return Double( 0.5 * (position * position * ((s + 1.0) * position + s) + 2.0) )
+        return 0.5 * (position * position * ((s + 1.0) * position + s) + 2.0)
     }
     
     internal static let EaseInBounce = { (elapsed: TimeInterval, duration: TimeInterval) -> Double in
@@ -365,22 +365,22 @@ internal struct EasingFunctions
         var position: TimeInterval = elapsed / duration
         if position < (1.0 / 2.75)
         {
-            return Double( 7.5625 * position * position )
+            return 7.5625 * position * position
         }
         else if position < (2.0 / 2.75)
         {
             position -= (1.5 / 2.75)
-            return Double( 7.5625 * position * position + 0.75 )
+            return 7.5625 * position * position + 0.75
         }
         else if position < (2.5 / 2.75)
         {
             position -= (2.25 / 2.75)
-            return Double( 7.5625 * position * position + 0.9375 )
+            return 7.5625 * position * position + 0.9375
         }
         else
         {
             position -= (2.625 / 2.75)
-            return Double( 7.5625 * position * position + 0.984375 )
+            return 7.5625 * position * position + 0.984375
         }
     }
     

--- a/Source/Charts/Charts/PieChartView.swift
+++ b/Source/Charts/Charts/PieChartView.swift
@@ -205,7 +205,7 @@ open class PieChartView: PieRadarChartViewBase
     @objc open override func distanceToCenter(x: CGFloat, y: CGFloat) -> CGFloat
     {
         let c = adjustedCenterOffsets()
-        var dist = CGFloat(0.0)
+        var dist = CGFloat.zero
 
         let xDist = x > c.x ? x - c.x : c.x - x
         let yDist = y > c.y ? y - c.y : c.y - y

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -106,7 +106,7 @@ open class AxisBase: ComponentBase
     /// If using granularity this could be avoided by having fewer axis values visible.
     @objc open var granularityEnabled = false
     
-    private var _granularity = Double(1.0)
+    private var _granularity: Double = 1.0
     
     /// The minimum interval between axis values.
     /// This can be used to avoid label duplicating when zooming in.
@@ -210,15 +210,15 @@ open class AxisBase: ComponentBase
     /// Do not touch this directly, instead, use axisMinimum.
     /// This is automatically calculated to represent the real min value,
     /// and is used when calculating the effective minimum.
-    internal var _axisMinimum = Double(0)
+    internal var _axisMinimum: Double = 0
     
     /// Do not touch this directly, instead, use axisMaximum.
     /// This is automatically calculated to represent the real max value,
     /// and is used when calculating the effective maximum.
-    internal var _axisMaximum = Double(0)
+    internal var _axisMaximum: Double = 0
     
     /// the total range of values this axis covers
-    @objc open var axisRange = Double(0)
+    @objc open var axisRange: Double = 0
     
     /// The minumum number of labels on the axis
     @objc open var axisMinLabels = Int(2) {

--- a/Source/Charts/Components/ChartLimitLine.swift
+++ b/Source/Charts/Components/ChartLimitLine.swift
@@ -34,11 +34,11 @@ open class ChartLimitLine: ComponentBase
     }
     
     /// limit / maximum (the y-value or xIndex)
-    @objc open var limit = Double(0.0)
+    @objc open var limit: Double = 0.0
     
-    private var _lineWidth = CGFloat(2.0)
+    private var _lineWidth: CGFloat = 2.0
     @objc open var lineColor = NSUIColor(red: 237.0/255.0, green: 91.0/255.0, blue: 91.0/255.0, alpha: 1.0)
-    @objc open var lineDashPhase = CGFloat(0.0)
+    @objc open var lineDashPhase: CGFloat = 0.0
     @objc open var lineDashLengths: [CGFloat]?
     
     @objc open var valueTextColor = NSUIColor.labelOrBlack

--- a/Source/Charts/Components/Legend.swift
+++ b/Source/Charts/Components/Legend.swift
@@ -155,8 +155,8 @@ open class Legend: ComponentBase
     
     @objc open func getMaximumEntrySize(withFont font: NSUIFont) -> CGSize
     {
-        var maxW = CGFloat(0.0)
-        var maxH = CGFloat(0.0)
+        var maxW: CGFloat = 0.0
+        var maxH: CGFloat = 0.0
         
         var maxFormSize: CGFloat = 0.0
 
@@ -189,10 +189,10 @@ open class Legend: ComponentBase
         )
     }
 
-    @objc open var neededWidth = CGFloat(0.0)
-    @objc open var neededHeight = CGFloat(0.0)
-    @objc open var textWidthMax = CGFloat(0.0)
-    @objc open var textHeightMax = CGFloat(0.0)
+    @objc open var neededWidth: CGFloat = 0.0
+    @objc open var neededHeight: CGFloat = 0.0
+    @objc open var textWidthMax: CGFloat = 0.0
+    @objc open var textHeightMax: CGFloat = 0.0
     
     /// flag that indicates if word wrapping is enabled
     /// this is currently supported only for `orientation == Horizontal`.
@@ -230,9 +230,9 @@ open class Legend: ComponentBase
         {
         case .vertical:
             
-            var maxWidth = CGFloat(0.0)
-            var width = CGFloat(0.0)
-            var maxHeight = CGFloat(0.0)
+            var maxWidth: CGFloat = 0.0
+            var width: CGFloat = 0.0
+            var maxHeight: CGFloat = 0.0
             let labelLineHeight = labelFont.lineHeight
             
             var wasStacked = false

--- a/Source/Charts/Data/Implementations/Standard/BarChartData.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartData.swift
@@ -32,7 +32,7 @@ open class BarChartData: BarLineScatterCandleBubbleChartData
     /// The width of the bars on the x-axis, in values (not pixels)
     ///
     /// **default**: 0.85
-    @objc open var barWidth = Double(0.85)
+    @objc open var barWidth: Double = 0.85
     
     /// Groups all BarDataSet objects this data object holds together by modifying the x-value of their entries.
     /// Previously set x-values of entries will be overwritten. Leaves space between bars and groups as specified by the parameters.

--- a/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
+++ b/Source/Charts/Data/Implementations/Standard/CandleChartDataEntry.swift
@@ -14,16 +14,16 @@ import Foundation
 open class CandleChartDataEntry: ChartDataEntry
 {
     /// shadow-high value
-    @objc open var high = Double(0.0)
+    @objc open var high: Double = 0.0
     
     /// shadow-low value
-    @objc open var low = Double(0.0)
+    @objc open var low: Double = 0.0
     
     /// close value
-    @objc open var close = Double(0.0)
+    @objc open var close: Double = 0.0
     
     /// open value
-    @objc open var open = Double(0.0)
+    @objc open var open: Double = 0.0
     
     public required init()
     {

--- a/Source/Charts/Renderers/LegendRenderer.swift
+++ b/Source/Charts/Renderers/LegendRenderer.swift
@@ -174,10 +174,10 @@ open class LegendRenderer: NSObject, Renderer
     
     @objc open func renderLegend(context: CGContext)
     {
-        guard let legend = legend else { return }
-        
-        if !legend.enabled
-        {
+        guard
+            let legend = legend,
+            legend.enabled
+        else {
             return
         }
         
@@ -376,7 +376,7 @@ open class LegendRenderer: NSObject, Renderer
         case .vertical:
             
             // contains the stacked legend size in pixels
-            var stack = CGFloat(0.0)
+            var stack: CGFloat = 0.0
             var wasStacked = false
             
             var posY: CGFloat = 0.0
@@ -432,7 +432,7 @@ open class LegendRenderer: NSObject, Renderer
                     }
                 }
                 
-                if e.label != nil
+                if let label = e.label
                 {
                     if drawingForm && !wasStacked
                     {
@@ -445,17 +445,17 @@ open class LegendRenderer: NSObject, Renderer
                     
                     if direction == .rightToLeft
                     {
-                        posX -= (e.label! as NSString).size(withAttributes: [.font: labelFont]).width
+                        posX -= (label as NSString).size(withAttributes: [.font: labelFont]).width
                     }
                     
                     if !wasStacked
                     {
-                        drawLabel(context: context, x: posX, y: posY, label: e.label!, font: labelFont, textColor: e.labelColor ?? labelTextColor)
+                        drawLabel(context: context, x: posX, y: posY, label: label, font: labelFont, textColor: e.labelColor ?? labelTextColor)
                     }
                     else
                     {
                         posY += labelLineHeight + yEntrySpace
-                        drawLabel(context: context, x: posX, y: posY, label: e.label!, font: labelFont, textColor: e.labelColor ?? labelTextColor)
+                        drawLabel(context: context, x: posX, y: posY, label: label, font: labelFont, textColor: e.labelColor ?? labelTextColor)
                     }
                     
                     // make a step down


### PR DESCRIPTION
I noticed that DGCharts amounted to a large portion of the compile times of our app, so I measured the times for evaluating expressions and function bodies by adding the below build flags:
```
-Xfrontend -warn-long-function-bodies=<ms>
-Xfrontend -warn-long-expression-type-checking=<ms>
```

It turned out that certain functions and expressions had evaluation times close to one second on an M1 Mac, so I added some help for the compiler to shorten those checking times.

As a result of these changes, the compile times have gone down from 6 s for the entire package to only 4 s — a 33 % decrease. Certain files still make out the bulk of the total compile time so a further refactoring of those files could enable higher parallelisation of compilation, but that would make this PR too big to review.

### Goals :soccer:
Shorter compile times.

### Implementation Details :construction:
1. Bracketing parts of certain long expressions such as `-0.5 * (sqrt(1.0 - position * position) - 1.0)`
2. Removing type conversions from `Double` to `Double` such as `Double( sqrt(1 - position * position) )`
3. Adding a `guard` to functions that consisted of just one big `if` statement
4. Adding a type specifier to variable declarations that instead used a type initialiser on a literal such as `var maxW: CGFloat = 0.0`

### Testing Details :mag:
The tests still run as before.
To ease code review, it helps to turn on "hide white spaces" in Github's code review view.