### PR TITLE
Allow trackpad swipe to scroll in Catalyst apps

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -128,6 +128,14 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         
         _panGestureRecognizer.delegate = self
         
+        // Allow trackpad swipe to scroll in Catalyst apps
+        #if targetEnvironment(macCatalyst)
+        if #available(iOS 13.4, macCatalyst 13.4, *) {
+            _panGestureRecognizer.allowedScrollTypesMask = .all
+        }
+        _panGestureRecognizer.maximumNumberOfTouches = 0
+        #endif
+        
         self.addGestureRecognizer(_tapGestureRecognizer)
         self.addGestureRecognizer(_doubleTapGestureRecognizer)
         self.addGestureRecognizer(_panGestureRecognizer)
@@ -677,7 +685,13 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     
     @objc private func panGestureRecognized(_ recognizer: NSUIPanGestureRecognizer)
     {
-        if recognizer.state == NSUIGestureRecognizerState.began && recognizer.nsuiNumberOfTouches() > 0
+        // Allow trackpad swipe to scroll in Catalyst apps
+        #if targetEnvironment(macCatalyst)
+        let isBeginning = recognizer.state == NSUIGestureRecognizerState.began
+        #else
+        let isBeginning = recognizer.state == NSUIGestureRecognizerState.began && recognizer.nsuiNumberOfTouches() > 0
+        #endif
+        if isBeginning
         {
             stopDeceleration()
             


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
In Mac Catalyst, most scroll views can be scrolled with a swipe gesture on the trackpad or mouse. (For instance, table views can be scrolled with a two-finger swipe.) Charts should be scrollable in the same way.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Set the allowed scroll types and eliminated the number of touches requirement to allow scrolling via trackpad in Mac Catalyst.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->