### PR TITLE
Remove deprecated UIGraphicsBeginImageContextWithOptions

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -704,33 +704,31 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
     /// - Returns: The bitmap that represents the chart.
     @objc open func getChartImage(transparent: Bool) -> NSUIImage?
     {
-        NSUIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque || !transparent, NSUIMainScreen()?.nsuiScale ?? 1.0)
-        
-        guard let context = NSUIGraphicsGetCurrentContext()
-            else { return nil }
-        
-        let rect = CGRect(origin: .zero, size: bounds.size)
-        
-        if isOpaque || !transparent
-        {
-            // Background color may be partially transparent, we must fill with white if we want to output an opaque image
-            context.setFillColor(NSUIColor.white.cgColor)
-            context.fill(rect)
-            
-            if let backgroundColor = self.backgroundColor
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = isOpaque || !transparent
+        format.scale = NSUIMainScreen()?.nsuiScale ?? 1.0
+
+        return UIGraphicsImageRenderer(size: bounds.size).image { ctx in
+
+            let context = ctx.cgContext
+            let rect = CGRect(origin: .zero, size: bounds.size)
+
+            if isOpaque || !transparent 
             {
-                context.setFillColor(backgroundColor.cgColor)
+                // Background color may be partially transparent, we must fill with white if we want to output an opaque
+                // image
+                context.setFillColor(NSUIColor.white.cgColor)
                 context.fill(rect)
+
+                if let backgroundColor = self.backgroundColor 
+                {
+                    context.setFillColor(backgroundColor.cgColor)
+                    context.fill(rect)
+                }
             }
+
+            nsuiLayer?.render(in: context)
         }
-        
-        nsuiLayer?.render(in: context)
-        
-        let image = NSUIGraphicsGetImageFromCurrentImageContext()
-        
-        NSUIGraphicsEndImageContext()
-        
-        return image
     }
     
     public enum ImageFormat

--- a/Source/Charts/Utils/ChartUtils.swift
+++ b/Source/Charts/Utils/ChartUtils.swift
@@ -136,12 +136,9 @@ extension CGContext
             if scaledImage == nil
             {
                 // Scale the image
-                NSUIGraphicsBeginImageContextWithOptions(size, false, 0.0)
-
-                image.draw(in: CGRect(origin: .zero, size: size))
-
-                scaledImage = NSUIGraphicsGetImageFromCurrentImageContext()
-                NSUIGraphicsEndImageContext()
+                scaledImage = UIGraphicsImageRenderer(size: size).image { _ in
+                    image.draw(in: CGRect(origin: .zero, size: size))
+                }
 
                 // Put the scaled image in a cache owned by the original image
                 objc_setAssociatedObject(image, key, scaledImage, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
As of iOS 17, `UIGraphicsBeginImageContextWithOptions` [has been deprecated](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho), and causes apps build with Xcode 15 to crash. The suggested fix is to use `UIGraphicsImageRenderer`, which this PR implements.