### PR TITLE
Fixed: Pie Chart percentage does not display on demo project

### DIFF
--- a/ChartsDemo-iOS/Objective-C/Demos/PieChartViewController.m
+++ b/ChartsDemo-iOS/Objective-C/Demos/PieChartViewController.m
@@ -118,17 +118,18 @@
     dataSet.colors = colors;
     
     PieChartData *data = [[PieChartData alloc] initWithDataSet:dataSet];
+
+    [data setValueFont:[UIFont fontWithName:@"HelveticaNeue-Light" size:11.f]];
+    [data setValueTextColor:UIColor.blackColor];
     
+    _chartView.data = data;
+
     NSNumberFormatter *pFormatter = [[NSNumberFormatter alloc] init];
     pFormatter.numberStyle = NSNumberFormatterPercentStyle;
     pFormatter.maximumFractionDigits = 1;
     pFormatter.multiplier = @1.f;
     pFormatter.percentSymbol = @" %";
     [data setValueFormatter:[[ChartDefaultValueFormatter alloc] initWithFormatter:pFormatter]];
-    [data setValueFont:[UIFont fontWithName:@"HelveticaNeue-Light" size:11.f]];
-    [data setValueTextColor:UIColor.blackColor];
-    
-    _chartView.data = data;
     [_chartView highlightValues:nil];
 }
 

--- a/ChartsDemo-iOS/Swift/Demos/PieChartViewController.swift
+++ b/ChartsDemo-iOS/Swift/Demos/PieChartViewController.swift
@@ -94,17 +94,17 @@ class PieChartViewController: DemoBaseViewController {
         
         let data = PieChartData(dataSet: set)
         
+        data.setValueFont(.systemFont(ofSize: 11, weight: .light))
+        data.setValueTextColor(.black)
+
+        chartView.data = data
+
         let pFormatter = NumberFormatter()
         pFormatter.numberStyle = .percent
         pFormatter.maximumFractionDigits = 1
         pFormatter.multiplier = 1
         pFormatter.percentSymbol = " %"
         data.setValueFormatter(DefaultValueFormatter(formatter: pFormatter))
-        
-        data.setValueFont(.systemFont(ofSize: 11, weight: .light))
-        data.setValueTextColor(.black)
-        
-        chartView.data = data
         chartView.highlightValues(nil)
     }
     


### PR DESCRIPTION
### Issue Link :link:
I didn't see any issues relevant to this. However, it's happening on both Swift and Objective-c targets in the demo project. The Pie Chart percentage doesn't show up even `DefaultValueFormatter` was set.

![Simulator Screenshot - iPhone 14 - 2024-01-13 at 16 08 37](https://github.com/danielgindi/Charts/assets/7067098/56f0cba6-3442-446e-8e34-8d72d04e225e)

### Goals Soccer ⚽ 
Make Pie Chart percentage show up.

### Implementation Details :construction:
Move `NumberFormatter` constructor and `setValueFormatter(formatter:)` function below `chartView.data = data`. I saw on the `didSet` implementation of `ChartData`, that each data in ChartData will be re-assigned to `defaultValueFormatter` if the `valueFormatter` of each data is a DefaultValueFormatter subtype. So, no matter what formatter is set, it will be replaced.

### Testing Details :mag:
I've tested on both Swift and Objective-c targets. It works as expected.

![Simulator Screenshot - iPhone 14 - 2024-01-13 at 16 20 19](https://github.com/danielgindi/Charts/assets/7067098/041a192e-1332-4744-a2e5-7996bcab294a)

![Simulator Screenshot - iPhone 14 - 2024-01-13 at 16 20 33](https://github.com/danielgindi/Charts/assets/7067098/370dbf26-3c9f-4559-892f-f7d049affeb1)